### PR TITLE
fix: 修复MOH 指纹模块取不到driver，显示不可用

### DIFF
--- a/deepin-devicemanager-server/src/HotPlug/MonitorUsb.cpp
+++ b/deepin-devicemanager-server/src/HotPlug/MonitorUsb.cpp
@@ -31,6 +31,7 @@ MonitorUsb::MonitorUsb()
     // 定时器发送消息
     connect(mp_Timer, &QTimer::timeout, this, &MonitorUsb::slotTimeout);
     mp_Timer->start(1000);
+    QTimer::singleShot(10000, this, &MonitorUsb::slotTimeout);
 }
 
 void MonitorUsb::monitor()


### PR DESCRIPTION
开机10秒后再多取一次信息。

Log: 修复MOH指纹模块显示不可用
Bug: https://pms.uniontech.com/bug-view-141439.html