### PR TITLE
fix: 支持MOH和FT9201 指纹模块取不到driver，显示可用

### DIFF
--- a/deepin-devicemanager-server/src/HotPlug/MonitorUsb.cpp
+++ b/deepin-devicemanager-server/src/HotPlug/MonitorUsb.cpp
@@ -31,7 +31,6 @@ MonitorUsb::MonitorUsb()
     // 定时器发送消息
     connect(mp_Timer, &QTimer::timeout, this, &MonitorUsb::slotTimeout);
     mp_Timer->start(1000);
-    QTimer::singleShot(10000, this, &MonitorUsb::slotTimeout);
 }
 
 void MonitorUsb::monitor()

--- a/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
@@ -54,6 +54,9 @@ void DeviceOthers::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Serial ID", m_SerialID);
     setAttribute(mapInfo, "Serial ID", m_UniqueID);
     setAttribute(mapInfo, "SysFS ID", m_SysPath);
+/* 禁用时提示获取序列号失败*/
+    setAttribute(mapInfo, "Unique ID", m_SerialID);
+    m_UniqueID = m_SerialID;
 
     if (mapInfo["Hardware Class"] != "fingerprint") {
         m_HardwareClass = "others";
@@ -135,7 +138,7 @@ bool DeviceOthers::available()
     if (driver().isEmpty() && m_HardwareClass == "others") {
         m_Available = false;
     }
-    return m_Available;
+    return m_forcedDisplay ? m_forcedDisplay : m_Available;
 }
 
 void DeviceOthers::initFilterKey()

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -983,9 +983,13 @@ void DeviceGenerator::getOthersInfoFromHwinfo()
     for (; it != lstMap.end(); ++it) {
         if ((*it).size() < 3)
             continue;
-
-        if ((*it).find("Device") != (*it).end() && (*it)["Device"].contains("fingerprint", Qt::CaseInsensitive)) {
+/*  bug 141439 不可见功能设计需要再次思考*/
+        if (  (*it).find("Device") != (*it).end() &&
+             ((*it)["Device"].contains("fingerprint", Qt::CaseInsensitive)  ||  
+              (*it)["Device"].contains("MOH", Qt::CaseInsensitive)
+             )) { 
             DeviceOthers *device = new DeviceOthers();
+            device->setForcedDisplay(true);
             device->setInfoFromHwinfo(*it);
             DeviceManager::instance()->addOthersDevice(device);
             continue;


### PR DESCRIPTION
取消指纹模块driver为空的判为“显示不可用 ”,让MOH和FT9201 指纹模块显示可用

Log: 修复MOH指纹模块显示不可用
Bug: https://pms.uniontech.com/bug-view-141439.html