### PR TITLE
fix: 驱动管理里蓝牙显示错误

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceBluetooth.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceBluetooth.cpp
@@ -122,7 +122,7 @@ bool DeviceBluetooth::setInfoFromWifiInfo(const QMap<QString, QString> &mapInfo)
 
 const QString &DeviceBluetooth::name()const
 {
-    return m_Name;
+    return m_Model;
 }
 
 const QString &DeviceBluetooth::vendor() const


### PR DESCRIPTION
驱动管理里蓝牙显示型号

Log: 正确显示蓝牙
/review @pengfeixx 