### PR TITLE
fix: 点击主界面左侧目录之间的间隙时不应触发显示概况且目录概况未被选中

### DIFF
--- a/deepin-devicemanager/src/Page/PageListView.cpp
+++ b/deepin-devicemanager/src/Page/PageListView.cpp
@@ -101,7 +101,7 @@ void PageListView::slotListViewItemClicked(const QModelIndex &index)
 {
     // Item 点击事件
     QString concateStr = mp_ListView->getConcatenateStrings(index);
-    if (!concateStr.isEmpty()) {
+    if (!concateStr.isEmpty() && concateStr != QString("Separator")) {
         emit itemClicked(concateStr);
         m_CurType = concateStr;
     }

--- a/deepin-devicemanager/src/Widget/DeviceListView.cpp
+++ b/deepin-devicemanager/src/Widget/DeviceListView.cpp
@@ -107,9 +107,12 @@ void DeviceListView::addItem(const QString &name, const QString &iconFile)
     item->setData(name, Qt::DisplayRole);
     item->setData(lst[1], Qt::UserRole);
     item->setTextAlignment(Qt::AlignVCenter);
-    item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemNeverHasChildren);
-    if (name != QString("Separator"))
+    if (name != QString("Separator")) {
         item->setToolTip(name);
+        item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemNeverHasChildren);
+    } else {
+        item->setFlags(Qt::ItemNeverHasChildren);
+    }
     item->setIcon(QIcon::fromTheme(lst[0]));
     setIconSize(QSize(20, 20));
     mp_ItemModel->appendRow(item);


### PR DESCRIPTION
取消选择空隙选中概况

Log:  点击主界面左侧目录之间的间隙时不应触发显示概况
Bug: https://pms.uniontech.com/bug-view-151783.html
/review @pengfeixx @feeengli @jeffshuai 