### PR TITLE
fix: 设备管理器没有显示设备信息

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
@@ -187,9 +187,12 @@ const QString DeviceMemory::getOverviewInfo()
 {
     // 获取概况信息
     QString ov;
+    QString nameStr = m_Name != "" ? m_Name : m_Vendor;
+    if(nameStr == "--")
+        nameStr.clear();
     ov += QString("%1(%2 %3 %4)") \
           .arg(m_Size) \
-          .arg(m_Name != "" ? m_Name : m_Vendor) \
+          .arg(nameStr) \
           .arg(m_Type) \
           .arg(m_Speed);
 

--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -138,6 +138,7 @@ void DeviceMonitor::setInfoFromEdid(const QMap<QString, QString> &mapInfo)
     m_Name = "Monitor " + mapInfo["Vendor"];
     setAttribute(mapInfo, "Size", m_ScreenSize);
     setAttribute(mapInfo, "Vendor", m_Vendor);
+    setAttribute(mapInfo, "Date", m_ProductionWeek);
     getOtherMapInfo(mapInfo);
 }
 

--- a/deepin-devicemanager/src/GenerateDevice/DeviceFactory.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceFactory.cpp
@@ -35,6 +35,8 @@ DeviceGenerator *DeviceFactory::getDeviceGenerator()
         if (!type.isEmpty()) {
             if (type == "KLVV")
                 generator = new KLVGenerator();
+            else if (type == "PGUV")
+                generator = new PanguVGenerator();
             else
                 generator = new HWGenerator();
         } else

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -169,7 +169,12 @@ void DeviceGenerator::generatorCpuDevice()
         logicalNum = map["logical"].toInt();
 
     // set cpu number
-    DeviceManager::instance()->setCpuNum(dmidecode4.size());
+    QSet<QString> allCPUS;
+    for (auto dd4:dmidecode4) {
+        if(dd4.contains("Socket Designation"))
+            allCPUS.insert(dd4["Socket Designation"]);
+    }
+    DeviceManager::instance()->setCpuNum(allCPUS.isEmpty() ? dmidecode4.size() : allCPUS.size());
 
     // set cpu info
     QList<QMap<QString, QString> >::const_iterator it = srcLst.begin();

--- a/deepin-devicemanager/src/GenerateDevice/PanguVGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/PanguVGenerator.cpp
@@ -4,6 +4,9 @@
 // 其它头文件
 #include "../DeviceManager/DeviceManager.h"
 #include "../DeviceManager/DeviceMonitor.h"
+#include "EDIDParser.h"
+
+#include <QProcess>
 
 PanguVGenerator::PanguVGenerator()
 {
@@ -13,27 +16,72 @@ PanguVGenerator::PanguVGenerator()
 void PanguVGenerator::generatorMonitorDevice()
 {
     // 生成显示设备信息
-    const QList<QMap<QString, QString>> lstMapHDMI = DeviceManager::instance()->cmdInfo("EDID_HDMI");
-    QList<QMap<QString, QString> >::const_iterator itHDMI = lstMapHDMI.begin();
-    for (; itHDMI != lstMapHDMI.end(); ++itHDMI) {
-        if ((*itHDMI).size() < 1)
+//    const QList<QMap<QString, QString>> lstMapHDMI = DeviceManager::instance()->cmdInfo("EDID_HDMI");
+//    QList<QMap<QString, QString> >::const_iterator itHDMI = lstMapHDMI.begin();
+//    for (; itHDMI != lstMapHDMI.end(); ++itHDMI) {
+//        if ((*itHDMI).size() < 1)
+//            continue;
+
+//        //HDMI interface EDID information
+//        DeviceMonitor *device = new  DeviceMonitor();
+//        device->setInfoFromEdid(*itHDMI);
+//        DeviceManager::instance()->addMonitor(device);
+//    }
+
+//    const QList<QMap<QString, QString>> lstMapVGA = DeviceManager::instance()->cmdInfo("EDID_VGA");
+//    QList<QMap<QString, QString> >::const_iterator it = lstMapVGA.begin();
+//    for (; it != lstMapVGA.end(); ++it) {
+//        if ((*it).size() < 1)
+//            continue;
+
+//        //VGA interface EDID information
+//        DeviceMonitor *device = new DeviceMonitor();
+//        device->setInfoFromEdid(*it);
+//        DeviceManager::instance()->addMonitor(device);
+//    }
+
+    QStringList allEDIDS;
+    allEDIDS.append("/sys/devices/platform/hisi-drm/drm/card0/card0-HDMI-A-1/edid");
+    allEDIDS.append("/sys/devices/platform/hisi-drm/drm/card0/card0-VGA-1/edid");
+    allEDIDS.append("/sys/devices/platform/hldrm/drm/card0/card0-HDMI-A-1/edid");
+    allEDIDS.append("/sys/devices/platform/hldrm/drm/card0/card0-VGA-1/edid");
+    for (auto edid:allEDIDS) {
+        QProcess process;
+        process.start(QString("hexdump %1").arg(edid));
+        process.waitForFinished(-1);
+
+        QString deviceInfo = process.readAllStandardOutput();
+        if(deviceInfo.isEmpty())
             continue;
 
-        //HDMI interface EDID information
-        DeviceMonitor *device = new  DeviceMonitor();
-        device->setInfoFromEdid(*itHDMI);
-        DeviceManager::instance()->addMonitor(device);
+        QString edidStr;
+        QStringList lines = deviceInfo.split("\n");
+        for (auto line:lines) {
+            QStringList words = line.trimmed().split(" ");
+            if(words.size() != 9)
+                continue;
+
+            words.removeAt(0);
+            QString l = words.join("");
+            l.append("\n");
+            edidStr.append(l);
+        }
+
+        lines = edidStr.split("\n");
+        if(lines.size() > 3){
+            EDIDParser edidParser;
+            QString errorMsg;
+            edidParser.setEdid(edidStr,errorMsg,"\n", false);
+
+            QMap<QString, QString> mapInfo;
+            mapInfo.insert("Vendor",edidParser.vendor());
+            mapInfo.insert("Date",edidParser.releaseDate());
+            mapInfo.insert("Size",edidParser.screenSize());
+
+            DeviceMonitor *device = new DeviceMonitor();
+            device->setInfoFromEdid(mapInfo);
+            DeviceManager::instance()->addMonitor(device);
+        }
     }
 
-    const QList<QMap<QString, QString>> lstMapVGA = DeviceManager::instance()->cmdInfo("EDID_VGA");
-    QList<QMap<QString, QString> >::const_iterator it = lstMapVGA.begin();
-    for (; it != lstMapVGA.end(); ++it) {
-        if ((*it).size() < 1)
-            continue;
-
-        //VGA interface EDID information
-        DeviceMonitor *device = new DeviceMonitor();
-        device->setInfoFromEdid(*it);
-        DeviceManager::instance()->addMonitor(device);
-    }
 }

--- a/deepin-devicemanager/src/GenerateDevice/PanguVGenerator.h
+++ b/deepin-devicemanager/src/GenerateDevice/PanguVGenerator.h
@@ -24,14 +24,14 @@
 #define PANGUVGENERATOR_H
 
 #include <QObject>
-#include "KLUGenerator.h"
+#include "HWGenerator.h"
 
 /**
  * @brief The PanguVGenerator class
  * 将获取的设备信息生成设备对象，panguV下的生成器
  */
 
-class PanguVGenerator : public KLUGenerator
+class PanguVGenerator : public HWGenerator
 {
 public:
     PanguVGenerator();

--- a/deepin-devicemanager/src/Tool/EDIDParser.cpp
+++ b/deepin-devicemanager/src/Tool/EDIDParser.cpp
@@ -163,7 +163,7 @@ void EDIDParser::parseScreenSize()
     m_Width = hexToDec(getBytes(1, m_LittleEndianMode ? 5 : 4)).toInt();
     m_Height = hexToDec(getBytes(1, m_LittleEndianMode ? 6 : 7)).toInt();
     double inch = sqrt((m_Width / 2.54) * (m_Width / 2.54) + (m_Height / 2.54) * (m_Height / 2.54));
-    m_ScreenSize = QString("%1 %2(%3mm X %4mm)").arg(QString::number(inch, 'f', 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
+    m_ScreenSize = QString("%1 %2(%3cm X %4cm)").arg(QString::number(inch, 'f', 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
 }
 
 QString EDIDParser::binToDec(QString strBin)   //二进制转十进制


### PR DESCRIPTION
添加读取edid显示设备；更新cpu数量计算方法；

Log: 正确显示显示设备和cpu个数
Bug: https://pms.uniontech.com/bug-view-152007.html
/review @pengfeixx @jeffshuai @feeengli @hundundadi @myk1343 