### PR TITLE
fix: 禁用显卡音频，重启后音频信息异常增多

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -687,6 +687,7 @@ void DeviceGenerator::getAudioInfoFromLshw()
 
         DeviceManager::instance()->setAudioInfoFromLshw(*it);
     }
+     DeviceManager::instance()->deleteDisableDuplicate_AudioDevice();  //bug 150331  禁用显卡音频，重启后音频信息异常增多
 }
 
 void DeviceGenerator::getAudioInfoFromCatInput()


### PR DESCRIPTION
禁用显卡音频，重启后音频信息异常增多because of from lshw

Log: 修复禁用显卡音频，重启后音频信息异常增多
Bug: https://pms.uniontech.com/bug-view-150331.html