### PR TITLE
fix: 144HZ显示器在设备管理器中显示为44HZ

### DIFF
--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -106,7 +106,7 @@ void ThreadExecXrandr::loadXrandrVerboseInfo(QList<QMap<QString, QString>> &lstM
         if ((*it).contains("*current")) {
             if ((it += 2) >= lines.end())
                 return;
-            QRegExp regRate(".*([0-9]{2}\\.[0-9]{2}Hz).*");
+            QRegExp regRate(".*([0-9]{1,5}\\.[0-9]{1,5}Hz).*");
             if (regRate.exactMatch(*it))
                 last.insert("rate", regRate.cap(1));
         }


### PR DESCRIPTION
正则表达式只取了2位数据

Log: 正常显示显示器的刷新率
Bug: https://pms.uniontech.com/bug-view-154667.html
/review @lzwind @feeengli @hundundadi @jeffshuai @myk1343 