### PR TITLE
fix: 设备管理器中显示适配器中最大分辨率和最小分辨率信息有误

### DIFF
--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -43,6 +43,18 @@ DWIDGET_USE_NAMESPACE
 
 static bool startScanningFlag = false;
 
+static bool checkWaylandMode()
+{
+    auto e = QProcessEnvironment::systemEnvironment();
+    QString XDG_SESSION_TYPE = e.value(QStringLiteral("XDG_SESSION_TYPE"));
+    QString WAYLAND_DISPLAY = e.value(QStringLiteral("WAYLAND_DISPLAY"));
+    bool waylandMode = false;
+    if (XDG_SESSION_TYPE == QLatin1String("wayland") || WAYLAND_DISPLAY.contains(QLatin1String("wayland"), Qt::CaseInsensitive)) //是否开启wayland
+        waylandMode = true;
+
+    return waylandMode;
+}
+
 MainWindow::MainWindow(QWidget *parent)
     : DMainWindow(parent)
     , mp_MainStackWidget(new DStackedWidget(this))
@@ -394,11 +406,11 @@ void MainWindow::slotListItemClicked(const QString &itemStr)
 {
     // xrandr would be execed later
     if (tr("Monitor") == itemStr || tr("Overview") == itemStr) { //点击显示设备，执行线程加载信息
-        ThreadExecXrandr tx(false);
+        ThreadExecXrandr tx(false, !checkWaylandMode());
         tx.start();
         tx.wait();
     } else if (tr("Display Adapter") == itemStr) { //点击显示适配器，执行线程加载信息
-        ThreadExecXrandr tx(true);
+        ThreadExecXrandr tx(true, !checkWaylandMode());
         tx.start();
         tx.wait();
     } else if (tr("CPU") == itemStr) { //点击处理器，执行加载处理器信息线程

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.h
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.h
@@ -26,7 +26,7 @@
 class ThreadExecXrandr : public QThread
 {
 public:
-    ThreadExecXrandr(bool gpu);
+    ThreadExecXrandr(bool gpu, bool isDXcbPlatform);
 
     /**
      * @brief run
@@ -56,6 +56,18 @@ private:
     void loadXrandrVerboseInfo(QList<QMap<QString, QString>> &lstMap, const QString &cmd);
 
     /**
+     * @brief getRefreshRateFromDBus:通过dbus获取刷新率
+     * @param lstMap
+     */
+    void getRefreshRateFromDBus(QList<QMap<QString, QString>> &lstMap);
+
+    /**
+     * @brief getResolutionFromDBus:通过dbus获取分辨率
+     * @param lstMap
+     */
+    void getResolutionFromDBus(QMap<QString, QString> &lstMap);
+
+    /**
      * @brief getMonitorInfoFromXrandrVerbose:从xrandr --verbose获取显示设备信息
      */
     void getMonitorInfoFromXrandrVerbose();
@@ -67,7 +79,8 @@ private:
 
 
 private:
-    bool m_Gpu;    //<!  判断是否是gpu
+    bool m_Gpu;                //<!  判断是否是gpu
+    bool m_isDXcbPlatform;     //<!  判断是否是DXcbPlatform
 };
 
 #endif // THREADEXECXRANDR_H

--- a/deepin-devicemanager/tests/src/GenerateDevice/ut_loadinfothread.cpp
+++ b/deepin-devicemanager/tests/src/GenerateDevice/ut_loadinfothread.cpp
@@ -46,7 +46,7 @@ class UT_ThreadExecXrandr : public UT_HEAD
 public:
     void SetUp()
     {
-        m_threadExecXrandr = new ThreadExecXrandr(true);
+        m_threadExecXrandr = new ThreadExecXrandr(true, true);
     }
     void TearDown()
     {


### PR DESCRIPTION
使用dbus的最大最小分辨率

Log: 正确显示分辨率
Bug: https://pms.uniontech.com/bug-view-151709.html
/review @lzwind @feeengli @hundundadi @jeffshuai @myk1343 