### PR TITLE
fix: hw声卡厂商和型号未显示

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
@@ -224,6 +224,8 @@ void DeviceAudio::setInfoFromCatAudio(const QMap<QString, QString> &mapInfo)
     //1. 获取设备的基本信息
     setAttribute(mapInfo, "Name", m_Name);
     setAttribute(mapInfo, "driver", m_Driver);
+    setAttribute(mapInfo, "Vendor", m_Vendor);
+    setAttribute(mapInfo, "Model", m_Model);
 
     //2. 获取设备的其它信息
     getOtherMapInfo(mapInfo);


### PR DESCRIPTION
添加声卡厂商和型号

Log: 正确显示声卡厂商和型号
/review @lzwind @myk1343 @pengfeixx @feeengli @hundundadi @jeffshuai 