### PR TITLE
fix: 设备管理器只有概况信息

### DIFF
--- a/deepin-devicemanager-server/deepin-devicemanager-server.service
+++ b/deepin-devicemanager-server/deepin-devicemanager-server.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Deepin Device Manager Daemon
-After=multi-user.target
+After=network.target
 [Service]
 Restart=always
 ExecStart=/usr/bin/deepin-devicemanager-server


### PR DESCRIPTION
将设备管理器服务调整到netwark之后启动

Log: 重启正常显示
Bug: https://pms.uniontech.com/bug-view-146857.html
/review @lzwind @feeengli @jeffshuai @hundundadi @myk1343 @pengfeixx 