### PR TITLE
fix: 部分CPU核心ID存在间隔问题

### DIFF
--- a/deepin-devicemanager-server/src/LoadInfo/cpu/CoreCpu.cpp
+++ b/deepin-devicemanager-server/src/LoadInfo/cpu/CoreCpu.cpp
@@ -22,6 +22,9 @@ CoreCpu::CoreCpu(int id)
 void CoreCpu::setCoreId(int id)
 {
     m_CoreId = id;
+    for (LogicalCpu &lCpu : m_MapLogicalCpu) {
+        lCpu.setCoreID(id);
+    }
 }
 
 void CoreCpu::addLogicalCpu(int id, const LogicalCpu &lc)


### PR DESCRIPTION
重新设置cpu线程的核心ID

Log: cpu的ID正常
/review @lzwind 