### PR TITLE
fix: 存在多个网络适配器时列表中的title应显示类型而非型号

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
@@ -255,6 +255,13 @@ void DeviceNetwork::loadOtherDeviceInfo()
     mapInfoToList();
 }
 
+void DeviceNetwork::loadTableHeader()
+{
+    m_TableHeader.append(tr("Name"));
+    m_TableHeader.append(tr("Vendor"));
+    m_TableHeader.append(tr("Type"));
+}
+
 void DeviceNetwork::loadTableData()
 {
     // 根据是否禁用设置设备名称

--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.h
@@ -124,6 +124,11 @@ protected:
     void loadOtherDeviceInfo() override;
 
     /**
+     * @brief loadTableHeader : 过去表格的表头数据
+     */
+    void loadTableHeader() override;
+
+    /**
      * @brief loadTableData:加载表头信息
      */
     void loadTableData() override;


### PR DESCRIPTION
自定义网络适配器表头

Log: 网络适配器表头显示类型

Bug: https://pms.uniontech.com/bug-view-161717.html
/review @lzwind @feeengli @jeffshuai @myk1343 @pengfeixx @HeeMingYang 