### PR TITLE
fix: 显卡声卡网卡的时钟频率和位宽错误

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
@@ -346,8 +346,8 @@ void DeviceAudio::loadOtherDeviceInfo()
     // 添加其他信息,成员变量
     addOtherDeviceInfo(tr("Chip"), m_Chip);
     addOtherDeviceInfo(tr("Capabilities"), m_Capabilities);
-    addOtherDeviceInfo(tr("Clock"), m_Clock);
-    addOtherDeviceInfo(tr("Width"), m_Width);
+//    addOtherDeviceInfo(tr("Clock"), m_Clock);
+//    addOtherDeviceInfo(tr("Width"), m_Width);
     addOtherDeviceInfo(tr("Memory Address"), m_Memory);   // 1050需求 内存改为内存地址
     addOtherDeviceInfo(tr("IRQ"), m_Irq);
 

--- a/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
@@ -239,7 +239,7 @@ void DeviceGpu::loadOtherDeviceInfo()
     addOtherDeviceInfo(tr("Current Resolution"), m_CurrentResolution);
     addOtherDeviceInfo(tr("Driver"), m_Driver);
     addOtherDeviceInfo(tr("Description"), m_Description);
-    addOtherDeviceInfo(tr("Clock"), m_Clock);
+//    addOtherDeviceInfo(tr("Clock"), m_Clock);
     addOtherDeviceInfo(tr("DP"), m_DisplayPort);
     addOtherDeviceInfo(tr("eDP"), m_eDP);
     addOtherDeviceInfo(tr("HDMI"), m_HDMI);
@@ -249,7 +249,7 @@ void DeviceGpu::loadOtherDeviceInfo()
     addOtherDeviceInfo(tr("Display Output"), m_DisplayOutput);
     addOtherDeviceInfo(tr("Capabilities"), m_Capabilities);
     addOtherDeviceInfo(tr("IRQ"), m_IRQ);
-    addOtherDeviceInfo(tr("Width"), m_Width);
+//    addOtherDeviceInfo(tr("Width"), m_Width);
 
     // 将QMap<QString, QString>内容转存为QList<QPair<QString, QString>>
     mapInfoToList();

--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
@@ -244,8 +244,8 @@ void DeviceNetwork::loadOtherDeviceInfo()
     addOtherDeviceInfo(tr("Duplex"), m_Duplex);
     addOtherDeviceInfo(tr("Broadcast"), m_Broadcast);
     addOtherDeviceInfo(tr("Auto Negotiation"), m_Autonegotiation);
-    addOtherDeviceInfo(tr("Clock"), m_Clock);
-    addOtherDeviceInfo(tr("Width"), m_Width);
+//    addOtherDeviceInfo(tr("Clock"), m_Clock);
+//    addOtherDeviceInfo(tr("Width"), m_Width);
     addOtherDeviceInfo(tr("Memory Address"), m_Memory);        // 1050需求 内存改为内存地址
     addOtherDeviceInfo(tr("IRQ"), m_Irq);
     addOtherDeviceInfo(tr("MAC Address"), m_MACAddress);

--- a/deepin-devicemanager/src/DeviceManager/DeviceOtherPCI.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceOtherPCI.cpp
@@ -72,8 +72,8 @@ void DeviceOtherPCI::loadOtherDeviceInfo()
     addOtherDeviceInfo(tr("Memory"), m_Memory);
     addOtherDeviceInfo(tr("IRQ"), m_Irq);
     addOtherDeviceInfo(tr("Latency"), m_Latency);
-    addOtherDeviceInfo(tr("Clock"), m_Clock);
-    addOtherDeviceInfo(tr("Width"), m_Width);
+//    addOtherDeviceInfo(tr("Clock"), m_Clock);
+//    addOtherDeviceInfo(tr("Width"), m_Width);
     addOtherDeviceInfo(tr("Driver"), m_Driver);
     addOtherDeviceInfo(tr("Capabilities"), m_Version);
 


### PR DESCRIPTION
隐藏显卡声卡网卡的PCI时钟频率和位宽

Log: 隐藏显卡声卡网卡的时钟频率和位宽
Bug: https://pms.uniontech.com/bug-view-160181.html,https://pms.uniontech.com/bug-view-159585.html
/review @pengfeixx @feeengli @jeffshuai @HeeMingYang 