### PR TITLE
fix: 侧边栏hover/高亮时背景底没有与侧边栏居中对齐

### DIFF
--- a/deepin-devicemanager/src/Widget/DeviceListView.cpp
+++ b/deepin-devicemanager/src/Widget/DeviceListView.cpp
@@ -90,7 +90,7 @@ DeviceListView::DeviceListView(QWidget *parent)
     setAutoFillBackground(true); //与背景色有关
 
     // bug51444左侧菜单和滚动条不重叠重叠
-    setViewportMargins(5, 2, 11, 5);
+    setViewportMargins(11, 2, 11, 5);
 
     setMovement(QListView::Static);
 }


### PR DESCRIPTION
侧边栏边距设置为11像素

Log: 居中显示侧边栏内容
Bug: https://pms.uniontech.com/bug-view-157697.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi 