### PR TITLE
fix: 音频适配器芯片信息显示不全

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
@@ -176,11 +176,11 @@ bool DeviceAudio::setInfoFrom_sysFS(QMap<QString, QString> &mapInfo, int ii)
     } else
         m_VID_PID = vid.trimmed() + pid.remove("0x", Qt::CaseSensitive).trimmed();
 
-    m_Chip = DeviceBaseInfo::get_string(hwCard_path + "/vendor_name") + DeviceBaseInfo::get_string(hwCard_path + "/chip_name");
+    m_Chip = DeviceBaseInfo::get_string(hwCard_path + "/vendor_name") + " " + DeviceBaseInfo::get_string(hwCard_path + "/chip_name");
     m_Vendor = DeviceBaseInfo::get_string(hwCard_path + "/vendor_name");
-    m_Name =  DeviceBaseInfo::get_string(Cardx_path + "/id") + QString("/card%1").arg(ii);
+    m_Name =  DeviceBaseInfo::get_string(Cardx_path + "/id") + " " + QString("/card%1").arg(ii);
     m_Model = m_VID_PID;
-    m_Driver = "driveby" + DeviceBaseInfo::get_string(hwCard_path + "/vendor_name");  //debug
+    m_Driver = "driveby " + DeviceBaseInfo::get_string(hwCard_path + "/vendor_name");  //debug
 
     // setAttribute(mapInfo, "SysFS ID", m_SysPath);
 

--- a/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
@@ -704,7 +704,7 @@ bool DeviceBaseInfo::matchToLshw(const QMap<QString, QString> &mapInfo)
 
 void DeviceBaseInfo::setsysFStoHwinfoKey(const QMap<QString, QString> &mapInfo)
 {
-    if (mapInfo.find("VID_PID") != mapInfo.end() ) {
+    if (mapInfo.find("VID_PID") != mapInfo.end()) {
         m_sysFSToHwinfo = mapInfo["VID_PID"];
         return;
     }
@@ -713,7 +713,7 @@ void DeviceBaseInfo::setsysFStoHwinfoKey(const QMap<QString, QString> &mapInfo)
 bool DeviceBaseInfo::sysFSmatchToHwinfo(const QMap<QString, QString> &mapInfo)
 {
     // VID_PID 匹配上
-    if (mapInfo.find("VID_PID") != mapInfo.end() ) {
+    if (mapInfo.find("VID_PID") != mapInfo.end()) {
         if (m_sysFSToHwinfo == mapInfo["VID_PID"]) {
             return true;
         }
@@ -729,6 +729,7 @@ const  QString DeviceBaseInfo::get_string(const QString &sysPathfile)
         return QString();
 
     QString info = file.readAll();
+    info = info.trimmed();
     file.close();
     return info;
 }


### PR DESCRIPTION
去掉芯片信息换行符

Log: 正确显示音频适配器芯片信息
Bug: https://pms.uniontech.com/bug-view-162727.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi