### PR TITLE
fix: 切换驱动后关闭出现coredump

### DIFF
--- a/deepin-devicemanager/src/Widget/DetectedStatusWidget.cpp
+++ b/deepin-devicemanager/src/Widget/DetectedStatusWidget.cpp
@@ -60,9 +60,9 @@ DetectedStatusWidget::DetectedStatusWidget(QWidget *parent)
 
 DetectedStatusWidget::~DetectedStatusWidget()
 {
-    DELETE_PTR(mp_HLayoutTotal);
     DELETE_PTR(mp_HLayoutButton);
     DELETE_PTR(mp_VLayoutLabel);
+    DELETE_PTR(mp_HLayoutTotal);
 }
 
 void DetectedStatusWidget::setDetectFinishUI(const QString &size, const QString &model, bool hasInstall)


### PR DESCRIPTION
调整释放界面顺序

Log: 正确关闭窗口
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi