### PR TITLE
fix: 设备管理器中内存单位与终端中输入dmidecode17查询的内存速率单位不符合

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
@@ -41,8 +41,6 @@ void DeviceMemory::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
 
     // 设置内存速率
     setAttribute(mapInfo, "clock", m_Speed);
-    if (m_Speed.contains("MT/s"))
-        m_Speed.replace("MT/s", "MHz");
 
     // 由lshw设置基本信息
     setAttribute(mapInfo, "width", m_TotalBandwidth);
@@ -62,10 +60,9 @@ bool DeviceMemory::setInfoFromDmidecode(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Part Number", m_Name);
     setAttribute(mapInfo, "Serial Number", m_SerialNumber);
 
+    setAttribute(mapInfo, "Speed", m_Speed);
     // 设置配置频率
     setAttribute(mapInfo, "Configured Memory Speed", m_ConfiguredSpeed);
-    if (m_ConfiguredSpeed.contains("MT/s"))
-        m_ConfiguredSpeed.replace("MT/s", "MHz");
 
     // 由dmidecode设置基本属性
     setAttribute(mapInfo, "Minimum Voltage", m_MinimumVoltage);
@@ -127,7 +124,7 @@ void DeviceMemory::loadOtherDeviceInfo()
 {
     // 倒序，头插，保证原来的顺序
     // 添加其他信息,成员变量
-    if(Common::boardVendorType().isEmpty()){
+    if (Common::boardVendorType().isEmpty()) {
         addOtherDeviceInfo(tr("Configured Voltage"), m_ConfiguredVoltage);
         addOtherDeviceInfo(tr("Maximum Voltage"), m_MaximumVoltage);
         addOtherDeviceInfo(tr("Minimum Voltage"), m_MinimumVoltage);
@@ -192,7 +189,7 @@ const QString DeviceMemory::getOverviewInfo()
     // 获取概况信息
     QString ov;
     QString nameStr = m_Name != "" ? m_Name : m_Vendor;
-    if(nameStr == "--")
+    if (nameStr == "--")
         nameStr.clear();
     ov += QString("%1(%2 %3 %4)") \
           .arg(m_Size) \


### PR DESCRIPTION
将dmidecode17查询的内存速率替换lshw信息

Log: 正确显示内存速率
Bug: https://pms.uniontech.com/bug-view-169555.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi