### PR TITLE
fix: 进入驱动管理并在它正在加载的时候关闭设备管理器会出现一个用户无感知的崩溃

### DIFF
--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -76,6 +76,11 @@ PageDriverManager::PageDriverManager(DWidget *parent)
 
 PageDriverManager::~PageDriverManager()
 {
+    // 扫描驱动时关闭线程
+    if (mp_scanner->isRunning()) {
+        mp_scanner->terminate();
+        mp_scanner->wait();
+    }
     DELETE_PTR(mp_ViewNotInstall);
     DELETE_PTR(mp_ViewCanUpdate);
     DELETE_PTR(mp_AllDriverIsNew);


### PR DESCRIPTION
关闭应用时取消扫描线程

Log: 正常关闭
Bug: https://pms.uniontech.com/bug-view-164681.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi