### PR TITLE
fix: 设备管理器无法显示设备信息且光标一直在转圈

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -353,10 +353,13 @@ void CmdTool::loadBluetoothCtlInfo(QMap<QString, QString> &mapInfo)
         addMapInfo("hciconfig", mapInfo);
         return;
     }
-    QString deviceInfo;
+    QProcess process;
+    process.start("bluetoothctl show " + mapInfo["BD Address"]);
+    process.waitForFinished(10000);
+    QString deviceInfo = process.readAllStandardOutput();
 
     // 读取文件信息
-    if (!getDeviceInfoFromCmd(deviceInfo, "bluetoothctl show " + mapInfo["BD Address"])) {
+    if (deviceInfo.isEmpty()) {
         addMapInfo("hciconfig", mapInfo);
         return;
     }


### PR DESCRIPTION
bluetoothctl命令卡住，已限制时间

Log: 正确显示设备管理器信息
Bug: https://pms.uniontech.com/bug-view-163665.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi