### PR TITLE
fix: 设置鼠标唤醒后从一个USB接口更换到其他USB接口后再S3后USB鼠标无法唤醒需要重新刷新后设置或重新开启设备管理器后再重新设置

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -87,7 +87,7 @@ void DeviceInput::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Unique ID", m_WakeupID);
     setAttribute(mapInfo, "Unique ID", m_SerialID);
     m_UniqueID = m_SerialID;
-    
+
 
     // 获取键盘的接口类型
     if (mapInfo.find("Hotplug") != mapInfo.end())
@@ -363,11 +363,8 @@ bool DeviceInput::canWakeupMachine()
 {
     if (m_WakeupID.isEmpty())
         return false;
-    QFile file(wakeupPath());
-    if (!file.open(QIODevice::ReadOnly)) {
-        return false;
-    }
-    return true;
+
+    return DBusWakeupInterface::getInstance()->canInputWakeupMachine(wakeupPath());
 }
 
 bool DeviceInput::isWakeupMachine()
@@ -376,10 +373,8 @@ bool DeviceInput::isWakeupMachine()
     if (!file.open(QIODevice::ReadOnly)) {
         return false;
     }
-    QString info = file.readAll();
-    if (info.contains("disabled"))
-        return false;
-    return true;
+
+    return DBusWakeupInterface::getInstance()->isInputWakeupMachine(wakeupPath());
 }
 
 QString DeviceInput::wakeupPath()

--- a/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.cpp
+++ b/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.cpp
@@ -8,6 +8,8 @@
 #include <QDBusInterface>
 #include <QDBusReply>
 #include <QDebug>
+#include <QFile>
+#include <QMetaMethod>
 
 // 以下这个问题可以避免单例的内存泄露问题
 std::atomic<DBusWakeupInterface *> DBusWakeupInterface::s_Instance;
@@ -16,15 +18,34 @@ std::mutex DBusWakeupInterface::m_mutex;
 const QString SERVICE_NAME = "com.deepin.devicemanager";
 const QString WAKEUP_SERVICE_PATH = "/com/deepin/wakeupmanager";
 const QString WAKEUP_INTERFACE = "com.deepin.wakeupmanager";
+const QString INPUT_SERVICE_NAME = "com.deepin.system.InputDevices";
+const QString INPUT_WAKEUP_SERVICE_PATH = "/com/deepin/system/InputDevices";
+const QString INPUT_WAKEUP_INTERFACE = "com.deepin.system.InputDevices";
+const QString INPUT_WAKEUP_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties";
 
 DBusWakeupInterface::DBusWakeupInterface()
-    :mp_Iface(nullptr)
+    : mp_Iface(nullptr), mp_InputIface(nullptr)
 {
     init();
 }
 
-bool DBusWakeupInterface::setWakeupMachine(const QString& unique_id, const QString& path, bool wakeup)
+bool DBusWakeupInterface::setWakeupMachine(const QString &unique_id, const QString &path, bool wakeup)
 {
+    if (nullptr != mp_InputIface && mp_InputIface->isValid()) {
+        QStringList pathList = path.split("/", QString::SkipEmptyParts);
+        if (pathList.size() < 3)
+            return false;
+
+        auto metaObject = mp_InputIface->metaObject();
+        for (int i = 0 ; i < metaObject->methodCount(); ++i) {
+            if (metaObject->method(i).name() == "SetWakeupDevices") {
+                QString curPath = pathList[pathList.size() - 2];
+                QString busPath = QString("/sys/bus/usb/devices/%1/power/wakeup").arg(curPath);
+                mp_InputIface->call("SetWakeupDevices", busPath, wakeup ? "enabled" : "disabled");
+                return true;
+            }
+        }
+    }
     QDBusReply<bool> reply = mp_Iface->call("setWakeupMachine", unique_id, path, wakeup);
     if (reply.isValid()) {
         return reply.value();
@@ -32,7 +53,66 @@ bool DBusWakeupInterface::setWakeupMachine(const QString& unique_id, const QStri
     return false;
 }
 
-int DBusWakeupInterface::isNetworkWakeup(const QString& logical_name)
+bool DBusWakeupInterface::canInputWakeupMachine(const QString &path)
+{
+    if (nullptr != mp_InputIface && mp_InputIface->isValid()) {
+        QDBusInterface interface(INPUT_SERVICE_NAME, INPUT_WAKEUP_SERVICE_PATH, INPUT_WAKEUP_PROPERTIES_INTERFACE, QDBusConnection::systemBus());
+        if (interface.isValid()) {
+            QDBusMessage replay = interface.call("Get", INPUT_WAKEUP_INTERFACE, "SupportWakeupDevices");
+            QVariant v =  replay.arguments().first();
+            if (v.isValid()) {
+                QDBusArgument arg = v.value<QDBusVariant>().variant().value<QDBusArgument>();
+                QMap<QString, QString> allSupportWakeupDevices;
+                arg >> allSupportWakeupDevices;
+
+                QString curPath = path.left(path.size() - 13);
+                int index = curPath.lastIndexOf('/');
+                if (index < 1) {
+                    return false;
+                }
+                curPath = curPath.right(curPath.size() - index - 1);
+                QString busPath = QString("/sys/bus/usb/devices/%1/power/wakeup").arg(curPath);
+                return allSupportWakeupDevices.contains(busPath);
+            }
+        }
+    }
+
+    QFile file(path);
+    return file.open(QIODevice::ReadOnly);
+}
+
+bool DBusWakeupInterface::isInputWakeupMachine(const QString &path)
+{
+    if (nullptr != mp_InputIface && mp_InputIface->isValid()) {
+        QDBusInterface interface(INPUT_SERVICE_NAME, INPUT_WAKEUP_SERVICE_PATH, INPUT_WAKEUP_PROPERTIES_INTERFACE, QDBusConnection::systemBus());
+        if (interface.isValid()) {
+            QDBusMessage replay = interface.call("Get", INPUT_WAKEUP_INTERFACE, "SupportWakeupDevices");
+            QVariant v =  replay.arguments().first();
+            if (v.isValid()) {
+                QDBusArgument arg = v.value<QDBusVariant>().variant().value<QDBusArgument>();
+                QMap<QString, QString> allSupportWakeupDevices;
+                arg >> allSupportWakeupDevices;
+
+                QString curPath = path.left(path.size() - 13);
+                int index = curPath.lastIndexOf('/');
+                if (index < 1)
+                    return false;
+                curPath = curPath.right(curPath.size() - index - 1);
+                QString busPath = QString("/sys/bus/usb/devices/%1/power/wakeup").arg(curPath);
+                return (allSupportWakeupDevices.contains(busPath) && allSupportWakeupDevices[busPath] == "enabled");
+            }
+        }
+    }
+
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return false;
+    }
+    QString info = file.readAll();
+    return !(info.contains("disabled"));
+}
+
+int DBusWakeupInterface::isNetworkWakeup(const QString &logical_name)
 {
     QDBusReply<int> reply = mp_Iface->call("isNetworkWakeup", logical_name);
     if (reply.isValid()) {
@@ -41,7 +121,7 @@ int DBusWakeupInterface::isNetworkWakeup(const QString& logical_name)
     return -1;
 }
 
-bool DBusWakeupInterface::setNetworkWakeup(const QString& logical_name, bool wake)
+bool DBusWakeupInterface::setNetworkWakeup(const QString &logical_name, bool wake)
 {
     QDBusReply<bool> reply = mp_Iface->call("setNetworkWake", logical_name, wake);
     if (reply.isValid()) {
@@ -62,4 +142,7 @@ void DBusWakeupInterface::init()
 
     // 2. create interface
     mp_Iface = new QDBusInterface(SERVICE_NAME, WAKEUP_SERVICE_PATH, WAKEUP_INTERFACE, QDBusConnection::systemBus());
+
+    // 3. create interface
+    mp_InputIface = new QDBusInterface(INPUT_SERVICE_NAME, INPUT_WAKEUP_SERVICE_PATH, INPUT_WAKEUP_INTERFACE, QDBusConnection::systemBus());
 }

--- a/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.h
+++ b/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.h
@@ -40,14 +40,28 @@ public:
      * @param wakeup 可唤醒 不可唤醒
      * @return
      */
-    bool setWakeupMachine(const QString& unique_id, const QString& path, bool wakeup);
+    bool setWakeupMachine(const QString &unique_id, const QString &path, bool wakeup);
+
+    /**
+     * @brief canWakeupMachine 获取input是否支持唤醒
+     * @param path 设备节点路径
+     * @return
+     */
+    bool canInputWakeupMachine(const QString &path);
+
+    /**
+     * @brief isWakeupMachine 获取input唤醒状态
+     * @param path 设备节点路径
+     * @return
+     */
+    bool isInputWakeupMachine(const QString &path);
 
     /**
      * @brief isNetworkWakeup 获取网卡是否支持远程唤醒
      * @param logical_name 网卡的逻辑名称
      * @return
      */
-    int isNetworkWakeup(const QString& logical_name);
+    int isNetworkWakeup(const QString &logical_name);
 
     /**
      * @brief setNetworkWakeup 设置网卡的唤醒功能
@@ -55,7 +69,7 @@ public:
      * @param wake 是否唤醒
      * @return
      */
-    bool setNetworkWakeup(const QString& logical_name, bool wake);
+    bool setNetworkWakeup(const QString &logical_name, bool wake);
 
 protected:
     DBusWakeupInterface();
@@ -69,6 +83,7 @@ private:
     static std::atomic<DBusWakeupInterface *> s_Instance;
     static std::mutex                         m_mutex;
     QDBusInterface                            *mp_Iface;
+    QDBusInterface                            *mp_InputIface;
 };
 
 #endif // DBUSWAKEUPINTERFACE_H


### PR DESCRIPTION
通过dde-daemon设置鼠标唤醒功能

Log: 正常设置鼠标唤醒
Bug: https://pms.uniontech.com/bug-view-172035.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi