### PR TITLE
fix: bluetoothctl命令卡死导致查询时间变长

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -356,7 +356,7 @@ void CmdTool::loadBluetoothCtlInfo(QMap<QString, QString> &mapInfo)
     }
     QProcess process;
     process.start("bluetoothctl show " + mapInfo["BD Address"]);
-    process.waitForFinished(10000);
+    process.waitForFinished(2000);
     QString deviceInfo = process.readAllStandardOutput();
 
     // 读取文件信息


### PR DESCRIPTION
减少bluetoothctl命令查询时间

Log: 优化启动时间
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi