### PR TITLE
fix: 设备管理器未正确获取处理器当前实时频率

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
@@ -68,9 +68,7 @@ void DeviceCpu::loadBaseDeviceInfo()
     addBaseDeviceInfo(tr("CPU ID"), m_PhysicalID);
     addBaseDeviceInfo(tr("Core ID"), m_CoreID);
     addBaseDeviceInfo(tr("Threads"), m_ThreadNum);
-    if (m_FrequencyIsCur)
-        addBaseDeviceInfo(tr("Current Speed"), m_CurFrequency);
-    else
+    if (!m_FrequencyIsCur)
         addBaseDeviceInfo(tr("Max Speed"), m_MaxFrequency);
     addBaseDeviceInfo(tr("BogoMIPS"), m_BogoMIPS);
     addBaseDeviceInfo(tr("Architecture"), m_Architecture);


### PR DESCRIPTION
去掉处理器当前实时频率显示

Log: 去掉处理器当前实时频率显示
Bug: https://pms.uniontech.com/bug-view-143719.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi