### PR TITLE
fix: 部分机型打开设备管理器窗口闪退不能正常打开

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
@@ -752,7 +752,12 @@ void DeviceBaseInfo::setHwinfoLshwKey(const QMap<QString, QString> &mapInfo)
 
     // 1-1.3
     // 1-3
-    QStringList nums = QStringList() << "0" << "1" << "2" << "3" << "4" << "5" << "6" << "7" << "8" << "9" << "a" << "b" << "c" << "d" << "e" << "f" << "g" << "h" << "i" << "j";
+    QStringList nums = QStringList() << "0" << "1" << "2" << "3" << "4" << "5"
+                       << "6" << "7" << "8" << "9" << "a" << "b"
+                       << "c" << "d" << "e" << "f" << "g" << "h"
+                       << "i" << "j" << "k" << "l" << "m" << "n"
+                       << "o" << "p" << "q" << "r" << "s" << "t"
+                       << "u" << "v" << "w" << "x" << "y" << "z";
     QRegExp reg("([0-9a-zA-Z]+)-([0-9a-zA-Z]+)\\.([0-9a-zA-Z]+)");
     if (reg.exactMatch(words[0])) {
         int first = reg.cap(1).toInt();


### PR DESCRIPTION
usb的key值转换失败

Log: 正确打开应用
Bug: https://pms.uniontech.com/bug-view-181737.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi