### PR TITLE
fix: 设备管理器中显示蓝牙不可用

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
@@ -286,6 +286,7 @@ void HWGenerator::getBluetoothInfoFromHciconfig()
         }
         DeviceBluetooth *device = new DeviceBluetooth();
         device->setCanEnale(false);
+        device->setForcedDisplay(true);
         device->setInfoFromHciconfig(*it);
         DeviceManager::instance()->addBluetoothDevice(device);
     }


### PR DESCRIPTION
部分机型显示蓝牙

Log: 显示蓝牙设备
Bug: https://pms.uniontech.com/bug-view-183587.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi