### PR TITLE
fix: 设备序列号乱码和设备管理器中显示蓝牙不可用 

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceBluetooth.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceBluetooth.cpp
@@ -63,8 +63,11 @@ bool DeviceBluetooth::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Speed", m_Speed);
     setAttribute(mapInfo, "SysFS ID", m_SysPath);
     setAttribute(mapInfo, "Device", m_Name);
-    setAttribute(mapInfo, "Unique ID", m_SerialID);
-    m_UniqueID = m_SerialID;
+    setAttribute(mapInfo, "Unique ID", m_UniqueID);
+    // 防止Serial ID为空
+    if (m_SerialID.isEmpty())
+        m_SerialID = m_UniqueID;
+
     m_HardwareClass = "bluetooth";
 
     setAttribute(mapInfo, "Module Alias", m_Modalias);

--- a/deepin-devicemanager/src/DeviceManager/DeviceImage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceImage.cpp
@@ -71,8 +71,10 @@ void DeviceImage::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
         m_Enable = false;
     }
     setAttribute(mapInfo, "Serial ID", m_SerialID);
-    setAttribute(mapInfo, "Unique ID", m_SerialID);
-    m_UniqueID = m_SerialID;
+    setAttribute(mapInfo, "Unique ID", m_UniqueID);
+    // 防止Serial ID为空
+    if (m_SerialID.isEmpty())
+        m_SerialID = m_UniqueID;
     setAttribute(mapInfo, "SysFS ID", m_SysPath);
     setAttribute(mapInfo, "Device", m_Name);
     setAttribute(mapInfo, "Vendor", m_Vendor);
@@ -170,7 +172,8 @@ void DeviceImage::loadOtherDeviceInfo()
     addOtherDeviceInfo(tr("Maximum Power"), m_MaximumPower);
     addOtherDeviceInfo(tr("Driver"), m_Driver);
     addOtherDeviceInfo(tr("Capabilities"), m_Capabilities);
-    addOtherDeviceInfo(tr("Serial Number"), m_SerialID);
+    if (m_SerialID != m_UniqueID)
+        addOtherDeviceInfo(tr("Serial Number"), m_SerialID);
 
     // 将QMap<QString, QString>内容转存为QList<QPair<QString, QString>>
     mapInfoToList();

--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -64,7 +64,7 @@ bool DeviceInput::setInfoFromlshw(const QMap<QString, QString> &mapInfo)
 TomlFixMethod DeviceInput::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
     TomlFixMethod ret = TOML_None;
-        // 添加基本信息
+    // 添加基本信息
     ret = setTomlAttribute(mapInfo, "Model", m_Model);
     ret = setTomlAttribute(mapInfo, "Interface", m_Interface);
     ret = setTomlAttribute(mapInfo, "Bus Info", m_BusInfo);
@@ -97,12 +97,13 @@ void DeviceInput::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Revision", m_Version);
     setAttribute(mapInfo, "SysFS ID", m_SysPath);
     setAttribute(mapInfo, "Unique ID", m_WakeupID);
-    setAttribute(mapInfo, "Unique ID", m_SerialID);
+    setAttribute(mapInfo, "Unique ID", m_UniqueID);
     setAttribute(mapInfo, "Module Alias", m_Modalias);
     setAttribute(mapInfo, "VID_PID", m_VID_PID);
     m_PhysID = m_VID_PID;
-
-    m_UniqueID = m_SerialID;
+    // 防止Serial ID为空
+    if (m_SerialID.isEmpty())
+        m_SerialID = m_UniqueID;
 
 
     // 获取键盘的接口类型

--- a/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
@@ -45,10 +45,10 @@ void DeviceOthers::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
 TomlFixMethod DeviceOthers::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
     TomlFixMethod ret = TOML_None;
-    // 添加基本信息      
-    ret = setTomlAttribute(mapInfo, "Model", m_Model);    
+    // 添加基本信息
+    ret = setTomlAttribute(mapInfo, "Model", m_Model);
     ret = setTomlAttribute(mapInfo, "Bus Info", m_BusInfo);
-    ret = setTomlAttribute(mapInfo, "Capabilities", m_Capabilities);    
+    ret = setTomlAttribute(mapInfo, "Capabilities", m_Capabilities);
     ret = setTomlAttribute(mapInfo, "Maximum Power", m_MaximumPower);
     ret = setTomlAttribute(mapInfo, "Speed", m_Speed);
 ////Others
@@ -68,11 +68,12 @@ void DeviceOthers::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Driver", m_Driver);
     setAttribute(mapInfo, "Speed", m_Speed);
     setAttribute(mapInfo, "Serial ID", m_SerialID);
-    setAttribute(mapInfo, "Serial ID", m_UniqueID);
     setAttribute(mapInfo, "SysFS ID", m_SysPath);
     /* 禁用时提示获取序列号失败*/
-    setAttribute(mapInfo, "Unique ID", m_SerialID);
-    m_UniqueID = m_SerialID;
+    setAttribute(mapInfo, "Unique ID", m_UniqueID);
+    // 防止Serial ID为空
+    if (m_SerialID.isEmpty())
+        m_SerialID = m_UniqueID;
 
     setAttribute(mapInfo, "Module Alias", m_Modalias);
     setAttribute(mapInfo, "VID_PID", m_VID_PID);
@@ -183,7 +184,8 @@ void DeviceOthers::loadBaseDeviceInfo()
 
 void DeviceOthers::loadOtherDeviceInfo()
 {
-    addOtherDeviceInfo(tr("Serial Number"), m_SerialID);
+    if (m_SerialID != m_UniqueID)
+        addOtherDeviceInfo(tr("Serial Number"), m_SerialID);
     mapInfoToList();
 }
 

--- a/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
@@ -286,6 +286,7 @@ void HWGenerator::getBluetoothInfoFromHciconfig()
         }
         DeviceBluetooth *device = new DeviceBluetooth();
         device->setCanEnale(false);
+        device->setForcedDisplay(true);
         device->setInfoFromHciconfig(*it);
         DeviceManager::instance()->addBluetoothDevice(device);
     }

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -73,13 +73,13 @@ QString Common::checkBoardVendorFlag()
     if (info.isEmpty()) {
         getDeviceInfo(info, "dmidecode_spn.txt");
     }
-    if (info.contains("KLVV")) {
+    if (info.contains("KLVV", Qt::CaseInsensitive) || info.contains("L540", Qt::CaseInsensitive)) {
         boardVendorKey = "KLVV";
-    } else if (info.contains("KLVU")) {
+    } else if (info.contains("KLVU", Qt::CaseInsensitive)) {
         boardVendorKey = "KLVU";
-    } else if (info.contains("PGUV")) {
+    } else if (info.contains("PGUV", Qt::CaseInsensitive)) {
         boardVendorKey = "PGUV";
-    } else if (info.contains("PGUW")) {
+    } else if (info.contains("PGUW", Qt::CaseInsensitive)) {
         boardVendorKey = "PGUW";
     }
     process.close();


### PR DESCRIPTION
隐藏无效设备序列号和部分机型显示蓝牙

Log: 隐藏无效设备序列号和显示蓝牙设备
Bug: https://pms.uniontech.com/bug-view-183587.html