### PR TITLE
fix: 显卡型号错误

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
@@ -72,6 +72,9 @@ void DeviceGpu::setLshwInfo(const QMap<QString, QString> &mapInfo)
         return;
 
     // 设置属性
+    if ((m_Name.isEmpty() || m_Name.startsWith("pci")) && mapInfo.contains("product") && !mapInfo["product"].startsWith("pci")) {
+        m_Model = mapInfo["product"];
+    }
     setAttribute(mapInfo, "product", m_Name, m_Name.isEmpty() || (m_Name.startsWith("pci") && mapInfo.contains("product") && !mapInfo["product"].startsWith("pci")));
     setAttribute(mapInfo, "vendor", m_Vendor);
     setAttribute(mapInfo, "version", m_Version);
@@ -132,6 +135,9 @@ bool DeviceGpu::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
         setAttribute(mapInfo, "SubDevice", m_Name, true);
     }
     setAttribute(mapInfo, "Model", m_Model);
+    if (!m_Name.isEmpty() && !m_Name.startsWith("pci")) {
+        m_Model = m_Name;
+    }
     setAttribute(mapInfo, "Revision", m_Version, false);
     setAttribute(mapInfo, "IRQ", m_IRQ, false);
     setAttribute(mapInfo, "Driver", m_Driver, false);


### PR DESCRIPTION
显卡型号统一为设备名称

Log: 显卡型号统一为设备名称
Bug: https://pms.uniontech.com/bug-view-173765.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi