### PR TITLE
fix: ps2的接口鼠标无法禁用

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -133,6 +133,9 @@ void DeviceInput::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     // ps2键盘的接口 将Device Files作为syspath解析
     if ("PS/2" == m_Interface) {
         getPS2Syspath(mapInfo["Device Files"]);
+        if(m_Model.contains("Mouse", Qt::CaseInsensitive)){
+            m_CanEnable = false;
+        }
     }
 
     // 获取映射到 lshw设备信息的 关键字


### PR DESCRIPTION
置灰ps2的接口鼠标的禁用按钮

Log: 置灰ps2的接口鼠标的禁用按钮
Bug: https://pms.uniontech.com/bug-view-181705.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @HeeMingYang @hundundadi