### PR TITLE
fix: 修改右键刷新界面coredump

### DIFF
--- a/deepin-devicemanager/src/Widget/DetailTreeView.cpp
+++ b/deepin-devicemanager/src/Widget/DetailTreeView.cpp
@@ -120,6 +120,8 @@ void DetailTreeView::setItem(int row, int column, QTableWidgetItem *item)
 
 void DetailTreeView::clear()
 {
+    mp_OldItem = nullptr;
+    mp_CurItem = nullptr;
     // 清空表格内容
     DTableWidget::clear();
 


### PR DESCRIPTION
DetailTreeView清空数据时未将当前用于显示tips的item置为空

Log: 正常刷新界面
Bug: https://pms.uniontech.com/bug-view-181085.html,https://pms.uniontech.com/bug-view-185727.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @hundundadi