### PR TITLE
fix: 右键菜单和tooltip内容同时展示

### DIFF
--- a/deepin-devicemanager/src/Widget/DetailTreeView.cpp
+++ b/deepin-devicemanager/src/Widget/DetailTreeView.cpp
@@ -525,6 +525,19 @@ void DetailTreeView::resizeEvent(QResizeEvent *event)
     mp_CurItem = itemAt(pt);
 }
 
+void DetailTreeView::mousePressEvent(QMouseEvent *event)
+{
+    // 鼠标右键事件
+    if (event->button() == Qt::RightButton) {
+        if (mp_ToolTips) {
+            // 隐藏toopTips
+            mp_CurItem = nullptr;
+            mp_ToolTips->hide();
+        }
+    }
+    DTableWidget::mouseMoveEvent(event);
+}
+
 void DetailTreeView::mouseMoveEvent(QMouseEvent *event)
 {
     // 鼠标移动获取位置

--- a/deepin-devicemanager/src/Widget/DetailTreeView.h
+++ b/deepin-devicemanager/src/Widget/DetailTreeView.h
@@ -162,6 +162,12 @@ protected:
     void resizeEvent(QResizeEvent *event) override;
 
     /**
+     * @brief mousePressEvent
+     * @param event
+     */
+    void mousePressEvent(QMouseEvent *event) override;
+
+    /**
      * @brief mouseMoveEvent
      * @param event
      */


### PR DESCRIPTION
鼠标右键点击时主动隐藏tooltip

Log: 正常显示右键菜单
Bug: https://pms.uniontech.com/bug-view-185777.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @hundundadi