### PR TITLE
fix: 在系统下设备管理器中网络适配器中未显示板载有线网卡信息

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
@@ -150,6 +150,7 @@ bool DeviceNetwork::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
         return true;
     }
 
+    setAttribute(mapInfo, "HW Address", m_MACAddress);
     setAttribute(mapInfo, "Permanent HW Address", m_UniqueID);
     setAttribute(mapInfo, "SysFS Device Link", m_SysPath);
     setAttribute(mapInfo, "Driver", m_Driver);
@@ -264,6 +265,11 @@ QString DeviceNetwork::logicalName()
 bool DeviceNetwork::isWireless()
 {
     return m_IsWireless;
+}
+
+QString DeviceNetwork::hwAddress()
+{
+    return m_MACAddress;
 }
 
 void DeviceNetwork::initFilterKey()

--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.h
@@ -25,13 +25,13 @@ public:
      */
     void setInfoFromLshw(const QMap<QString, QString> &mapInfo);
 
-  /**
-      * @brief setInfoFromTomlOneByOne:设置从toml里面获取的信息
-      * @param mapInfo:由toml获取的信息map
-      * @return枚举值
-      */
-   TomlFixMethod setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo);
-   
+    /**
+    * @brief setInfoFromTomlOneByOne:设置从toml里面获取的信息
+    * @param mapInfo:由toml获取的信息map
+    * @return枚举值
+    */
+    TomlFixMethod setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo);
+
     /**
      * @brief setInfoFromHwinfo:设置由hwinfo --network命令获取的设备信息
      * @param mapInfo:由hwinfo获取的信息map
@@ -112,6 +112,12 @@ public:
      * @return
      */
     bool isWireless();
+
+    /**
+     * @brief hwAddress: 获取HW地址
+     * @return HW地址
+     */
+    QString hwAddress();
 
 protected:
 

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -275,7 +275,7 @@ void DeviceGenerator::generatorNetworkDevice()
             continue;
         const QString &serialNumber = (*it)["serial"];
         for (QList<DeviceNetwork *>::iterator itDevice = lstDevice.begin(); itDevice != lstDevice.end(); ++itDevice) {
-            if (!serialNumber.isEmpty() && (*itDevice)->uniqueID() == serialNumber) {
+            if (!serialNumber.isEmpty() && ((*itDevice)->uniqueID() == serialNumber || (*itDevice)->hwAddress() == serialNumber)) {
                 (*itDevice)->setInfoFromLshw(*it);
                 break;
             }


### PR DESCRIPTION
HW Address和Permanent HW Address不一致导致lshw网卡匹配失败

Log: 正确显示网卡信息
Bug: https://pms.uniontech.com/bug-view-189671.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @hundundadi