### PR TITLE
fix: 只插入一个显示器的情况下设备管理器中显示2个显示设备

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -545,7 +545,8 @@ void CmdTool::loadHwinfoInfo(const QString &key, const QString &debugfile)
                 continue;
             QMap<QString, QString> mapInfo;
             getMapInfoFromHwinfo(item, mapInfo);
-            addMapInfo(key, mapInfo);
+            if ("monitor" == mapInfo["Hardware Class"])
+                addMapInfo(key, mapInfo);
         }
     } else { // 处理其它信息 mouse sound keyboard usb display cdrom disk
         getDeviceInfo(deviceInfo, debugfile);


### PR DESCRIPTION
去除多余的framebuffer

Log: 正确显示显示器设备
Bug: https://pms.uniontech.com/bug-view-193741.html
/review @lzwind @myk1343 @feeengli @jeffshuai @pengfeixx @hundundadi