### PR TITLE
fix: 设备管理器 概况-网络适配中klu缺少无线的展示 Hi110addKLVU

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
@@ -46,7 +46,7 @@ DeviceNetwork::DeviceNetwork()
 
 void DeviceNetwork::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
-    if (!matchToLshw(mapInfo) && Common::boardVendorType() != "KLVV") {
+    if (!matchToLshw(mapInfo) && Common::boardVendorType() != "KLVV" && Common::boardVendorType() != "KLVU") {
         return;
     }
     // 设置由lshw获取的信息

--- a/deepin-devicemanager/src/GenerateDevice/KLUGenerator.h
+++ b/deepin-devicemanager/src/GenerateDevice/KLUGenerator.h
@@ -17,15 +17,15 @@ class KLUGenerator : public HWGenerator
 public:
     KLUGenerator();
 
-    /**@brief:generator network info*/
-    virtual void generatorNetworkDevice() override;
-
 protected:
 
     /**
      * @brief getDiskInfoFromLshw:从lshw获取存储设备信息
      */
     virtual void getDiskInfoFromLshw() override;
+
+    /**@brief:generator network info*/
+    virtual void generatorNetworkDevice() override;
 
     /**@brief:generator network info*/
     virtual void getNetworkInfoFromCatWifiInfo();


### PR DESCRIPTION
设备管理器 概况-网络适配中klu缺少无线的展示 Hi1103-2addKLVU

Log: 设备管理器 概况-网络适配中klu缺少无线的展示 Hi1103addKLVU

Bug: https://pms.uniontech.com/bug-view-197543.html