### PR TITLE
fix: 设备管理器PGW未展示音频适配器相关信息

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
@@ -216,6 +216,10 @@ void HWGenerator::getAudioInfoFromCatAudio()
             tempMap["Model"] = "Hi6405";
         }
 
+        if (tempMap.contains("Vendor")) {
+            tempMap["Vendor"]= "HUAWEI";
+        }
+
         DeviceAudio *device = new DeviceAudio();
         device->setCanEnale(false);
         device->setCanUninstall(false);


### PR DESCRIPTION
设备管理器HW音频适配器相关信息定制为HUAWEI

Log: 设备管理器HW音频适配器相关信息定制为HUAWEI

Bug: https://pms.uniontech.com/bug-view-190965.html