### PR TITLE
fix: 正在查询信息时关闭窗口导致程序无法退出

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/LoadInfoThread.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/LoadInfoThread.cpp
@@ -12,7 +12,8 @@
 #include <QDateTime>
 #include <QTimer>
 
-#include<malloc.h>
+#include <malloc.h>
+#include <unistd.h>
 
 static bool firstLoadFlag = true;
 LoadInfoThread::LoadInfoThread()
@@ -31,8 +32,8 @@ LoadInfoThread::~LoadInfoThread()
     while (m_Running)
     {
         long long end = QDateTime::currentMSecsSinceEpoch();
-        if (end - begin > 100000)
-            exit();
+        if (end - begin > 1000)
+            _exit(0);
         usleep(100);
     }
     mp_ReadFilePool.deleteLater();


### PR DESCRIPTION
正在查询信息时关闭窗口导致程序无法退出

Log: 正在查询信息时关闭窗口导致程序无法退出
Bug: https://pms.uniontech.com/bug-view-200233.html