### PR TITLE
fix: 修复设备管理器在驱动管理的检测过程中立即断网，检测过程一直扫描状态

### DIFF
--- a/deepin-devicemanager/src/DriverControl/DriverScanner.cpp
+++ b/deepin-devicemanager/src/DriverControl/DriverScanner.cpp
@@ -39,6 +39,8 @@ void DriverScanner::run()
         // 扫描结束
         usleep(10000);
         emit scanFinished(SR_SUCESS);
+    } else {
+        emit scanFinished(SR_NETWORD_ERR);
     }
 
 // 测试代码


### PR DESCRIPTION
设备管理器在驱动管理的检测过程中进入待机状态，会立即断网

Log: 修复设备管理器在驱动管理的检测过程中立即断网，检测过程一直扫描状态

Bug: https://pms.uniontech.com/bug-view-202141.html