### PR TITLE
fix: 修复panguv显示设备中当前分辨率信息与实际设置的不符

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -878,6 +878,20 @@ void DeviceManager::setMonitorInfoFromXrandr(const QString &main, const QString 
     }
 }
 
+void DeviceManager::setMonitorInfoFromDbus(const QMap<QString, QString> &mapInfo)
+{
+    // 从 dbus 中添加显示设备信息
+    QList<DeviceBaseInfo *>::iterator it = m_ListDeviceMonitor.begin();
+    for (; it != m_ListDeviceMonitor.end(); ++it) {
+        DeviceMonitor *device = dynamic_cast<DeviceMonitor *>(*it);
+        if (!device)
+            continue;
+
+        device->setInfoFromDbus(mapInfo);
+
+    }
+}
+
 void DeviceManager::addBiosDevice(DeviceBios *const device)
 {
     // 添加主板信息

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.h
@@ -273,6 +273,12 @@ public:
      */
     void setMonitorInfoFromXrandr(const QString &main, const QString &edid, const QString &rate = "");
 
+    /**
+     * @brief setMonitorInfoFromDbus:设置由 dbus 获取的显示设备信息
+     * @param mapInfo:被添加的信息map
+     */
+    void setMonitorInfoFromDbus(const QMap<QString, QString> &mapInfo);
+
     // Bios设备相关 ************************************************************************************
     /**
      * @brief addBiosDevice:添加BIOS设备

--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -160,7 +160,16 @@ void DeviceMonitor::setInfoFromEdid(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Size", m_ScreenSize);
     setAttribute(mapInfo, "Vendor", m_Vendor);
     setAttribute(mapInfo, "Date", m_ProductionWeek);
+    setAttribute(mapInfo, "Display Input", m_DisplayInput);
     getOtherMapInfo(mapInfo);
+}
+
+void DeviceMonitor::setInfoFromDbus(const QMap<QString, QString> &mapInfo)
+{
+    if(mapInfo["Name"].toLower().contains(m_DisplayInput.toLower(),Qt::CaseInsensitive))
+    {
+        setAttribute(mapInfo, "CurResolution", m_CurrentResolution);
+    }
 }
 
 QString DeviceMonitor::transWeekToDate(const QString &year, const QString &week)

--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.h
@@ -73,6 +73,13 @@ public:
      */
     void setInfoFromEdid(const QMap<QString, QString> &mapInfo);
 
+    /**@brief:华为PanGuV项目里面的显示屏信息是从dbus里面获取的*/
+    /**
+     * @brief setInfoFromDbus:设置华为PanGuV项目里面的显示屏信息
+     * @param mapInfo:获取的信息map
+     */
+    void setInfoFromDbus(const QMap<QString, QString> &mapInfo);
+
     /**
      * @brief name:获取名称属性值
      * @return QString 名称属性值

--- a/deepin-devicemanager/src/GenerateDevice/PanguVGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/PanguVGenerator.cpp
@@ -17,38 +17,8 @@ PanguVGenerator::PanguVGenerator()
 
 }
 
-void PanguVGenerator::generatorMonitorDevice()
+void parseEDID(QStringList allEDIDS,QString input)
 {
-    // 生成显示设备信息
-//    const QList<QMap<QString, QString>> lstMapHDMI = DeviceManager::instance()->cmdInfo("EDID_HDMI");
-//    QList<QMap<QString, QString> >::const_iterator itHDMI = lstMapHDMI.begin();
-//    for (; itHDMI != lstMapHDMI.end(); ++itHDMI) {
-//        if ((*itHDMI).size() < 1)
-//            continue;
-
-//        //HDMI interface EDID information
-//        DeviceMonitor *device = new  DeviceMonitor();
-//        device->setInfoFromEdid(*itHDMI);
-//        DeviceManager::instance()->addMonitor(device);
-//    }
-
-//    const QList<QMap<QString, QString>> lstMapVGA = DeviceManager::instance()->cmdInfo("EDID_VGA");
-//    QList<QMap<QString, QString> >::const_iterator it = lstMapVGA.begin();
-//    for (; it != lstMapVGA.end(); ++it) {
-//        if ((*it).size() < 1)
-//            continue;
-
-//        //VGA interface EDID information
-//        DeviceMonitor *device = new DeviceMonitor();
-//        device->setInfoFromEdid(*it);
-//        DeviceManager::instance()->addMonitor(device);
-//    }
-
-    QStringList allEDIDS;
-    allEDIDS.append("/sys/devices/platform/hisi-drm/drm/card0/card0-HDMI-A-1/edid");
-    allEDIDS.append("/sys/devices/platform/hisi-drm/drm/card0/card0-VGA-1/edid");
-    allEDIDS.append("/sys/devices/platform/hldrm/drm/card0/card0-HDMI-A-1/edid");
-    allEDIDS.append("/sys/devices/platform/hldrm/drm/card0/card0-VGA-1/edid");
     for (auto edid:allEDIDS) {
         QProcess process;
         process.start(QString("hexdump %1").arg(edid));
@@ -81,13 +51,26 @@ void PanguVGenerator::generatorMonitorDevice()
             mapInfo.insert("Vendor",edidParser.vendor());
             mapInfo.insert("Date",edidParser.releaseDate());
             mapInfo.insert("Size",edidParser.screenSize());
+            mapInfo.insert("Display Input",input);
 
             DeviceMonitor *device = new DeviceMonitor();
             device->setInfoFromEdid(mapInfo);
             DeviceManager::instance()->addMonitor(device);
         }
     }
+}
 
+void PanguVGenerator::generatorMonitorDevice()
+{
+    QStringList allEDIDS1;
+    allEDIDS1.append("/sys/devices/platform/hisi-drm/drm/card0/card0-HDMI-A-1/edid");
+    allEDIDS1.append("/sys/devices/platform/hldrm/drm/card0/card0-HDMI-A-1/edid");
+    parseEDID(allEDIDS1,"HDMI-A-1");
+
+    QStringList allEDIDS2;
+    allEDIDS2.append("/sys/devices/platform/hisi-drm/drm/card0/card0-VGA-1/edid");
+    allEDIDS2.append("/sys/devices/platform/hldrm/drm/card0/card0-VGA-1/edid");
+    parseEDID(allEDIDS2,"VGA-1");
 }
 
 void PanguVGenerator::generatorNetworkDevice()

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "ThreadExecXrandr.h"
+#include "commonfunction.h"
 
 #include <QProcess>
 #include <QDebug>
@@ -49,7 +50,19 @@ void ThreadExecXrandr::run()
     if (m_Gpu) {
         getGpuInfoFromXrandr();
     } else {
-        getMonitorInfoFromXrandrVerbose();
+        if(m_isDXcbPlatform)
+            getMonitorInfoFromXrandrVerbose();
+       else if(Common::boardVendorType() == "PGUV") {
+           QList<QMap<QString, QString>> lstMap;
+           getResolutionRateFromDBus(lstMap);
+           QList<QMap<QString, QString> >::const_iterator it = lstMap.begin();
+           for (; it != lstMap.end(); ++it) {
+               if ((*it).size() < 1)
+                   continue;
+
+               DeviceManager::instance()->setMonitorInfoFromDbus(*it);
+           }
+       }
     }
 }
 
@@ -350,4 +363,62 @@ void ThreadExecXrandr::getGpuInfoFromXrandr()
 
         DeviceManager::instance()->setGpuInfoFromXrandr(*it);
     }
+}
+
+void ThreadExecXrandr::getResolutionRateFromDBus(QList<QMap<QString, QString> > &lstMap)
+{
+    QDBusInterface displayInterface(DISPLAY_DAEMON_SERVICE_NAME, DISPLAY_DAEMON_SERVICE_PATH, DISPLAY_DAEMON_INTERFACE, QDBusConnection::sessionBus());
+    if (!displayInterface.isValid())
+        return;
+
+    QVariant monitors = displayInterface.property("Monitors");
+
+    if (!monitors.isValid())
+        return;
+
+    QList<QDBusObjectPath> monitorList = monitors.value<QList<QDBusObjectPath> >();
+    for (auto monitor : monitorList) {
+        if (monitor.path().isEmpty())
+            continue;
+
+        QDBusInterface monitorEnabledInterface(DISPLAY_DAEMON_SERVICE_NAME, monitor.path(), DISPLAY_MONITOR_INTERFACE, QDBusConnection::sessionBus());
+        if (!monitorEnabledInterface.isValid())
+            continue;
+
+        QVariant enbaled = monitorEnabledInterface.property("Enabled");
+        if (!enbaled.isValid() || !enbaled.toBool())
+            continue;
+        QVariant tconnected = monitorEnabledInterface.property("Connected");
+        QVariant tmanufacture = monitorEnabledInterface.property("Manufacturer");
+        QVariant tname = monitorEnabledInterface.property("Name");
+
+        // QVariant rep_currentRes = monitorEnabledInterface.property("CurrentMode");
+
+        QDBusInterface monitorInterface(DISPLAY_DAEMON_SERVICE_NAME, monitor.path(), DISPLAY_PROPERTIES_INTERFACE, QDBusConnection::sessionBus());
+        if (!monitorInterface.isValid())
+            continue;
+
+        QDBusMessage replay = monitorInterface.call("Get", DISPLAY_MONITOR_INTERFACE, "CurrentMode");   // "com.deepin.daemon.Display.Monitor","CurrentMode"
+       QVariant v =  replay.arguments().first();
+        qDebug() << v.value<QDBusVariant>().variant();
+        QDBusArgument arg = v.value<QDBusVariant>().variant().value<QDBusArgument>();
+
+        int curResolutionWidth = -1, curResolutionHeight = -1;
+        double resRate = 0;
+        {
+           MonitorResolution resolution;
+           arg >> resolution;
+
+            curResolutionWidth = resolution.width;
+            curResolutionHeight = resolution.height;
+            resRate = resolution.refreshRate;
+            QMap<QString,QString>infoMap;
+
+            infoMap.insert("CurResolution", QString("%1 x %2 @ %3").arg(curResolutionWidth).arg(curResolutionHeight).arg(resRate));
+            infoMap.insert("Name", tname.toString());
+            infoMap.insert("Display Input", tname.toString());
+            infoMap.insert("Manufacture", tmanufacture.toString());
+            lstMap.append(infoMap);
+        }  //end of while
+    }  //end of for
 }

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.h
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.h
@@ -53,6 +53,12 @@ private:
     void getResolutionFromDBus(QMap<QString, QString> &lstMap);
 
     /**
+     * @brief getResolutionRateFromDBus:通过dbus获取分辨率和刷新率
+     * @param lstMap
+     */
+    void getResolutionRateFromDBus(QList<QMap<QString, QString> > &lstMap);
+
+    /**
      * @brief getMonitorInfoFromXrandrVerbose:从xrandr --verbose获取显示设备信息
      */
     void getMonitorInfoFromXrandrVerbose();


### PR DESCRIPTION
修复panguv显示设备中当前分辨率信息与实际设置的不符

Log: 修复panguv显示设备中当前分辨率信息与实际设置的不符

Bug: https://pms.uniontech.com/bug-view-204349.html