### PR TITLE
feat: hw机型判断适配dconfig

### DIFF
--- a/deepin-devicemanager/assets/org.deepin.devicemanager.json
+++ b/deepin-devicemanager/assets/org.deepin.devicemanager.json
@@ -3,7 +3,7 @@
     "version": "1.0",
     "contents": {
 	"specialComType": {
-            "value": 0,
+            "value": -1,
             "serial": 0,
             "flags": ["global"],
             "name": "Special Computer Type",

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -97,6 +97,9 @@ QString Common::checkBoardVendorFlag()
 {
     if(specialComType != -1){
         switch (specialComType) {
+        case NormalCom:
+            boardVendorKey = "";
+            break;
         case PGUW:
             boardVendorKey = "PGUW";
             break;


### PR DESCRIPTION
Description: 修改默认配置值为-1,存在dconfig接口但是底层未修改配置文件时，将采用以前判断hw的方式

Log: hw机型判断适配dconfig

Task: https://pms.uniontech.com/task-view-276433.html