### PR TITLE
fix: 适配当两个序列号一致的U盘

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -322,6 +322,9 @@ void DeviceStorage::setDiskSerialID(const QString &deviceFiles)
 
 QString DeviceStorage::getDiskSerialID()
 {
+    if (m_Interface.contains("USB", Qt::CaseInsensitive)) {
+        return m_SerialNumber + m_KeyToLshw;
+    }
     return m_SerialNumber;
 }
 


### PR DESCRIPTION
修复当两个U盘序列号一致时不正常情况下 被误合并为一个

Log: 适配当两个序列号一致的U盘