### PR TITLE
fix: 适配当两个序列号一致的U盘

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-devicemanager (6.0.11) unstable; urgency=medium
+
+  * new version 6.0.11
+
+ -- shuaijie <shuaijie@uniontech.com>  Wed, 16 Aug 2023 15:44:01 +0800
+
 deepin-devicemanager (6.0.10) unstable; urgency=medium
 
   * new version 6.0.10

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -322,6 +322,9 @@ void DeviceStorage::setDiskSerialID(const QString &deviceFiles)
 
 QString DeviceStorage::getDiskSerialID()
 {
+    if (m_Interface.contains("USB", Qt::CaseInsensitive)) {
+        return m_SerialNumber + m_KeyToLshw;
+    }
     return m_SerialNumber;
 }
 


### PR DESCRIPTION
修复当两个U盘序列号一致时不正常情况下 被误合并为一个

Log: 适配当两个序列号一致的U盘