### PR TITLE
fix: 显示设备-大小和hwinfo命令获取内容不一致

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -387,7 +387,7 @@ void DeviceMonitor::caculateScreenSize()
         m_Height = re.cap(2).toInt();
 
         double inch = std::sqrt((m_Width / 2.54) * (m_Width / 2.54) + (m_Height / 2.54) * (m_Height / 2.54)) / 10.0;
-        m_ScreenSize = QString("%1 %2(%3mm X %4mm)").arg(QString::number(inch, 'f', 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
+        m_ScreenSize = QString("%1 %2(%3mm X %4mm)").arg(QString::number(inch, '0', 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
     }
 }
 
@@ -416,7 +416,7 @@ bool DeviceMonitor::caculateScreenSize(const QString &edid)
     if (fabs(width * 10 - m_Width) < 10 && fabs(height * 10 - m_Height) < 10)
         return true;
 
-    double inch = std::sqrt(height * height + width * width) / 2.54;
-    m_ScreenSize = QString("%1 %2(%3cm X %4cm)").arg(QString::number(inch, '0', 1)).arg(QObject::tr("inch")).arg(width).arg(height);
+    double inch = std::sqrt(height * height + width * width) / 2.54 / 10;
+    m_ScreenSize = QString("%1 %2(%3mm X %4mm)").arg(QString::number(inch, '0', 1)).arg(QObject::tr("inch")).arg(width).arg(height);
     return true;
 }

--- a/deepin-devicemanager/src/Tool/EDIDParser.cpp
+++ b/deepin-devicemanager/src/Tool/EDIDParser.cpp
@@ -164,10 +164,19 @@ void EDIDParser::parseReleaseDate()
 void EDIDParser::parseScreenSize()
 {
     // edid中的  15H和16H就是屏幕大小
-    m_Width = hexToDec(getBytes(1, m_LittleEndianMode ? 5 : 4)).toInt();
-    m_Height = hexToDec(getBytes(1, m_LittleEndianMode ? 6 : 7)).toInt();
-    double inch = sqrt((m_Width / 2.54) * (m_Width / 2.54) + (m_Height / 2.54) * (m_Height / 2.54));
-    m_ScreenSize = QString("%1 %2(%3cm X %4cm)").arg(QString::number(inch, 'f', 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
+    if(m_LittleEndianMode){
+        QString tmpw = getBytes(4,2);
+        QString tmph = getBytes(4,3);
+        QString tmpshl = getBytes(4,4);
+        m_Width = hexToDec(tmpshl.mid(0,1) + tmpw).toInt();
+        m_Height = hexToDec(tmpshl.mid(1,1) + tmph).toInt();
+    }else {
+        m_Width = hexToDec(getBytes(1, m_LittleEndianMode ? 5 : 4)).toInt()*10;
+        m_Height = hexToDec(getBytes(1, m_LittleEndianMode ? 6 : 7)).toInt()*10;
+    }
+
+    double inch = sqrt((m_Width / 2.54) * (m_Width / 2.54) + (m_Height / 2.54) * (m_Height / 2.54))/10;
+    m_ScreenSize = QString("%1 %2(%3mm X %4mm)").arg(QString::number(inch, '0', 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
 }
 
 QString EDIDParser::binToDec(QString strBin)   //二进制转十进制


### PR DESCRIPTION
修复显示设备-大小和hwinfo命令获取内容不一致

Log: 显示设备-大小和hwinfo命令获取内容不一致

Bug: https://pms.uniontech.com/bug-view-216003.html