### PR TITLE
fix: 修复“其它设备”驱动为空时显示不可用

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
@@ -24,7 +24,7 @@ void DeviceOthers::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
     if (!matchToLshw(mapInfo))
         return;
-
+    QString            tmp_Name = m_Name;
     setAttribute(mapInfo, "product", m_Name, false);
     setAttribute(mapInfo, "vendor", m_Vendor, false);
     setAttribute(mapInfo, "product", m_Model, false);
@@ -35,6 +35,13 @@ void DeviceOthers::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "maxpower", m_MaximumPower);
     setAttribute(mapInfo, "speed", m_Speed);
     setAttribute(mapInfo, "logical name", m_LogicalName);
+
+    if(m_Driver.isEmpty() && !m_Avail.compare("yes", Qt::CaseInsensitive)){
+        setForcedDisplay(true);
+        setCanEnale(false);
+        if(!(tmp_Name.contains("fingerprint", Qt::CaseInsensitive) || tmp_Name. contains("MOH", Qt::CaseInsensitive)))
+            setCanUninstall(false);
+    }
 
     // 核内驱动不显示卸载菜单
     if (driverIsKernelIn(m_Driver)) {
@@ -87,6 +94,7 @@ void DeviceOthers::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
         m_CanEnable = false;
         m_CanUninstall = false;
     }
+    setAttribute(mapInfo, "cfg_avail", m_Avail);
 
     getOtherMapInfo(mapInfo);
     // 核内驱动不显示卸载菜单

--- a/deepin-devicemanager/src/DeviceManager/DeviceOthers.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceOthers.h
@@ -118,6 +118,7 @@ private:
     QString             m_Speed;                        //<! 【速度】
     QString             m_BusID;                        //<! 【总线ID】
     QString             m_LogicalName;
+    QString             m_Avail;                        //<! 【Config Status:avail=yes】
 };
 
 #endif // DEVICEOTHERS_H

--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -1210,6 +1210,11 @@ void CmdTool::getMapInfoFromHwinfo(const QString &info, QMap<QString, QString> &
                     mapInfo[words[0].trimmed()] = words[1].trimmed();
             }
         }
+        if ((*it).contains("Config Status")) {
+            //qInfo() << "  Config Status"<< words[0]<<words[1];
+            if(words[1].contains("avail=yes"))
+                mapInfo["cfg_avail"] = "yes";
+        }
     }
 
     if (mapInfo.contains("VID_PID") && !mapInfo["VID_PID"].isEmpty() && (mapInfo.contains("SysFS ID") || mapInfo.contains("SysFS Device Link"))) {

--- a/deepin-devicemanager/src/GenerateDevice/LoadInfoThread.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/LoadInfoThread.cpp
@@ -13,6 +13,7 @@
 #include <QTimer>
 
 #include<malloc.h>
+#include <unistd.h>
 
 static bool firstLoadFlag = true;
 LoadInfoThread::LoadInfoThread()
@@ -27,6 +28,14 @@ LoadInfoThread::LoadInfoThread()
 
 LoadInfoThread::~LoadInfoThread()
 {
+    long long begin = QDateTime::currentMSecsSinceEpoch();
+    while (m_Running)
+    {
+        long long end = QDateTime::currentMSecsSinceEpoch();
+        if (end - begin > 1000)
+            _exit(0);
+        usleep(100);
+    }
     mp_ReadFilePool.deleteLater();
     mp_GenerateDevicePool.deleteLater();
 }


### PR DESCRIPTION
修复“其它设备”驱动为空时显示不可用
修复正在查询信息时关闭窗口导致程序无法退出Commit_id e5e465c5

Log: 修复“其它设备”驱动为空时显示不可用

Bug: https://pms.uniontech.com/bug-view-203907.html (cherry picked from commit 5769d210c534db2ce8c6a9e751685676710054bc)