### PR TITLE
fix: 备份还原bug修复

### DIFF
--- a/deepin-devicemanager/src/Page/PageDriverBackupInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverBackupInfo.cpp
@@ -104,17 +104,11 @@ void PageDriverBackupInfo::initTable()
 void PageDriverBackupInfo::addDriverInfoToTableView(DriverInfo *info, int index)
 {
     PageDriverTableView *view = nullptr;
-    if (info->debBackupVersion().isEmpty()) {
+    if (info->debBackupVersion() != info->debVersion()) {
         view = mp_ViewBackable;
         view->appendRowItems(6);
-    }  else {
-        view = mp_ViewBackedUp;
-        view->appendRowItems(2);
-    }
 
-    int row = view->model()->rowCount() - 1;
-
-    if (view != mp_ViewBackedUp) {
+        int row = view->model()->rowCount() - 1;
 
         // 设置CheckBtn
         DriverCheckItem *cbItem = new DriverCheckItem(this);
@@ -146,7 +140,14 @@ void PageDriverBackupInfo::addDriverInfoToTableView(DriverInfo *info, int index)
         // 添加操作按钮
         DriverOperationItem *operateItem = new DriverOperationItem(this,  DriverOperationItem::BACKUP);
         view->setWidget(row, 5, operateItem);
-    } else {
+    }
+
+    if (!info->debBackupVersion().isEmpty()) {
+        view = mp_ViewBackedUp;
+        view->appendRowItems(2);
+
+        int row = view->model()->rowCount() - 1;
+
         // 设置设备信息
         DriverNameItem *nameItem = new DriverNameItem(this, info->type());
         nameItem->setName(info->name());
@@ -195,6 +196,8 @@ void PageDriverBackupInfo::clearAllData()
 void PageDriverBackupInfo::updateItemStatus(int index, Status status)
 {
     mp_ViewBackable->setItemStatus(index, status);
+    if (status == ST_DRIVER_BACKUP_FAILED)
+        mp_ViewBackable->setErrorMsg(index, QString("Backup Failed"));
 }
 
 void PageDriverBackupInfo::setCheckedCBDisnable()

--- a/deepin-devicemanager/src/Page/PageDriverInstallInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverInstallInfo.cpp
@@ -187,7 +187,7 @@ void PageDriverInstallInfo::addDriverInfoToTableView(DriverInfo *info, int index
         view->setWidget(row, 0, nameItem);
 
         // 设置版本
-        DriverLabelItem *versionItem = new DriverLabelItem(this, info->debVersion());
+        DriverLabelItem *versionItem = new DriverLabelItem(this, info->version());
         view->setWidget(row, 1, versionItem);
     }
 }

--- a/deepin-devicemanager/src/Page/PageDriverManager.h
+++ b/deepin-devicemanager/src/Page/PageDriverManager.h
@@ -298,6 +298,10 @@ private:
 
     QList<int>            m_ListBackableIndex;    // 可备份列表
     QList<int>            m_ListBackedupeIndex;   // 已备份列表
+    QList<int>            m_ListRestorableIndex;  // 可还原列表
+
+    int                   m_backupSuccessNum = 0;
+    int                   m_backupFailedNum = 0;
 
     DDialog               *mp_FailedDialog;     //还原失败弹窗
 

--- a/deepin-devicemanager/src/Page/PageDriverRestoreInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverRestoreInfo.cpp
@@ -185,6 +185,12 @@ void PageDriverRestoreInfo::setItemOperationEnable(int index, bool enable)
     mp_ViewBackable->setItemOperationEnable(index, enable);
 }
 
+void PageDriverRestoreInfo::setReDetectEnable(bool enable)
+{
+    if (mp_ReDetectedSgButton)
+        mp_ReDetectedSgButton->setEnabled(enable);
+}
+
 void PageDriverRestoreInfo::slotOperatorClicked(int index, int itemIndex, DriverOperationItem::Mode mode)
 {
     PageDriverTableView *view = mp_ViewBackable;

--- a/deepin-devicemanager/src/Page/PageDriverRestoreInfo.h
+++ b/deepin-devicemanager/src/Page/PageDriverRestoreInfo.h
@@ -46,6 +46,7 @@ public:
      * @brief setItemOperationEnable
      */
     void setItemOperationEnable(int index, bool enable);
+    void setReDetectEnable(bool enable);
 
 private slots:
     /**

--- a/deepin-devicemanager/src/Widget/BtnLabel.cpp
+++ b/deepin-devicemanager/src/Widget/BtnLabel.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "BtnLabel.h"
+#include "commontools.h"
+
+#include <QBoxLayout>
 
 #include <DDialog>
 #include <DFontSizeManager>
@@ -18,11 +21,39 @@ BtnLabel::BtnLabel(DWidget *parent)
     connect(this, &QLabel::linkActivated, this, [this]() {
         if (m_Desc.isEmpty())
             return;
-        DDialog dialog;
-        dialog.setIcon(style()->standardIcon(QStyle::SP_MessageBoxWarning));
-        dialog.setTitle(m_Desc);
-        dialog.addButton(tr("OK", "button"));
-        dialog.exec();
+
+        if (m_Desc == QString("Backup Failed")) {
+            DDialog dialog;
+
+            DWidget *contentFrame = new DWidget(this);
+
+            DLabel *retryLabel = new DLabel(this);
+            QVBoxLayout *vLayout = new QVBoxLayout(this);
+            retryLabel->setElideMode(Qt::ElideMiddle);
+            retryLabel->setText(QObject::tr("Please try again or give us feedback"));
+            vLayout->addWidget(retryLabel, 0, Qt::AlignHCenter);
+
+            contentFrame->setLayout(vLayout);
+
+            dialog.setIcon(QIcon::fromTheme("cautious"));
+            dialog.setTitle(QObject::tr("Driver backup failed!"));
+            dialog.addContent(contentFrame);
+            dialog.addButton(tr("OK"), false, DDialog::ButtonNormal);
+            dialog.addButton(tr("Feedback"), false, DDialog::ButtonNormal);
+
+            int clickedButtonIndex = dialog.exec();
+            if (1 == clickedButtonIndex) {
+                //反馈
+                qDebug() << __func__ << "fedback....";
+                CommonTools::feedback();
+            }
+        } else {
+            DDialog dialog;
+            dialog.setIcon(style()->standardIcon(QStyle::SP_MessageBoxWarning));
+            dialog.setTitle(m_Desc);
+            dialog.addButton(tr("OK", "button"));
+            dialog.exec();
+        }
     });
 }
 

--- a/deepin-devicemanager/src/Widget/DetectedStatusWidget.cpp
+++ b/deepin-devicemanager/src/Widget/DetectedStatusWidget.cpp
@@ -488,16 +488,24 @@ void DetectedStatusWidget::setBackableDriverUI(int backableSize, int backedupSiz
     mp_PicLabel->setPixmap(pic);
 
     int total = backableSize + backedupSize;
-    mp_UpdateLabel->setText(QObject::tr("You have %1 drivers that can be backed up").arg(backableSize));
-    mp_ModelLabel->setText(QObject::tr("A total of %1 drivers, of which %2 have been backed up").arg(total).arg(backedupSize));
+    if (backedupSize <= 0) {
+        mp_UpdateLabel->setText(QObject::tr("You have %1 drivers that can be backed up, it is recommended to do so immediately").arg(backableSize));
+        mp_ModelLabel->setText("");
+    } else {
+        mp_UpdateLabel->setText(QObject::tr("You have %1 drivers that can be backed up").arg(backableSize));
+        mp_ModelLabel->setText(QObject::tr("A total of %1 drivers, of which %2 have been backed up").arg(total).arg(backedupSize));
+    }
+
     mp_HLayoutTotal->addWidget(mp_PicLabel);
     mp_HLayoutTotal->addSpacing(SPACE_15);
     mp_VLayoutLabel->addStretch();
     mp_VLayoutLabel->addWidget(mp_UpdateLabel);
     mp_VLayoutLabel->addSpacing(SPACE_5);
     mp_HLayoutLabel->addWidget(mp_ModelLabel);
-    mp_HLayoutLabel->addSpacing(SPACE_5);
-    mp_HLayoutLabel->addWidget(mp_BackupPathLabel);
+    if (backedupSize > 0) {
+        mp_HLayoutLabel->addSpacing(SPACE_5);
+        mp_HLayoutLabel->addWidget(mp_BackupPathLabel);
+    }
     mp_VLayoutLabel->addLayout(mp_HLayoutLabel);
     mp_VLayoutLabel->addStretch();
     mp_HLayoutTotal->addLayout(mp_VLayoutLabel);
@@ -515,7 +523,9 @@ void DetectedStatusWidget::setBackableDriverUI(int backableSize, int backedupSiz
     mp_ModelLabel->show();
     mp_ReDetectedIconButton->show();
     mp_BackupSgButton->show();
-    mp_BackupPathLabel->show();
+    if (backedupSize > 0) {
+        mp_BackupPathLabel->show();
+    }
     this->setLayout(mp_HLayoutTotal);
 }
 
@@ -667,6 +677,14 @@ void DetectedStatusWidget::setRestoringUI(int progressValue, QString driverDescr
     this->setLayout(mp_HLayoutTotal);
 }
 
+void DetectedStatusWidget::setReDetectEnable(bool enable)
+{
+    if (mp_ReDetectedSgButton)
+        mp_ReDetectedSgButton->setEnabled(enable);
+    if (mp_ReDetectedIconButton)
+        mp_ReDetectedIconButton->setEnabled(enable);
+}
+
 void DetectedStatusWidget::slotReboot()
 {
     // 调用DBus接口重启
@@ -676,7 +694,6 @@ void DetectedStatusWidget::slotReboot()
                 "/teval `dbus-launch --auto-syntax`/n");
     }
 
-    //
     QDBusInterface *iface = new QDBusInterface(SERVICE_NAME, DEVICE_SERVICE_PATH, DEVICE_SERVICE_INTERFACE, QDBusConnection::sessionBus());
     iface->call("Restart");
 }
@@ -767,6 +784,7 @@ void DetectedStatusWidget::initUI()
     QFont font = mp_UpdateLabel->font();
     font.setWeight(FONT_WEIGHT);
     mp_UpdateLabel->setFont(font);
+    mp_UpdateLabel->setWordWrap(true);
     DFontSizeManager::instance()->bind(mp_UpdateLabel, DFontSizeManager::T5);
 
     // 检测时间

--- a/deepin-devicemanager/src/Widget/DetectedStatusWidget.h
+++ b/deepin-devicemanager/src/Widget/DetectedStatusWidget.h
@@ -112,6 +112,7 @@ public:
     void setBackupSuccessUI(const QString &success, const QString &failed);
     void setRestoreDriverUI(int restorableSize);
     void setRestoringUI(int progressValue = 0, QString driverDescription = "");
+    void setReDetectEnable(bool enable);
 
 signals:
     void redetected();

--- a/deepin-devicemanager/src/Widget/driveritem.cpp
+++ b/deepin-devicemanager/src/Widget/driveritem.cpp
@@ -174,7 +174,7 @@ void DriverStatusItem::setStatus(Status st)
     // bug132075 安装成功状态此button无法点击
     QString ts = DApplication::translate("QObject", CommonTools::getStausType(st).toStdString().data());
 
-    if (ST_FAILED == st) {
+    if (ST_FAILED == st || ST_DRIVER_BACKUP_FAILED == st) {
         QString statusStr = QString("<a style=\"text-decoration:none\" href=\"failed\">") + ts + "</a>";
         mp_Status->setText(statusStr);
     } else {

--- a/deepin-devicemanager/src/Widget/drivertableview.cpp
+++ b/deepin-devicemanager/src/Widget/drivertableview.cpp
@@ -532,12 +532,12 @@ void DriverTableView::setItemStatus(int index, Status s)
             if (ST_SUCESS == s || ST_FAILED == s || ST_DRIVER_BACKUP_FAILED == s || ST_DRIVER_BACKUP_SUCCESS == s) {
                 DriverCheckItem *cb = dynamic_cast<DriverCheckItem *>(indexWidget(mp_Model->index(i, 0)));
                 if (cb) {
-                    cb->setCbEnable(ST_FAILED == s ? true : false);
+                    cb->setCbEnable(ST_FAILED == s || ST_DRIVER_BACKUP_FAILED == s ? true : false);
                     cb->setChecked(false);
                 }
                 DriverOperationItem *opera = dynamic_cast<DriverOperationItem *>(indexWidget(mp_Model->index(i, 5)));
                 if (opera) {
-                    opera->setBtnEnable(ST_FAILED == s ? true : false);
+                    opera->setBtnEnable(ST_FAILED == s || ST_DRIVER_BACKUP_FAILED == s ? true : false);
                 }
             }
             break;

--- a/deepin-devicemanager/translations/deepin-devicemanager.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Device Info</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Device Manager</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Display Adapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Network Adapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Battery</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Action</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Hardware Class</translation>
@@ -3117,17 +3127,23 @@
         <translation>No disk found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>No monitor found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>No network adapter found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>No audio device found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Search for drivers in this path</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 driver updates available</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Time checked: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Downloading drivers for %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Download speed: %1 Downloaded %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Installing drivers for %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 drivers installed, %2 drivers failed</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 drivers installed</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Failed to install drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Network error. Reconnecting...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Download speed: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Your drivers are up to date</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>reboot</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Please %1 for the installed drivers to take effect</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>submit feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Please try again or %1 to us</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Install All</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Scan Again</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Please scan again or %1 to us</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>You are installing a driver, which will be interrupted if you exit.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Are you sure you want to exit?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Exit</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_az.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_az.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OLDU</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Kanal haqqında məlumatlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>İmkanlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Maksimum güc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Seriya nömrəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Cihaz məlumatı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Qısayolları göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Kömək</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sİstem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>İxrac</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Təzələmək</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Cihaz idarəetməsi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Avadanlıq</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Sürücülər</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>İcmal</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Ekran uzlaşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>Mərkəzi Prosessor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Şəbəkə uzlaşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Batareya</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Əməl</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OLDU</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Avadanlıq sinfi</translation>
@@ -3117,17 +3127,23 @@
         <translation>Disk tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Monitor tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Şəbəkə uzlaşdırıcısı tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Səs cihazı tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Sürücüləri bu yolda axtarın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 sürücü yenilənmələri əlçatandır</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Yoxlanılma vaxtı: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>%1 üçün sürücülər endirilir...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Endirmə sürəti: %1 Endirildi: %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>%1 üçün sürücülər quraşdırılır...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 sürücü quraşdırıldı, %2 sürücü alınmadı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 sürücüquraşdırıldı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Sürücülərin quraşdırılması baş tutmadı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Şəbəkə xətası. Yenidən qoşulur...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Endirmə srəti: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Sürücüləriniz köhnəlib</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>yenidən başladın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Sürücülərin işə düşməsi üçün lütfən %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>rəy göndərin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Lütfən yenidən cəhd edin və ya bizə %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Hamısını quraşdırın</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Yenidən axtarılsın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Lütfən yenidən axtarın edin və ya bizə %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Sürücü quraşdırılır, indi çıxsanız quraşdırma pozulacaq.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Çıxmaq istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Çıxış</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">གཏན་ཁེལ། </translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ། </translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>མ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>སྒུལ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>ནུས་ཆོད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>རིམ་སྟར་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>སྒྲིག་ཆས་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>མྱུར་མཐེབ་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>རོགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>མ་ལག</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>གསར་འཇུག</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>སྒྲིག་ཆས་དོ་དམ་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>སྒྲིག་ཆས་མངོན་སྟོན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>གནས་ཚུལ་རགས་བསྡུས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>འཚམ་སྒྲིག་ཆས་མངོན་སྟོན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>ཐག་གཅོད་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>དྲ་བའི་འཚམ་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>གློག་རྫས། </translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">གཏན་ཁེལ། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>བརྟན་ཆས་རིགས་དབྱེ།</translation>
@@ -3117,17 +3127,23 @@
         <translation>སྡུད་སྡེར་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>འཆར་བའི་སྒྲིག་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>དྲ་བའི་འཚམ་སྒྲིག་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>སྒྲ་ཟློས་སྒྲིག་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>སྐུལ་བྱེད་གནས་ཡུལ་འདེམས་པ། </translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <source>Exit</source>
+        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Page/MainWindow.cpp" line="606"/>
         <location filename="../src/Page/MainWindow.cpp" line="619"/>
         <location filename="../src/Page/MainWindow.cpp" line="632"/>
-        <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ca.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ca.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">D&apos;acord</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Informació de Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Capacitats</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Energia màxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Número de sèrie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Informació del dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Dreceres de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Tanca</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exporta</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Refresca</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Gestor de dispositius</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Maquinari</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Controladors</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Resum</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Adaptador de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Adaptador de xarxa</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Acció</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Classe del maquinari</translation>
@@ -3117,17 +3127,23 @@
         <translation>No s&apos;ha trobat cap disc.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>No s&apos;ha trobat cap monitor.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>No s&apos;ha trobat cap adaptador de xarxa.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>No s&apos;ha trobat cap dispositiu d&apos;àudio.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Cerca controladors en aquest camí</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 actualitzacions de controladors disponibles</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Hora de la comprovació: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Es baixen els controladors per a %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Velocitat de baixada: %1 Baixat: %2 / %3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>S&apos;instal·len els controladors per a %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 controladors instal·lats, %2 controladors han fallat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 controladors instal·lats</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Ha fallat instal·lar els controladors.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Error de xarxa. Es torna a connectar...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Velocitat de baixada: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Els controladors estan actualitzats.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>reinicieu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Si us plau, %1 perquè els controladors instal·lats tinguin efecte.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>envieu comentaris</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Si us plau, torneu-ho a provar o %1.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Instal·la-ho tot</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Torna a escanejar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Si us plau, torneu a escanejar o %1.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>S&apos;instal·la un controlador, i s&apos;interromprà si en sortiu.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Segur que en voleu sortir?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Surt</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_cs.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_cs.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Informace o sběrnici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Schopnosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Ovladač</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Nejvyšší odběr</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Sériové číslo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Informace o zařízení</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Zobrazit zkratky</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Zkopírovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Systém</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exportovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Načíst znovu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Správa zařízení</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Přehled</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Zobrazovací adaptér</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Síťový adaptér</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Akumulátor</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Třída hardware</translation>
@@ -3117,17 +3127,23 @@
         <translation>Nenalezen žádný disk</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Nenalezen žádný monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Nenalezen žádný síťový adaptér</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Nenalezeno žádné zvukové zařízení</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Ovladače hledat v této cestě</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Storno</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <source>Exit</source>
+        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Page/MainWindow.cpp" line="606"/>
         <location filename="../src/Page/MainWindow.cpp" line="619"/>
         <location filename="../src/Page/MainWindow.cpp" line="632"/>
-        <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Storno</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_de.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_de.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Bus-Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Fähigkeiten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Treiber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Maximale Leistung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Seriennummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Geräte-Info</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Kürzel anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Geräteverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Treiber</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Übersicht</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Anzeigeadapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Netzwerkadapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Akku</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Aktion</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Hardwareklasse</translation>
@@ -3117,17 +3127,23 @@
         <translation>Keine Festplatte gefunden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Kein Monitor gefunden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Kein Netzwerkadapter gefunden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Kein Audiogerät gefunden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Nach Treibern in diesem Pfad suchen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 Treiberaktualisierungen verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Treiber für %1 werden heruntergeladen ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Herunterladegeschwindigkeit: %1 Heruntergeladen %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Treiber für %1 werden installiert ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 Treiber installiert, %2 Treiber fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 Treiber installiert</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Netzwerkfehler. Verbindung wiederherstellen ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Herunterladegeschwindigkeit: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Ihre Treiber sind auf dem neuesten Stand</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>Rückmeldung absenden</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Alle installieren</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sind Sie sicher, dass Sie beenden möchten?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_en_AU.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_en_AU.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Device Info</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Device Manager</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation type="unfinished">Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation type="unfinished">Display Adapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Network Adapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Battery</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Hardware Class</translation>
@@ -3117,17 +3127,23 @@
         <translation>No disk found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>No monitor found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>No network adapter found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>No audio device found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3389,7 +3405,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3894,7 +3910,7 @@
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3905,197 +3921,202 @@
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <source>Exit</source>
+        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Page/MainWindow.cpp" line="606"/>
         <location filename="../src/Page/MainWindow.cpp" line="619"/>
         <location filename="../src/Page/MainWindow.cpp" line="632"/>
-        <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_es.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_es.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">Aceptar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Información de bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Potencia máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Información del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atajos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Administrador de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Resumen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Adaptador de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Adaptador de red</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Acción</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Clase de hardware</translation>
@@ -3117,17 +3127,23 @@
         <translation>No se encontró ningún disco</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>No se encontró ningún monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>No se encontraron adaptadores de red</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>No se encontraron dispositivos de audio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Buscar controladores en esta ruta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 actualizaciones de controladores disponibles</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Tiempo de comprobación: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Descargando controladores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Velocidad de descarga: %1 Descargado %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Instalando controladores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 controladores instalados, %2 controladores que fallaron</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 controladores instalados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Error al instalar los controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Error de red. Reconectando...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Velocidad de descarga: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Sus controladores están actualizados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Por favor espere, %1 para que los controladores instalados surtan efecto</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>Enviar comentarios</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Vuelva a intentarlo o %1 contáctenos</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Instalar todo</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Buscar nuevamente</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Escanee de nuevo o %1 contáctenos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Está instalando un controlador, se interrumpirá si sale.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Está seguro de que quiere salir?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_fi.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_fi.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Malli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Väylän tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Ajuri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Suurin teho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Sarjanumero</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Laiteen tiedot</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Näytä pikakuvakkeet</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Sulje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Apua</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Kopio</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Järjestelmä</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Vie</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Virkistä</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Laitehallinta</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Laitteisto</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Ajurit</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Näyttö</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Yleiskuva</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Näytönohjain</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>Prosessori</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Verkkokortti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Akku</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Toiminta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Laitteistoluokka</translation>
@@ -3117,17 +3127,23 @@
         <translation>Levyä ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Näyttöä ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Verkkokorttia ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Äänilaitetta ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Etsi ajurit tästä polusta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 ajuripäivitystä saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Tarkistettu: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Ajurien lataus %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Latausnopeus: %1 ladattu %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Asennetaan ajureita %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 ajuria asennettu, %2 ajuria epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 ajuria asennettu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Ajurien asentaminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Verkkovirhe. Yhdistetään uudelleen...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Latausnopeus: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Ajurit ovat ajan tasalla</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>käynnistä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Ole hyvä ja %1, jotta asennetut ajurit tulevat voimaan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>anna palautetta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Yritä uudelleen tai %1 meille</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Asenna kaikki</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Tarkista uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Peru</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Tarkista uudelleen tai %1 meille</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Olet asentamassa ajuria, joka rikkoutuu, jos poistut.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Oletko varma, että haluat poistua?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Poistu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_fr.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_fr.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Modèle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Infos du bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Capacités</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Charge maximum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Numéro de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Infos de l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Afficher les raccourcis</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Système</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Actualiser</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Gestionnaire de périphériques</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Matériel</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Conducteurs</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Écran</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Aperçu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Adaptateur pour écran</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Adaptateur réseau</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Batterie</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Action</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Classe de matériel</translation>
@@ -3117,17 +3127,23 @@
         <translation>Aucun disque trouvé</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Aucun écran trouvé</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Aucune carte réseau trouvée</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Aucun appareil audio détecté</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Rechercher des pilotes dans ce chemin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 mises à jour de pilotes disponibles</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Heure vérifiée : %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Téléchargement des pilotes pour %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Vitesse de téléchargement : %1 Téléchargé %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Installation des pilotes pour %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 pilotes installés, %2 pilotes ont échoué</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 pilotes installés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Échec de l&apos;installation des pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Erreur réseau. Reconnexion...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Vitesse de téléchargement &amp; #160; :  %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Vos pilotes sont à jour</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>redémarrer</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Veuillez %1 pour que les pilotes installés prennent effet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>soumettre des commentaires</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Veuillez réessayer ou %1 pour nous</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Tout installer</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Numériser à nouveau</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Veuillez numériser à nouveau ou %1 pour nous</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Vous êtes en train d&apos;installer un pilote, qui sera interrompu si vous quittez.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Êtes-vous sûr de vouloir quitter ?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_gl_ES.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_gl_ES.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Información do bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Poder máximo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Información do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Amosar atallos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Pechar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Axuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Recargar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Xestor de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Visión xeral</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Adaptador de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Adaptador de rede</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Clase de hardware</translation>
@@ -3117,17 +3127,23 @@
         <translation>Non se atopou ningún disco</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Non se atopou ningún monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Non se atopou ningún adaptador da rede</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Non se atopou ningún dispositivo de audio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <source>Exit</source>
+        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Page/MainWindow.cpp" line="606"/>
         <location filename="../src/Page/MainWindow.cpp" line="619"/>
         <location filename="../src/Page/MainWindow.cpp" line="632"/>
-        <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_hu.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_hu.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Busz adatok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Képességek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Illesztőprogram</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Legnagyobb teljesítmény</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Sorozatszám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Eszköz információ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Parancsikonok megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Bezárás</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Segítség</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Rendszer</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exportálás</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Eszközkezelő</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Hardver</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Illesztőprogramok</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Kijelző</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Áttekintés</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Kijelző feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>Processzor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Hálózati feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Akkumulátor</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Művelet</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Hardver osztályok</translation>
@@ -3117,17 +3127,23 @@
         <translation>Lemez nem található</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Monitor nem található</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Hálózati feldolgozó nem található</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Hang eszköz nem található</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Keressen illesztőprogramokat ezen az útvonalon</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 illesztőprogram frissítése érhető el</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Ellenőrzési idő: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>A %1 illesztőprogramjának letöltése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>letöltési sebesség: %1 Letöltve %2 / %3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>A %1 illesztőprogramjának telepítése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 illesztőprogram telepítve, %2 illesztőprogram meghiúsult</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 illesztőprogram telepítve</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Az illesztőprogramok telepítése sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Hálózati hiba. Újra csatlakozás...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Letöltési sebesség: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Az illesztőprogramok naprakészek</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>Újraindítás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Kérjük %1, hogy a telepített illesztőprogramok érvénybe lépjenek</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>Visszajelzés küldése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Kérjük próbálja újra, vagy küldje el nekünk %1-et</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Összes telepítése</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Újra ellenőrzés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Kérjük ellenőrizze újra, vagy küldje be nekünk a %1-et</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Az illesztőprogramok telepítése folyamatban, kilépés esetén a folyamat megszakad.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Valóban ki szeretne lépni? </translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Kilépés</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_it.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_it.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Info BUS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Potenza massima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Numero di serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Info dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Visualizza scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Gestore dispositivi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Panoramica</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Adattatore video</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Adattatore di Rete</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Batteria</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Azione</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Classe hardware</translation>
@@ -3117,17 +3127,23 @@
         <translation>Nessun disco rilevato</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Nessuno schermo rilevato</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Nessun adattatore di rete rilevato</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Nessun dispositivo audio rilevato</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3737,166 +3753,171 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
         <translation>Ricerca driver in questo percorso</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 aggiornamenti driver disponibili</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Ora verifica: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Download dei driver per %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Valicità download: %1 Scaricati %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Installazione driver per %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 driver installati, %2 installazione driver fallita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 driver installati</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Installazione driver fallita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Errore rete. Riconnessione in corso...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Valocità Download: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>I tuoi driver sono aggiornati</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>riavvia</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Per cortesia %1 per rendere effettive le modifiche ai driver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>invia un feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Per cortesia riprova oppure %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Installa tutti</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Analizza nuovamente</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -3932,40 +3953,40 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
         <translation>Analizza nuovamente oppure %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Stai installando un driver, così facendo rischi di interrompere l&apos;operazione.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Desideri veramente proseguire?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ko.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ko.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>모델</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>버스 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>드라이버</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>최대 전원</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>일련 번호</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>장치 정보</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>단축키 표시</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>도움말</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>복사</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>시스텝</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>내보내기</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>새로고침</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>장치 관리자</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation type="unfinished">모니터</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>개요</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation type="unfinished">디스플레이 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>네트워크 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>배터리</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>하드웨어 클래스</translation>
@@ -3117,17 +3127,23 @@
         <translation>디스크를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>모니터를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>네트워크 어댑터를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>오디오 장치를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3389,7 +3405,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3894,7 +3910,7 @@
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3905,197 +3921,202 @@
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <source>Exit</source>
+        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Page/MainWindow.cpp" line="606"/>
         <location filename="../src/Page/MainWindow.cpp" line="619"/>
         <location filename="../src/Page/MainWindow.cpp" line="632"/>
-        <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ms.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ms.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Maklumat Bas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Keupayaan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Kuasa Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Nombor Siri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Maklumat Peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Papar pintasan</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Bantuan</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Segar Semula</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Pengurus Peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Perkakasan</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Selayang Pandang</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Penyesuai Paparan</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Penyesuai Rangkaian</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Bateri</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Tindakan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Kelas Perkakasan</translation>
@@ -3117,17 +3127,23 @@
         <translation>Tiada cakera ditemui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Tiada monitor ditemui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Tiada penyesuai rangkaian ditemui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Tiada peranti audio ditemui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Gelintar pemacu dalam laluan ini</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 kemas kini pemacu telah tersedia</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Masa diperiksa: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Memuat turun pemacu untuk %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Kelajuan muat turun: %1 Muat turun %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Memasang pemacu untuk %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 pemacu dipasang, %2 pemacu mengalami kegagalan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 pemacu dipasang</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Gagal memasang pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Ralat rangkaian. Menyambung semula...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Kelajuan muat turun: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Pemacu anda adalah yang terkini</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>but semula</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Sila %1 supaya pemacu yang baru dipasang berkesan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>serah maklum balas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Cuba sekali lagi atau %1 kepada kami</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Pasang Semua</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Imbas Sekali Lagi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Sila imbas sekali lagi atau %1 kepada kami</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Anda sedang memasang sebuah pemacu, yang akan terganggu sekiranya anda keluar.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Anda pasti mahu keluar?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Keluar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_nl.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_nl.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">Oké</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Businformatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Mogelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Maximale energie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Apparaatinformatie</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Sneltoetsen tonen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Hulp</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Systeem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Apparaatbeheer</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Stuurprogramma&apos;s</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Beeldscherm</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Overzicht</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Beeldschermadapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Netwerkadapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Accu</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Actie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">Oké</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Hardwareklasse</translation>
@@ -3117,17 +3127,23 @@
         <translation>Geen schijf aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Geen beeldscherm aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Geen netwerkadapter aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Geen audio-apparaat aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Deze locatie doorzoeken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>Er zijn %1 stuurprogramma-updates beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Gecontroleerd om %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Bezig met downloaden van stuurprogramma&apos;s…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Downloadsnelheid: %1 - Gedownload: %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Bezig met installeren van stuurprogramma&apos;s…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 stuurprogramma&apos;s geïnstalleerd; %2 mislukt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 stuurprogramma&apos;s geïnstalleerd</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>De stuurprogramma&apos;s kunnen niet worden geïnstalleerd</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Netwerfout - bezig met opnieuw verbinden…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Downloadsnelheid: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Alle stuurprogramma&apos;s zijn actueel</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>Start de computer opnieuw op</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>%1 om de geïnstalleerde stuurprogramma&apos;s in gebruik te nemen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>verstuur feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Probeer het opnieuw of %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Alles installeren</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Opnieuw zoeken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Probeer het opnieuw of %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Er wordt nog een stuurprogramma geïnstalleerd, Als je nu afsluit, wordt het proces afgebroken.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet je zeker dat je wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_pl.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_pl.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Informacje o szynie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Możliwości</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Sterownik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Moc maksymalna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Numer seryjny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Informacje o urządzeniu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Wyświetl skróty</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Eksportuj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Odśwież</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Menedżer urządzeń</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Sprzęt</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Sterowniki</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Podgląd</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Karta graficzna</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Adapter sieciowy</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Działanie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Klasa sprzętu</translation>
@@ -3117,17 +3127,23 @@
         <translation>Nie znaleziono dysku</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Nie znaleziono monitora</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Nie znaleziono adaptera sieciowego</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Nie znaleziono urządzenia audio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Szukaj sterowników w tej ścieżce</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 sterowników może zostać zaktualizowanych</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Data sprawdzania: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Pobieranie sterowników dla %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Prędkość pobierania: %1 Pobrano %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Instalowanie sterowników dla %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 sterowników zainstalowano, %2 napotkało błąd</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>Zainstalowano %1 sterowników</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Nie udało się zainstalować sterowników</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Błąd sieci. Próba ponownego połączenia...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Prędkość pobierania %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Wszystkie sterowniki są aktualne</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>uruchom ponownie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Prosimy %1, aby zastosować zmiany</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>prześlij opinię</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Spróbuj ponownie lub %1 do nas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Zainstaluj wszystko</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Skanuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Zeskanuj ponownie lub %1 do nas</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Wyjście przerwie instalację sterownika.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Czy na pewno chcesz wyjść?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Wyjście</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_pt.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_pt.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">Aceitar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Energia máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Info dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atalhos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Gestor de Dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Equipamento</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Adaptador gráfico</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Adaptador de rede</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Ação</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Classe de hardware</translation>
@@ -3117,17 +3127,23 @@
         <translation>Nenhum disco encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Nenhum monitor encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Nenhum adaptador de rede encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Nenhum dispositivo áudio encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Procurar por controladores neste local</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 atualizações de controladores disponíveis</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Hora da verificação: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>A transferir controladores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>A instalar controladores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Falha ao instalar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Instalar tudo</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Verificar novamente</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sair?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_pt_BR.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_pt_BR.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Informações do Barramento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Potência Máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Número de Série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Informações do Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Exibir atalhos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Gerenciador de Dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Máquina</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Placa de Vídeo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Placa de Rede</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Ações</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Classe do Hardware</translation>
@@ -3117,17 +3127,23 @@
         <translation>Nenhum disco encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Nenhum monitor encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Nenhuma placa de rede encontrada</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Nenhum dispositivo de áudio encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Procurar por drivers neste local</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 atualizações de drivers disponíveis</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Tempo decorrido: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Baixando drivers %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Velocidade download: %1 Baixado %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Drivers sendo instalados %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 Drivers instalados, %2 Falhas na instalação</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 Drivers instalados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Falha ao instalar drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Erro de conexão. Reconectando...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Velocidade download: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Seus drivers estão desatualizados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Por favor aguarde %1 para os drivers instalados surtirem efeito</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>Enviar feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Por favor tente novamente ou %1 para nós</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Instalador Todos</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Verificar Novamente</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Por favor verifique novamente ou %1 para nós</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>O driver está sendo instalado, a instalação será cancelada se você sair.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Tem certeza que deseja sair?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ro.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ro.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Versiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Info Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Capabilități</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Putere Maximă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Numar Serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Informații Dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Scurtături Afișaj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Închide</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Ajutor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Copiază</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Exportare</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Reîmprospătare</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Manager Dispozitive</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Prezentare Generală</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Adaptor Afișaj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Adaptor Rețea</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Baterie</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Clasă Hardware</translation>
@@ -3117,17 +3127,23 @@
         <translation>Unitate disc negasită</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Monitor Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Adaptor Rețea Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Dispozitiv Audio Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <source>Exit</source>
+        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Page/MainWindow.cpp" line="606"/>
         <location filename="../src/Page/MainWindow.cpp" line="619"/>
         <location filename="../src/Page/MainWindow.cpp" line="632"/>
-        <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ru.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ru.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">ОК</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Информация о шине</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Способность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Максимальная мощность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Серийный номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Информация об устройстве</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Отобразить горячие клавиши</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Скопировать</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Диспетчер устройств</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Оборудование</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Драйверы</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Монитор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Обзор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Видеоадаптер</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>Процессор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Сетевой адаптер</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Батарея</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Действие</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">ОК</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation type="unfinished"></translation>
@@ -3117,17 +3127,23 @@
         <translation>Диск не найден</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Сетевой адаптер не найден</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Не найдено звуковое устройство</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>Доступно обновленных драйверов: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Последняя проверка: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Загрузка драйверов для %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Скорость загрузки: %1 Загружено %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Установка драйверов для %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>Установлено драйверов: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Не удалось установить драйверы</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Скорость загрузки: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Ваши драйверы обновлены</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>перезагрузите компьютер</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Чтобы задействовать установленные драйвера, %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Установить все</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Повторный поиск</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Отменить</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Выход</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sl.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sl.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Podatki o vodilu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Zmogljivosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Gonilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Največja moč</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Serijska številka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Podatki o napravi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Bližnjice zaslona</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Zapri</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Pomoč</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Izvozi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Osveži</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Upravitelj naprav</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Pregled</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Grafični vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Omrežni vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Akumulator</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Razred strojne opreme</translation>
@@ -3117,17 +3127,23 @@
         <translation>Ni najdenega diska</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Ni najdenega monitorja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Ni najdenega omrežnega vmesnika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Ni najdene zvočne naprave</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Prekini</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <source>Exit</source>
+        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Page/MainWindow.cpp" line="606"/>
         <location filename="../src/Page/MainWindow.cpp" line="619"/>
         <location filename="../src/Page/MainWindow.cpp" line="632"/>
-        <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sq.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sq.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Të dhëna Busi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Aftësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Maksimum Fuqie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Numër Serial</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Të dhëna Pajisjeje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Shfaq shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Mbylle</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Ndihmë</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Eksporto</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Rifreskoje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Përgjegjës Pajisjesh</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Përmbledhje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Përshtatës Ekrani</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Përshtatës Rrjeti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Bateri</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Veprim</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Klasë Hardware-i</translation>
@@ -3117,17 +3127,23 @@
         <translation>S’u gjet disk</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>S’u gjet monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>S’u gjet përshtatës rrjeti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>S’u gjet pajisje audio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Kërko për përudhës në këtë shteg</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 përditësime përudhësish të gatshme</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Kohë kontrolli: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Po shkarkohen përudhësa për %1…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Shpejtësi shkarkimi: %1 Të shkarkuar %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Po instalohen përudhës për %1…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>U instaluan %1 përudhës, dështoi instalimi për %2 përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>U instaluan %1 përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>S’u arrit të instalohet përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Gabim rrjeti. Po rilidhet…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Shpejtësi shkarkimi: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Përudhësit tuaj janë të përditësuar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>riniseni</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Ju lutemi, %1 që të hyjnë në fuqi përudhësit e instaluar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>jepni përshtypjet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Ju lutemi, riprovoni, ose na %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Instaloji Krejt</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Rikontrollo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Ju lutemi, rikontrolloni, ose na %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Po instaloni një përudhës, çka do të ndalet, nëse dilni.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Jeni i sigurt se doni të dilet?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Dil</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sr.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sr.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation type="unfinished"></translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Модел</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Подаци магистрале</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Могућности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Управљач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Максимална снага</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Серијски број</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Подаци уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Прикажи пречице</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Затвори</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Помоћ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Копирај</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Систем</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Извези</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Освежи</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Упраник Уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Монитор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Уопштено</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Графичка картица</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>ЦПЈ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Мрежна картица</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Батерија</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Класа уређаја</translation>
@@ -3117,17 +3127,23 @@
         <translation>Није пронађен диск</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Монитор није пронађен</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Мрежна картица није пронађена</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Није пронађен аудио уређај</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Откажи</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <source>Exit</source>
+        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Page/MainWindow.cpp" line="606"/>
         <location filename="../src/Page/MainWindow.cpp" line="619"/>
         <location filename="../src/Page/MainWindow.cpp" line="632"/>
-        <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_tr.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_tr.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Bus Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Yetenekler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Azami Güç</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Seri Numarası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Aygıt Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Kısayolları göster</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Yardım</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Dışa aktar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Aygıt Yöneticisi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Donanım</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Sürücüler</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Ekran</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Özet</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Görüntü Bağdaştırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Ağ Bağdaştırıcı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Pil</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Eylem</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Donanım Sınıfı</translation>
@@ -3117,17 +3127,23 @@
         <translation>Disk bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Monitör bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Ağ bağdaştırıcısı bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Ses aygıtı bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Bu yoldaki sürücüleri arayın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>%1 sürücü güncellemeleri mevcut</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Kontrol edilen zaman: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>%1 için sürücüler indiriliyor...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>İndirme hızı: %1 İndirildi %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>%1 için sürücüler yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 sürücü yüklendi, %2 sürücü başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>%1 sürücüler yüklü</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Sürücülerin yüklenmesi başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Ağ hatası. Yeniden bağlanılıyor...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>İndirme hızı: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Senin sürücülerin güncel</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>Yeniden başlat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Yüklü sürücülerin etkinleşmesi için lütfen %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>geribildirim gönder</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Lütfen tekrar deneyin veya bize %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Hepsini Yükle</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Tekrar tara</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Lütfen tekrar tarayın veya bize %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Çıktığınızda kesintiye uğrayacak bir sürücü kuruyorsunuz.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Çıkış yapmak istediğinden emin misin?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Çıkış</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">جەزىملەش</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>جەزىملەش</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>ساتقۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>مودىل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>ئەڭ چوڭ قۇۋۋەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>تەرتىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>ئۈسكۈنە ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>تېزلەتمىلەرنى كۆرسەت</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>ياردەم</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>سىستېما</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>ئېكسپورت</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>ئۈسكۈنە باشقۇرغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>كۆرسىتىش ئۈسكۈنىسى</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>ئومۇمىي چۈشەنچە</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>كۆرسەتكۈچ ماسلاشتۇرغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>تور ماسلاشتۇرغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>باتارېيە</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">جەزىملەش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>قاتتىق دېتال سىنىپى</translation>
@@ -3117,17 +3127,23 @@
         <translation>دىسكا تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>نازارەتچى تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>تور ماسلاشتۇرغۇچ تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>ئاۋاز ئۈسكۈنىسى تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>قۇرغاتقۇچ ئورنىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <source>Exit</source>
+        <comment>button</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Page/MainWindow.cpp" line="606"/>
         <location filename="../src/Page/MainWindow.cpp" line="619"/>
         <location filename="../src/Page/MainWindow.cpp" line="632"/>
-        <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_uk.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_uk.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">Гаразд</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>Дані щодо каналу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>Можливості</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>Максимальна потужність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>Серійний номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Дані щодо пристрою</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>Скорочення дисплея</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>Експортувати</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>Керування пристроями</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>Обладнання</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>Драйвери</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>Монітор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>Огляд</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>Адаптер дисплея</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>Процесор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>Адаптер мережі</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>Акумулятор</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">Дія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>Клас обладнання</translation>
@@ -3117,17 +3127,23 @@
         <translation>Не знайдено дисків</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>Моніторів не знайдено</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>Не знайдено адаптера мережі</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>Звукових пристроїв не знайдено</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>Шукати драйвери у цій теці</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>Доступні оновлення драйверів (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>Минуло часу: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>Отримуємо драйвери до %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Швидкість отримання: %1 Отримано %2 з %3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>Встановлюємо драйвери до %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>Встановлено %1 драйверів, %2 драйверів не вдалося встановити</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>Встановлено %1 драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>Не вдалося встановити драйвери</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>Помилка мережі. Відновлюємо з&apos;єднання…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>Швидкість отримання: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>Ваші драйвери є найновішими</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>виконайте перезавантаження</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Будь ласка, %1, щоб встановлені драйвери запрацювали</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>надішліть відгук</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>Будь ласка, повторіть спробу або %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>Встановити усе</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>Повторити пошук</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>Будь ласка, повторіть пошук або %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Ви встановлюєте драйвер. Процедуру буде перервано, якщо ви вийдете з програми.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви справді хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation>确 定</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation>反馈</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>驱动</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>设备信息</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>系统</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>设备管理器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>硬件信息</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>驱动管理</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>显示设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>概况</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>显示适配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>处理器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>网络适配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>电池</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation>操作</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation>可备份驱动</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation>已备份驱动</translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation>驱动安装</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation>驱动备份</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation>驱动还原</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation>反馈</translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>硬件类别</translation>
@@ -3117,17 +3127,23 @@
         <translation>未发现磁盘</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation>驱动还原失败！</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation>请重试，或反馈给我们</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation>备份失败！</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>未发现显示设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>未发现网络适配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>未发现音频设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>选择驱动所在位置</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>发现%1个驱动可安装更新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>检测时间: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>正在下载%1驱动…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>下载速度：%1 已完成 %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>正在安装%1驱动…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>驱动安装成功%1个，失败%2个</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>共成功安装%1个驱动</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>驱动安装失败</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>网络异常，重试中</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>下载速度：%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>驱动已是最新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation>驱动已全部备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>总计%1个驱动，其中%2个已备份</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>您有%1个驱动可以备份，建议立即备份</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>您有%1个驱动可以备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>正在备份第%1个驱动，共%2个</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation>正在备份：%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>驱动备份成功%1个，失败%2个</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation>备份失败</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation>%1个驱动已备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>您有%1个驱动可以还原</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation>请选择驱动还原</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation>驱动还原中…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation>正在还原：%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>重启电脑</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>驱动已安装完成，请稍后%1生效</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation>查看备份路径</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation>一键备份</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>反馈</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>驱动未安装成功，请重试或%1给我们</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>一键安装</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>重新检测</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>请重新检测或%1给我们</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>当前正在安装驱动，退出应用后任务将会中断</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>确认是否退出应用？</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>退 出</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>当前正在备份驱动，退出应用后任务将会中断</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>当前正在还原驱动，退出应用后任务将会中断</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">確 定</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>總線訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>驅動</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>序列號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>設備訊息</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>系統</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>導出</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>設備管理器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>硬件訊息</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>驅動管理</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>顯示設備</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>概況</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>顯示適配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>處理器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>網絡適配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>電池</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">操作</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">確 定</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>硬件類別</translation>
@@ -3117,17 +3127,23 @@
         <translation>未發現磁盤</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>未發現顯示設備</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>未發現網絡適配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>未發現音頻設備</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>選擇驅動所在位置</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>發現%1個驅動可安裝更新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>檢測時間: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>正在下載%1驅動…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>下載速度：%1 已完成 %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>正在安裝%1驅動…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>驅動安裝成功%1個，失敗%2個</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>共成功安裝%1個驅動</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>驅動安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>網絡異常，重試中</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>下載速度：%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>驅動已是最新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>重啟電腦</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>驅動已安裝完成，請稍後%1生效</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>反饋</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>驅動未安裝成功，請重試或%1給我們</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>一鍵安裝</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>重新檢測</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>請重新檢測或%1給我們</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>當前正在安裝驅動，退出應用後任務將會中斷</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>確認是否退出應用？</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>退 出</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
@@ -4,7 +4,17 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="24"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <source>OK</source>
+        <translation type="unfinished">確 定</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="54"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
@@ -1218,62 +1228,62 @@
 <context>
     <name>DeviceOthers</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="183"/>
         <source>Vendor</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
         <source>Model</source>
         <translation>型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
         <source>Bus Info</source>
         <translation>匯流排訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
         <source>Driver</source>
         <translation>驅動</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="196"/>
         <source>Serial Number</source>
         <translation>序號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="205"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="208"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
@@ -1592,88 +1602,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="187"/>
+        <location filename="../src/Page/MainWindow.cpp" line="186"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>裝置訊息</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="258"/>
+        <location filename="../src/Page/MainWindow.cpp" line="257"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="259"/>
+        <location filename="../src/Page/MainWindow.cpp" line="258"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="260"/>
+        <location filename="../src/Page/MainWindow.cpp" line="259"/>
         <source>Help</source>
         <translation>說明</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="261"/>
+        <location filename="../src/Page/MainWindow.cpp" line="260"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="265"/>
+        <location filename="../src/Page/MainWindow.cpp" line="264"/>
         <source>System</source>
         <translation>系統</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="272"/>
+        <location filename="../src/Page/MainWindow.cpp" line="271"/>
         <source>Export</source>
         <translation>匯出</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="273"/>
+        <location filename="../src/Page/MainWindow.cpp" line="272"/>
         <source>Refresh</source>
         <translation>重新整理</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="277"/>
+        <location filename="../src/Page/MainWindow.cpp" line="276"/>
         <source>Device Manager</source>
         <translation>裝置管理器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Hardware</source>
         <translation>硬體訊息</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="346"/>
+        <location filename="../src/Page/MainWindow.cpp" line="345"/>
         <source>Drivers</source>
         <translation>驅動管理</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Monitor</source>
         <translation>顯示裝置</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="493"/>
+        <location filename="../src/Page/MainWindow.cpp" line="489"/>
         <source>Overview</source>
         <translation>概況</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="497"/>
+        <location filename="../src/Page/MainWindow.cpp" line="493"/>
         <source>Display Adapter</source>
         <translation>顯示適配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="501"/>
+        <location filename="../src/Page/MainWindow.cpp" line="497"/>
         <source>CPU</source>
         <translation>處理器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="505"/>
+        <location filename="../src/Page/MainWindow.cpp" line="501"/>
         <source>Network Adapter</source>
         <translation>網路適配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="511"/>
+        <location filename="../src/Page/MainWindow.cpp" line="507"/>
         <source>Battery</source>
         <translation>電池</translation>
     </message>
@@ -1716,12 +1726,12 @@
         <translation type="unfinished">操作</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="166"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="167"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1925,31 +1935,31 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="56"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="421"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="55"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="451"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="98"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="423"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="453"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="425"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="455"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="544"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="578"/>
         <source>OK</source>
         <translation type="unfinished">確 定</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="545"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="579"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2592,7 +2602,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="397"/>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="486"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="175"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="434"/>
         <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
         <source>Device File</source>
@@ -3047,7 +3057,7 @@
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceStorage.cpp" line="485"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="176"/>
         <location filename="../src/DeviceManager/DeviceInput.cpp" line="435"/>
         <source>Hardware Class</source>
         <translation>硬體類別</translation>
@@ -3117,17 +3127,23 @@
         <translation>未發現磁碟</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="533"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="576"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="535"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="33"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="572"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="582"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="39"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1342"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
@@ -3160,7 +3176,7 @@
         <translation>未發現顯示裝置</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="591"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1344"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
@@ -3177,7 +3193,7 @@
         <translation>未發現網路適配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="585"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="625"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1345"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
@@ -3194,7 +3210,7 @@
         <translation>未發現音訊裝置</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="588"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1346"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
@@ -3278,7 +3294,7 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="597"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
@@ -3736,166 +3752,171 @@
         <translation>選擇驅動所在位置</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="93"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="92"/>
         <source>%1 driver updates available</source>
         <translation>發現%1個驅動可安裝更新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="99"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="367"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="98"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="366"/>
         <source>Time checked: %1</source>
         <translation>檢測時間: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="149"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="148"/>
         <source>Downloading drivers for %1...</source>
         <translation>正在下載%1驅動…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="151"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="150"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>下載速度：%1 已完成 %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="197"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="196"/>
         <source>Installing drivers for %1...</source>
         <translation>正在安裝%1驅動…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="239"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="238"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>驅動安裝成功%1個，失敗%2個</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="241"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="240"/>
         <source>%1 drivers installed</source>
         <translation>共成功安裝%1個驅動</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="281"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="280"/>
         <source>Failed to install drivers</source>
         <translation>驅動安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="321"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="320"/>
         <source>Network error. Reconnecting...</source>
         <translation>網路異常，重試中</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="323"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="322"/>
         <source>Download speed: %1</source>
         <translation>下載速度：%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="364"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="363"/>
         <source>Your drivers are up to date</source>
         <translation>驅動已是最新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="453"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="452"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="455"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="493"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="454"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="496"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="492"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="495"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="531"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="540"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="532"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="541"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="570"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="579"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="572"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="581"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="583"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="613"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="622"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="623"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="644"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="653"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="645"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="654"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="780"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
         <source>reboot</source>
         <translation>重啟電腦</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="781"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="798"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>驅動已安裝完成，請稍後%1生效</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="789"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="806"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="283"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="784"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="801"/>
         <source>submit feedback</source>
         <translation>回饋</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="785"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="802"/>
         <source>Please try again or %1 to us</source>
         <translation>驅動未安裝成功，請重試或%1給我們</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="792"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="809"/>
         <source>Install All</source>
         <translation>一鍵安裝</translation>
     </message>
     <message>
         <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="797"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="814"/>
         <source>Scan Again</source>
         <translation>重新檢測</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
@@ -3931,40 +3952,40 @@
         <translation>請重新檢測或%1給我們</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="601"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>目前正在安裝驅動，退出應用後任務將會中斷</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="606"/>
-        <location filename="../src/Page/MainWindow.cpp" line="619"/>
-        <location filename="../src/Page/MainWindow.cpp" line="632"/>
+        <location filename="../src/Page/MainWindow.cpp" line="602"/>
+        <location filename="../src/Page/MainWindow.cpp" line="615"/>
+        <location filename="../src/Page/MainWindow.cpp" line="628"/>
         <source>Are you sure you want to exit?</source>
         <translation>確認是否退出應用？</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="609"/>
-        <location filename="../src/Page/MainWindow.cpp" line="622"/>
-        <location filename="../src/Page/MainWindow.cpp" line="635"/>
+        <location filename="../src/Page/MainWindow.cpp" line="605"/>
+        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="631"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>退 出</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="610"/>
-        <location filename="../src/Page/MainWindow.cpp" line="623"/>
-        <location filename="../src/Page/MainWindow.cpp" line="636"/>
+        <location filename="../src/Page/MainWindow.cpp" line="606"/>
+        <location filename="../src/Page/MainWindow.cpp" line="619"/>
+        <location filename="../src/Page/MainWindow.cpp" line="632"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="618"/>
+        <location filename="../src/Page/MainWindow.cpp" line="614"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="631"/>
+        <location filename="../src/Page/MainWindow.cpp" line="627"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
修复备份/还原失败无法调起反馈弹窗，驱动还原界面可以扫描出当前备份版本，升级后无法继续备份问题；
备份/还原时置灰重新检测按钮；
UI问题修复。

Log: 修复备份/还原相关bug

Bug: https://pms.uniontech.com/bug-view-222339.html
     https://pms.uniontech.com/bug-view-222363.html
     https://pms.uniontech.com/bug-view-222379.html
     https://pms.uniontech.com/bug-view-222503.html
     https://pms.uniontech.com/bug-view-222513.html
     https://pms.uniontech.com/bug-view-222541.html
     https://pms.uniontech.com/bug-view-222567.html