### PR TITLE
fix: 一键备份部分驱动备份失败失败,鉴权弹框长时间静止不操作提示失败

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
@@ -314,9 +314,12 @@ bool ControlInterface::unInstallPrinter(const QString &vendor, const QString &mo
 bool ControlInterface::backupDeb(const QString &debpath)
 {
     if (!getUserAuthorPasswd()) {
+        emit sigBackupProgressFinished(false);
         return false;
     }
-    return  mp_drivermanager->backupDeb(debpath);
+    bool ret = mp_drivermanager->backupDeb(debpath);
+    emit sigBackupProgressFinished(ret);
+    return  ret;
 }
 
 bool ControlInterface::delDeb(const QString &debname)

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.h
@@ -35,6 +35,7 @@ signals:
     Q_SCRIPTABLE void sigDownloadFinished();//下载完成
     Q_SCRIPTABLE void sigInstallProgressChanged(int progress);//安装进度
     Q_SCRIPTABLE void sigInstallProgressFinished(bool bsuccess, int err);
+    Q_SCRIPTABLE void sigBackupProgressFinished(bool bsuccess);
 #endif
 
 public slots:

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.h
@@ -70,6 +70,7 @@ signals:
     void sigDownloadFinished();//下载完成
     void sigInstallProgressChanged(int progress);//安装进度
     void sigInstallProgressFinished(bool bsuccess, int err);
+    void sigBackupProgressFinished(bool bsuccess);
 
 private:
     ModCore *mp_modcore = nullptr;

--- a/deepin-devicemanager/src/DriverControl/DBusDriverInterface.cpp
+++ b/deepin-devicemanager/src/DriverControl/DBusDriverInterface.cpp
@@ -166,5 +166,6 @@ void DBusDriverInterface::init()
         connect(mp_Iface, SIGNAL(sigInstallProgressFinished(bool, int)), this, SLOT(slotInstallProgressFinished(bool, int)));
         connect(mp_Iface, SIGNAL(sigFinished(bool, QString)), this, SIGNAL(installFinished(bool, QString)));
         connect(mp_Iface, SIGNAL(sigProgressDetail(int, QString)), this, SIGNAL(installProgressDetail(int, QString)));
+        connect(mp_Iface, SIGNAL(sigBackupProgressFinished(bool)), this, SIGNAL(backupProgressFinished(bool)));
     }
 }

--- a/deepin-devicemanager/src/DriverControl/DBusDriverInterface.h
+++ b/deepin-devicemanager/src/DriverControl/DBusDriverInterface.h
@@ -105,6 +105,7 @@ signals:
     void installProgressFinished(bool bsuccess, int err);
     void installFinished(bool, QString);
     void installProgressDetail(int, QString);
+    void backupProgressFinished(bool);
 
 protected:
     explicit DBusDriverInterface(QObject *parent = nullptr);

--- a/deepin-devicemanager/src/DriverControl/DriverBackupThread.h
+++ b/deepin-devicemanager/src/DriverControl/DriverBackupThread.h
@@ -14,6 +14,12 @@ class DriverBackupThread : public QThread
 {
     Q_OBJECT
 public:
+    enum BackupStatus {
+        Waiting = 0,
+        Failed,
+        Success
+    };
+
     explicit DriverBackupThread(QObject *parent = nullptr);
 
     void run();
@@ -27,6 +33,10 @@ public:
      * @brief undoBackup 取消备份
      */
     void undoBackup();
+    void setStatus(BackupStatus status){
+        m_status = status;
+    }
+
 
 signals:
     void backupProgressChanged(int progress);
@@ -37,6 +47,7 @@ public slots:
 private:
     DriverInfo *mp_driverInfo;
     bool m_isStop = true;
+    BackupStatus m_status = Waiting;
 };
 
 #endif // DRIVERBACKUPTHREAD_H

--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -66,6 +66,13 @@ PageDriverManager::PageDriverManager(DWidget *parent)
     connect(DBusDriverInterface::getInstance(), &DBusDriverInterface::installProgressFinished, this, &PageDriverManager::slotInstallProgressFinished);
     connect(DBusDriverInterface::getInstance(), &DBusDriverInterface::installProgressDetail, this, &PageDriverManager::slotRestoreProgress);//还原
     connect(DBusDriverInterface::getInstance(), &DBusDriverInterface::installFinished, this, &PageDriverManager::slotRestoreFinished);
+    connect(DBusDriverInterface::getInstance(), &DBusDriverInterface::backupProgressFinished, this, [=](bool success){
+        if (success) {
+            mp_BackupThread->setStatus(DriverBackupThread::Success);
+        } else {
+            mp_BackupThread->setStatus(DriverBackupThread::Failed);
+        }
+    });
 
     connect(mp_DriverInstallInfoPage, &PageDriverInstallInfo::operatorClicked, this, &PageDriverManager::slotDriverOperationClicked);
     connect(mp_DriverBackupInfoPage, &PageDriverBackupInfo::operatorClicked, this, &PageDriverManager::slotDriverOperationClicked);


### PR DESCRIPTION
修复一键备份部分驱动备份失败失败,鉴权弹框长时间静止不操作提示失败问题

Log: 修复一键备份部分驱动备份失败失败,鉴权弹框长时间静止不操作提示失败问题

Bug: https://pms.uniontech.com/bug-view-226193.html
     https://pms.uniontech.com/bug-view-226257.html