### PR TITLE
fix: 一键备份点击取消不能终止流程

### DIFF
--- a/deepin-devicemanager/src/DriverControl/DriverBackupThread.cpp
+++ b/deepin-devicemanager/src/DriverControl/DriverBackupThread.cpp
@@ -86,7 +86,7 @@ void DriverBackupThread::run()
                     DBusDriverInterface::getInstance()->backupDeb(backupPath);
 
                     while (m_status == Waiting) {
-                        sleep(10);
+                        msleep(500);
                     }
 
                     destdir.remove(fileInfo.fileName());
@@ -119,4 +119,8 @@ void DriverBackupThread::setBackupDriverInfo(DriverInfo *info)
 void DriverBackupThread::undoBackup()
 {
     m_isStop = true;
+}
+
+void DriverBackupThread::setStatus(BackupStatus status){
+    m_status = status;
 }

--- a/deepin-devicemanager/src/DriverControl/DriverBackupThread.h
+++ b/deepin-devicemanager/src/DriverControl/DriverBackupThread.h
@@ -33,10 +33,7 @@ public:
      * @brief undoBackup 取消备份
      */
     void undoBackup();
-    void setStatus(BackupStatus status){
-        m_status = status;
-    }
-
+    void setStatus(BackupStatus status);
 
 signals:
     void backupProgressChanged(int progress);

--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -453,6 +453,12 @@ void PageDriverManager::slotUndoInstall()
 void PageDriverManager::slotUndoBackup()
 {
     mp_BackupThread->undoBackup();
+
+    // 直接清空列表，不再备份剩余的驱动
+    for (int index : m_ListBackupIndex) {
+        mp_DriverBackupInfoPage->updateItemStatus(index, ST_DRIVER_NOT_BACKUP);
+    }
+    m_ListBackupIndex.clear();
 }
 
 void PageDriverManager::slotListViewWidgetItemClicked(const QString &itemStr)
@@ -480,6 +486,8 @@ void PageDriverManager::slotBackupFinished(bool bsuccess)
     // 成功
     if (bsuccess) {
         m_backupSuccessNum += 1;
+        m_ListRestorableIndex.append(m_ListBackableIndex[0]);
+        m_ListBackableIndex.removeAt(0);
     } else { // 失败
         m_backupFailedNum += 1;
     }


### PR DESCRIPTION
修复一键备份点击取消按钮不能终止流程问题

Log: 修复一键备份点击取消按钮不能终止流程问题

Bug: https://pms.uniontech.com/bug-view-226197.html