### PR TITLE
fix: 一键安装，点击取消不能终止流程

### DIFF
--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -449,6 +449,11 @@ void PageDriverManager::slotUndoInstall()
         m_CancelIndex = m_CurIndex;
         DBusDriverInterface::getInstance()->undoInstallDriver();
     }
+
+    for (int index : m_ListDriverIndex) {
+        mp_DriverInstallInfoPage->updateItemStatus(index, m_ListDriverInfo[index]->status());
+    }
+    m_ListDriverIndex.clear();
 }
 
 void PageDriverManager::slotUndoBackup()
@@ -494,7 +499,7 @@ void PageDriverManager::slotBackupFinished(bool bsuccess)
             mp_DriverRestoreInfoPage->addDriverInfoToTableView(m_ListDriverInfo[m_CurBackupIndex], m_CurBackupIndex);
         }
         mp_DriverRestoreInfoPage->showTables(m_ListRestorableIndex.size());
-        m_ListBackableIndex.removeAt(0);
+        m_ListBackableIndex.removeAt(m_ListBackableIndex.indexOf(m_CurBackupIndex));
     } else {
         m_backupFailedNum += 1;
     }
@@ -514,7 +519,6 @@ void PageDriverManager::slotBackupFinished(bool bsuccess)
             mp_DriverBackupInfoPage->headWidget()->setNoBackupDriverUI(m_ListBackableIndex.size(), m_ListBackedupeIndex.size());
             mp_DriverBackupInfoPage->setHeaderCbEnable(false);
         }
-
 
         mp_DriverInstallInfoPage->headWidget()->setReDetectEnable(true);
         mp_DriverBackupInfoPage->headWidget()->setReDetectEnable(true);

--- a/deepin-devicemanager/src/Widget/drivertableview.cpp
+++ b/deepin-devicemanager/src/Widget/drivertableview.cpp
@@ -530,15 +530,15 @@ void DriverTableView::setItemStatus(int index, Status s)
 
             // 如果是安装成功则取消选中且不可选
             if (ST_SUCESS == s || ST_FAILED == s|| ST_DRIVER_BACKUP_FAILED == s || ST_DRIVER_BACKUP_SUCCESS == s
-                    || ST_DRIVER_NOT_BACKUP == s) {
+                    || ST_DRIVER_NOT_BACKUP == s || ST_CAN_UPDATE == s || ST_NOT_INSTALL == s) {
                 DriverCheckItem *cb = dynamic_cast<DriverCheckItem *>(indexWidget(mp_Model->index(i, 0)));
                 if (cb) {
-                    cb->setCbEnable(ST_FAILED == s || ST_DRIVER_BACKUP_FAILED == s || ST_DRIVER_NOT_BACKUP == s ? true : false);
+                    cb->setCbEnable(ST_FAILED == s || ST_DRIVER_BACKUP_FAILED == s || ST_DRIVER_NOT_BACKUP == s  || ST_CAN_UPDATE == s || ST_NOT_INSTALL == s ? true : false);
                     cb->setChecked(false);
                 }
                 DriverOperationItem *opera = dynamic_cast<DriverOperationItem *>(indexWidget(mp_Model->index(i, 5)));
                 if (opera) {
-                    opera->setBtnEnable(ST_FAILED == s || ST_DRIVER_BACKUP_FAILED == s || ST_DRIVER_NOT_BACKUP == s? true : false);
+                    opera->setBtnEnable(ST_FAILED == s || ST_DRIVER_BACKUP_FAILED == s || ST_DRIVER_NOT_BACKUP == s  || ST_CAN_UPDATE == s || ST_NOT_INSTALL == s ? true : false);
                 }
             }
             break;


### PR DESCRIPTION
修复一键安装时点击取消不能终止流程

Log: 修复一键安装时点击取消不能终止流程

Bug: https://pms.uniontech.com/bug-view-226819.html