### PR TITLE
fix: 一键安装时安装失败后无法重新全选

### DIFF
--- a/deepin-devicemanager/src/Page/PageDriverInstallInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverInstallInfo.cpp
@@ -260,6 +260,11 @@ void PageDriverInstallInfo::setCheckedCBDisnable()
     mp_ViewCanUpdate->setCheckedCBDisnable();
 }
 
+void PageDriverInstallInfo::setHeaderCbEnable(bool enable)
+{
+    mp_ViewNotInstall->setHeaderCbEnable(enable);
+    mp_ViewCanUpdate->setHeaderCbEnable(enable);
+}
 void PageDriverInstallInfo::slotDownloadProgressChanged(DriverType type, QString size, QStringList msg)
 {
     // 将下载过程时时更新到表格上方的状态里面 qInfo() << "Download ********** " << msg[0] << " , " << msg[1] << " , " << msg[2];

--- a/deepin-devicemanager/src/Page/PageDriverInstallInfo.h
+++ b/deepin-devicemanager/src/Page/PageDriverInstallInfo.h
@@ -62,6 +62,11 @@ public:
      */
     void setCheckedCBDisnable();
 
+    /**
+     * @brief setHeaderCbEnable 设置表头checkbox状态
+     */
+    void setHeaderCbEnable(bool enable);
+
 public slots:
     /**
      * @brief slotDownloadProgressChanged 下载进度刷新

--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -315,6 +315,7 @@ void PageDriverManager::slotInstallProgressFinished(bool bsuccess, int err)
     // 成功
     if (bsuccess) {
         successNum += 1;
+        m_ListUpdateIndex.removeAt(m_ListUpdateIndex.indexOf(m_CurIndex));
     } else { // 失败
         // 通知网络错误
         if (err == EC_NOTIFY_NETWORK) {
@@ -358,6 +359,11 @@ void PageDriverManager::slotInstallProgressFinished(bool bsuccess, int err)
             mp_DriverInstallInfoPage->headWidget()->setInstallFailedUI();
         }
 
+        if (m_ListUpdateIndex.isEmpty()) {
+            mp_DriverInstallInfoPage->setHeaderCbEnable(false);
+        } else {
+            mp_DriverInstallInfoPage->setHeaderCbEnable(true);
+        }
         mp_DriverInstallInfoPage->headWidget()->setReDetectEnable(true);
         mp_DriverBackupInfoPage->headWidget()->setReDetectEnable(true);
         mp_DriverRestoreInfoPage->headWidget()->setReDetectEnable(true);
@@ -389,7 +395,7 @@ void PageDriverManager::slotBackupAllDrivers()
 
 void PageDriverManager::slotScanFinished(ScanResult sr)
 {
-    // testDevices();
+//     testDevices();
 
     if (SR_SUCESS == sr) {
         foreach (DriverInfo *info, m_ListDriverInfo) {

--- a/deepin-devicemanager/src/Page/PageDriverRestoreInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverRestoreInfo.cpp
@@ -96,6 +96,7 @@ void PageDriverRestoreInfo::initUI()
     mp_GotoBackupSgButton->setText(tr("Go to Backup Driver"));
     mp_GotoBackupSgButton->setFixedWidth(310);
     mp_GotoBackupSgButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    mp_GotoBackupSgButton->setFocusPolicy(Qt::NoFocus);
 
     noRestoreMainLayout->addStretch();
     noRestoreMainLayout->addWidget(picLabel);
@@ -170,7 +171,6 @@ void PageDriverRestoreInfo::showTables(int backedLength)
         mp_StackWidget->setCurrentIndex(0);
     } else {
         mp_StackWidget->setCurrentIndex(1);
-
     }
 }
 


### PR DESCRIPTION
修复一键安装时安装失败后无法重新全选，还原页面焦点异常问题

Log: 修复一键安装时安装失败后无法重新全选

Bug: https://pms.uniontech.com/bug-view-226817.html
     https://pms.uniontech.com/bug-view-226831.html