### PR TITLE
fix: 待机后不能通过PS2鼠标唤醒

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -399,8 +399,21 @@ bool DeviceInput::isWakeupMachine()
         return false;
     }
     QString info = file.readAll();
-    if (info.contains("disabled"))
-        return false;
+
+    if (m_Name.contains("PS/2")) {
+//        QStringList lines = info.split("\n");
+//        for (QString line : lines) {
+//            if (line.startsWith("PS2M" && line.contains("disabled"))) {
+//                return false;
+//            }
+        // /proc/acpi/wakeup文件中状态未刷新，ps2设备通过dbus获取状态
+        return DBusWakeupInterface::getInstance()->isInputWakeupMachine(m_SysPath, m_Name);
+
+    } else {
+        if (info.contains("disabled"))
+            return false;
+    }
+
     return true;
 }
 
@@ -410,7 +423,12 @@ QString DeviceInput::wakeupPath()
     if (index < 1) {
         return "";
     }
-    return QString("/sys") + m_SysPath.left(index) + QString("/power/wakeup");
+
+    if (m_Name.contains("PS/2")) {
+        return "/proc/acpi/wakeup";
+    } else {
+        return QString("/sys") + m_SysPath.left(index) + QString("/power/wakeup");
+    }
 }
 
 const QString &DeviceInput::wakeupID()

--- a/deepin-devicemanager/src/Page/PageSingleInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageSingleInfo.cpp
@@ -349,7 +349,7 @@ void PageSingleInfo::slotWakeupMachine()
     // 键盘鼠标唤醒机器
     DeviceInput *input = qobject_cast<DeviceInput *>(mp_Device);
     if (input && !input->wakeupID().isEmpty() && !input->sysPath().isEmpty()) {
-        DBusWakeupInterface::getInstance()->setWakeupMachine(input->wakeupID(), input->sysPath(), mp_WakeupMachine->isChecked());
+        DBusWakeupInterface::getInstance()->setWakeupMachine(input->wakeupID(), input->sysPath(), mp_WakeupMachine->isChecked(), input->name());
     }
 
     // 网卡的远程唤醒

--- a/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.h
+++ b/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.h
@@ -40,7 +40,7 @@ public:
      * @param wakeup 可唤醒 不可唤醒
      * @return
      */
-    bool setWakeupMachine(const QString &unique_id, const QString &path, bool wakeup);
+    bool setWakeupMachine(const QString &unique_id, const QString &path, bool wakeup, const QString &name);
 
     /**
      * @brief canWakeupMachine 获取input是否支持唤醒
@@ -54,7 +54,7 @@ public:
      * @param path 设备节点路径
      * @return
      */
-    bool isInputWakeupMachine(const QString &path);
+    bool isInputWakeupMachine(const QString &path, const QString &name);
 
     /**
      * @brief isNetworkWakeup 获取网卡是否支持远程唤醒

--- a/deepin-devicemanager/src/Widget/TextBrowser.cpp
+++ b/deepin-devicemanager/src/Widget/TextBrowser.cpp
@@ -111,7 +111,7 @@ void TextBrowser::setWakeupMachine(bool wakeup)
     // 键盘鼠标唤醒机器
     DeviceInput *input = qobject_cast<DeviceInput*>(mp_Info);
     if(input && !input->wakeupID().isEmpty() && !input->sysPath().isEmpty()){
-        DBusWakeupInterface::getInstance()->setWakeupMachine(input->wakeupID(),input->sysPath(),wakeup);
+        DBusWakeupInterface::getInstance()->setWakeupMachine(input->wakeupID(),input->sysPath(),wakeup, input->name());
     }
 
     // 网卡的远程唤醒


### PR DESCRIPTION
修复待机后不能通过PS2鼠标唤醒

Log: 修复待机后不能通过PS2鼠标唤醒

Bug: https://pms.uniontech.com/bug-view-219597.html