### PR TITLE
fix: 部分设备“物理ID”和“模块别名”重复显示

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
@@ -328,8 +328,6 @@ void DeviceAudio::loadBaseDeviceInfo()
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name);
     addBaseDeviceInfo(tr("Vendor"), m_Vendor);
-    addBaseDeviceInfo(tr("Module Alias"), m_Modalias);
-    addBaseDeviceInfo(tr("Physical ID"), m_PhysID);
     addBaseDeviceInfo(tr("SysFS_Path"), m_SysPath);
     addBaseDeviceInfo(tr("Description"), m_Description);
     addBaseDeviceInfo(tr("Revision"), m_Version);

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -512,8 +512,6 @@ void DeviceStorage::loadBaseDeviceInfo()
 void DeviceStorage::loadOtherDeviceInfo()
 {
     // 添加其他信息,成员变量
-    addOtherDeviceInfo(tr("Module Alias"), m_Modalias);
-    addOtherDeviceInfo(tr("Physical ID"), m_PhysID);
     addOtherDeviceInfo(tr("Firmware Version"), m_FirmwareVersion);
     addOtherDeviceInfo(tr("Speed"), m_Speed);
     addOtherDeviceInfo(tr("Description"), m_Description);


### PR DESCRIPTION
修复部分设备 “物理ID”和“模块别名”重复显示

Log: 修复部分设备 “物理ID”和“模块别名”重复显示

Bug: https://pms.uniontech.com/bug-view-228921.html