### PR TITLE
fix: 修复当为PS2键盘置灰允许唤起电脑该功能

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -383,7 +383,7 @@ bool DeviceInput::enable()
 
 bool DeviceInput::canWakeupMachine()
 {
-    if (m_WakeupID.isEmpty())
+    if (m_WakeupID.isEmpty() || (m_HardwareClass == "keyboard" && "PS/2" == m_Interface))
         return false;
     QFile file(wakeupPath());
     if (!file.open(QIODevice::ReadOnly)) {


### PR DESCRIPTION
 修复当为PS2键盘置灰允许唤起电脑该功能

Log:  修复当为PS2键盘置灰允许唤起电脑该功能

Bug: https://pms.uniontech.com/bug-view-237867.html