### PR TITLE
fix: 修复驱动扫描过程中必现设备管理器窗口崩溃

### DIFF
--- a/deepin-devicemanager/src/DriverControl/DriverScanner.cpp
+++ b/deepin-devicemanager/src/DriverControl/DriverScanner.cpp
@@ -38,10 +38,12 @@ void DriverScanner::run()
 
                 QString output = process.readAllStandardOutput();
                 QStringList lines = output.split("\n");
-                QRegExp rxlen("(\\d+\\S*)");
-                int pos = rxlen.indexIn(lines[1]);
-                if (pos > -1 && info->version().isEmpty()) {
-                    info->m_Version = rxlen.cap(1);
+                if(lines.size()>=2) {
+                    QRegExp rxlen("(\\d+\\S*)");
+                    int pos = rxlen.indexIn(lines[1]);
+                    if (pos > -1 && info->version().isEmpty()) {
+                        info->m_Version = rxlen.cap(1);
+                    }
                 }
             }
 


### PR DESCRIPTION
 aptupdate前驱动扫描过程中必现设备管理器窗口崩溃

Log:  aptupdate前驱动扫描过程中必现设备管理器窗口崩溃

Bug: https://pms.uniontech.com/bug-view-238513.html