### PR TITLE
fix: “硬件信息”页面快速点击左侧导航栏后，点击界面上方的“驱动管理”，应用会发生闪退

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -125,6 +125,7 @@ void DeviceManager::clear()
     m_ListDeviceGPU.clear();
     m_ListDeviceMemory.clear();
     m_ListDeviceCPU.clear();
+    m_DeviceClassMap.clear();
 }
 
 const QList<QPair<QString, QString>> &DeviceManager::getDeviceTypes()


### PR DESCRIPTION
修复“硬件信息”页面快速点击左侧导航栏后，点击界面上方的“驱动管理”，应用会发生闪退

Log: 修复“硬件信息”页面快速点击左侧导航栏后，点击界面上方的“驱动管理”，应用会发生闪退

Bug: https://pms.uniontech.com/bug-view-243127.html