### PR TITLE
fix: 仓库未更新时无法备份驱动

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
@@ -324,10 +324,18 @@ bool ControlInterface::backupDeb(const QString &debpath)
 
 bool ControlInterface::delDeb(const QString &debname)
 {
-        if (!getUserAuthorPasswd()) {
-            return false;
-        }
+    if (!getUserAuthorPasswd()) {
+        return false;
+    }
     return  mp_drivermanager->delDeb(debname);
+}
+
+bool ControlInterface::aptUpdate()
+{
+    if (!getUserAuthorPasswd()) {
+        return false;
+    }
+    return  mp_drivermanager->aptUpdate();
 }
 
 #endif

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.h
@@ -138,6 +138,7 @@ public slots:
     Q_SCRIPTABLE bool unInstallPrinter(const QString &vendor, const QString &model);
     Q_SCRIPTABLE bool backupDeb(const QString &debpath); //debpath格式须是： “/tmp/xx/debname
     Q_SCRIPTABLE bool delDeb(const QString &debname);
+    Q_SCRIPTABLE bool aptUpdate();
 
 #endif
 

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.cpp
@@ -711,6 +711,22 @@ bool DriverManager::delDeb(const QString &debname)
     return (!destdir.exists());
 }
 
+bool DriverManager::aptUpdate()
+{
+    QProcess process;
+    /* connect(&process, &QProcess::readyReadStandardOutput, this, [&](){
+        QByteArray outArry = process.readAllStandardOutput();
+        QList<QString> lines = QString(outArry).split('\n', QString::SkipEmptyParts);
+        for (const QString &line : qAsConst(lines)) {
+            // qDebug() << line;
+            // error handling...
+        }
+    }); */
+    process.start("apt update");
+    process.waitForFinished(-1);
+    return true;
+}
+
 /**
  * @brief DriverManager::backupDeb backup 驱动
  * @param modulename 驱动deb模块名

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.h
@@ -53,6 +53,7 @@ public:
     bool isDebValid(const QString &filePath);
     bool backupDeb(const QString &debpath);
     bool delDeb(const QString &debname);
+    bool aptUpdate();
 
 private:
     void initConnections();

--- a/deepin-devicemanager/src/DriverControl/DBusDriverInterface.cpp
+++ b/deepin-devicemanager/src/DriverControl/DBusDriverInterface.cpp
@@ -92,6 +92,13 @@ bool DBusDriverInterface::delDeb(const QString &debname)
     return reply.value();
 }
 
+bool DBusDriverInterface::aptUpdate()
+{
+    QDBusReply<bool> reply = mp_Iface->call("aptUpdate");
+
+    return reply.value();
+}
+
 DBusDriverInterface::DBusDriverInterface(QObject *parent)
     : QObject(parent)
     , mp_Iface(nullptr)

--- a/deepin-devicemanager/src/DriverControl/DBusDriverInterface.h
+++ b/deepin-devicemanager/src/DriverControl/DBusDriverInterface.h
@@ -96,6 +96,12 @@ public:
          */
     bool delDeb(const QString &debname);
 
+    /**
+     * @brief aptUpdate apt update
+     * @return
+     */
+    bool aptUpdate();
+
 signals:
     void processChange(qint32 value, QString details);
     void processEnd(bool sucess, QString msg);

--- a/deepin-devicemanager/src/DriverControl/DriverBackupThread.cpp
+++ b/deepin-devicemanager/src/DriverControl/DriverBackupThread.cpp
@@ -12,6 +12,8 @@
 // 备份临时路径
 #define DB_PATH_TMP "/tmp/deepin-devicemanager"
 
+static bool updateFlag = false;
+
 DriverBackupThread::DriverBackupThread(QObject *parent)
     : QThread(parent)
     , mp_driverInfo(nullptr)
@@ -39,6 +41,16 @@ void DriverBackupThread::run()
         if (m_isStop) {
             emit backupProgressFinished(false);
             return;
+        }
+
+        if(!updateFlag) {
+            bool ret = DBusDriverInterface::getInstance()->aptUpdate();
+            updateFlag = true;
+            if (!ret) {
+                emit backupProgressFinished(false);
+                qInfo() << "apt update failed.";
+                return;
+            }
         }
 
         QStringList options;


### PR DESCRIPTION
修复仓库未更新时无法下载驱动进行备份

Log: 修复仓库未更新时无法下载驱动进行备份

https://pms.uniontech.com/bug-view-242971.html