### PR TITLE
fix:  由deepin-service-manager 控制延时3秒启动服务端

### DIFF
--- a/deepin-devicemanager-server/deepin-deviceinfo/deepin-deviceinfo.json
+++ b/deepin-devicemanager-server/deepin-deviceinfo/deepin-deviceinfo.json
@@ -3,5 +3,6 @@
     "libPath": "deepin-deviceinfo.so",
     "group": "app",
     "policyStartType": "Resident",
+    "startDelay": 3,
     "pluginType": "qt"
 }


### PR DESCRIPTION
 由deepin-service-manager 控制延时3秒启动

Log:  由deepin-service-manager 控制延时3秒启动

Bug: https://pms.uniontech.com/bug-view-238905.html