### PR TITLE
fix: the overflow bug of the stack in deepin-devicemanager

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enableutils.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enableutils.cpp
@@ -152,7 +152,7 @@ bool EnableUtils::ioctlOperateNetworkLogicalName(const QString &logicalName, boo
     if (fd < 0)
         return false;
     struct ifreq ifr;
-    strcpy(ifr.ifr_name, logicalName.toStdString().c_str());
+    strncpy(ifr.ifr_name, logicalName.toStdString().c_str(),strlen(ifr.ifr_name));
 
     short flag;
     if (enable) {


### PR DESCRIPTION
ioctlEnableNetwork-> ioctlOperateNetworkLogicalName, in this function directly to the user input parameter path, strcpy gives ifr.ifr_name a stack overflow

Log: overflow bug (strcpy)
Bug: https://pms.uniontech.com/bug-view-253863.html