### PR TITLE
fix: 鼠标在不能用的情况下，解决能用鼠标唤醒的问题

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -349,6 +349,7 @@ const QString DeviceInput::getOverviewInfo()
  *
  * 修改：修改触摸板禁用方法，改为调用daemon提供的接口
  */
+
 EnableDeviceStatus DeviceInput::setEnable(bool e)
 {
     if (m_Name.contains("Touchpad", Qt::CaseInsensitive)) {
@@ -362,6 +363,15 @@ EnableDeviceStatus DeviceInput::setEnable(bool e)
 
         if (m_UniqueID.isEmpty() || m_SysPath.isEmpty()) {
             return EDS_Faild;
+        }
+        if(e){
+            if(isWakeupMachine()){
+                DBusWakeupInterface::getInstance()->setWakeupMachine(wakeupID(), sysPath(), false, name());
+                m_wakeupChanged = true;
+            }
+        } else if (m_wakeupChanged) {
+            m_wakeupChanged = false;
+            DBusWakeupInterface::getInstance()->setWakeupMachine(wakeupID(), sysPath(), true, name());
         }
         bool res  = DBusEnableInterface::getInstance()->enable(m_HardwareClass, m_Name, m_SysPath, m_UniqueID, e, m_Driver);
         if (res) {

--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.h
@@ -184,8 +184,10 @@ private:
     QString             m_KeyToLshw;                    //<!
     QString             m_WakeupID;                     //<!  wakeup id
     bool                m_BluetoothIsConnected;         //<!  记录蓝牙的连接状态
+    bool                m_wakeupChanged = true;                //<!   记录鼠标的唤醒状态
 
     QString             m_keysToPairedDevice;           //<! 【用来标识蓝牙键盘】
+    
 };
 
 #endif // DEVICEINPUT_H


### PR DESCRIPTION
鼠标在不能用的情况下，解决能用鼠标唤醒的问题

Log: 记录状态，禁用之前，将唤醒能力关掉;启动时，再将唤醒能力打开。
Bug: https://pms.uniontech.com/bug-view-254187.html