### PR TITLE
fix: the overflow bug of the stack in deepin-devicemanager

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enableutils.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enableutils.cpp
@@ -152,8 +152,8 @@ bool EnableUtils::ioctlOperateNetworkLogicalName(const QString &logicalName, boo
     if (fd < 0)
         return false;
     struct ifreq ifr;
-    strncpy(ifr.ifr_name, logicalName.toStdString().c_str(),strlen(ifr.ifr_name));
-
+    strncpy(ifr.ifr_name, logicalName.toStdString().c_str(),IFNAMSIZ);
+    ifr.ifr_name[IFNAMSIZ - 1] = '\0';
     short flag;
     if (enable) {
         flag = IFF_UP | IFF_PROMISC;


### PR DESCRIPTION
ioctlEnableNetwork-> ioctlOperateNetworkLogicalName, in this function directly to the user input parameter path, strcpy gives ifr.ifr_name a stack overflow

Log: overflow bug (strcpy) (latest change)
Bug: https://pms.uniontech.com/bug-view-253863.html