### PR TITLE
fix: 增加UPower服务的刷新接口，解决电池状态显示延迟

### DIFF
--- a/deepin-devicemanager/src/Page/MainWindow.h
+++ b/deepin-devicemanager/src/Page/MainWindow.h
@@ -12,6 +12,9 @@
 #include <DMainWindow>
 #include <DStackedWidget>
 #include <DButtonBox>
+#include <qdbusconnection.h>
+#include <QDBusInterface>
+#include <QDBusReply>
 
 #include <QObject>
 
@@ -39,6 +42,11 @@ public:
      * @brief refresh:界面刷新
      */
     void refresh();
+
+    /**
+     * @brief refreshBatteryStatus:刷新电池状态
+     */
+    void refreshBatteryStatus();
 
     /**
      * @brief exportTo:导出设备信息


### PR DESCRIPTION
增加UPower服务的刷新接口，解决电池状态显示延迟

Log: 增加UPower服务的刷新接口，解决电池状态显示延迟
Bug: https://pms.uniontech.com/bug-view-254185.html