### PR TITLE
fix: printer and scanner driver updates disabled

### DIFF
--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -679,9 +679,9 @@ void PageDriverManager::scanDevices()
 //    scanDevicesInfo(QObject::tr("Camera"), DR_Camera);
 
     // 打印机
-    scanDevicesInfo(QObject::tr("Printer"), DR_Printer);
+//    scanDevicesInfo(QObject::tr("Printer"), DR_Printer); //由于task 353401 要求
 
-    scanDevicesInfo(QObject::tr("Other Devices"), DR_OtherDevice);
+//    scanDevicesInfo(QObject::tr("Other Devices"), DR_OtherDevice); //由于task 353401 要求
 }
 
 void PageDriverManager::testScanDevices()


### PR DESCRIPTION
Printer or scanner drivers will not be updated,【 Driver Management 】 The interface does not display printer and scanner information

Log: Printer and scanner driver updates disabled
Task: https://pms.uniontech.com/task-view-353401.html