### PR TITLE
fix:  修复卸载驱动会弹出未发现该驱动模块错误

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
@@ -186,15 +186,14 @@ bool DeviceAudio::setInfoFrom_sysFS(QMap<QString, QString> &mapInfo, int ii)
     mapInfo.insert("VID_PID", m_VID_PID);
     mapInfo.insert("SysFS ID", m_SysPath);
     mapInfo.insert("chip", m_Chip);
-    return true;
-    //----------------
+
     //2. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
 
     // 设置不可禁用
     m_CanEnable = false;
     m_CanUninstall = false;
-
+    return true;
 }
 
 bool DeviceAudio::setInfoFromCatDevices(const QMap<QString, QString> &mapInfo)


### PR DESCRIPTION
 修复部分设备sysfs的设备设置驱动信息

Log: 修复部分设备卸载驱动时问题

Bug: https://pms.uniontech.com/bug-view-262223.html