### PR TITLE
fix:  修复其它设备中不可用情况

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
@@ -95,6 +95,8 @@ void DeviceOthers::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
         m_CanUninstall = false;
     }
     setAttribute(mapInfo, "cfg_avail", m_Avail);
+    if(!m_Avail.compare("yes", Qt::CaseInsensitive))
+        setForcedDisplay(true);
 
     getOtherMapInfo(mapInfo);
     // 核内驱动不显示卸载菜单


### PR DESCRIPTION
 依据hwinfo的"cfg_avail=yes"作可用

Log: 修复其它设备中指纹不可用

Bug: https://pms.uniontech.com/bug-view-262721.html