### PR TITLE
fix: 禁用USB设备再重启启用后显示不可用

### DIFF
--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -600,6 +600,7 @@ void MainWindow::slotListItemClicked(const QString &itemStr)
 
 void MainWindow::slotRefreshInfo()
 {
+    refreshDataBaseLater();
     // 界面刷新
     refresh();
 }


### PR DESCRIPTION
 禁用USB设备退出重启应用

Log:  显示不可用

Bug: https://pms.uniontech.com/bug-view-269251.html