### PR TITLE
fix:  adpator V23 dde for PS2 mouse wakeup

### DIFF
--- a/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.cpp
+++ b/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.cpp
@@ -18,9 +18,15 @@ std::mutex DBusWakeupInterface::m_mutex;
 const QString SERVICE_NAME = "org.deepin.DeviceControl";
 const QString WAKEUP_SERVICE_PATH = "/org/deepin/DeviceControl";
 const QString WAKEUP_INTERFACE = "org.deepin.DeviceControl";
+#ifdef OS_BUILD_V23
+const QString INPUT_SERVICE_NAME = "org.deepin.dde.InputDevices1";
+const QString INPUT_WAKEUP_SERVICE_PATH = "/org/deepin/dde/InputDevices1";
+const QString INPUT_WAKEUP_INTERFACE = "org.deepin.dde.InputDevices1";
+#else
 const QString INPUT_SERVICE_NAME = "com.deepin.system.InputDevices";
 const QString INPUT_WAKEUP_SERVICE_PATH = "/com/deepin/system/InputDevices";
 const QString INPUT_WAKEUP_INTERFACE = "com.deepin.system.InputDevices";
+#endif
 const QString INPUT_WAKEUP_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties";
 
 DBusWakeupInterface::DBusWakeupInterface()

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -14,6 +14,7 @@
 #include <QProcess>
 #include <QFile>
 #include <QLoggingCategory>
+#include <QRegularExpression>
 
 #include <sys/utsname.h>
 


### PR DESCRIPTION
 adpator V23 dde for PS2 mouse wakeup

Log:  adpator V23 dde for PS2 mouse wakeup

Bug: https://pms.uniontech.com/bug-view-271823.html