### PR TITLE
fix: Resolve the issue of empty device information display

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,0 @@
-etc/systemd/system/deepin-service-group@.service.d/*

--- a/debian/rules
+++ b/debian/rules
@@ -17,8 +17,5 @@ override_dh_auto_configure:
 %:
 	dh $@
 
-override_dh_auto_install:
-	dh_auto_install --destdir=debian/tmp
-
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info


### PR DESCRIPTION
   1.Resolve the issue of empty device information display
   2.Fix the issue of incomplete packaging content in the deb package

Log: Fix the issue of incomplete packaging content in the deb package
Bug: https://pms.uniontech.com/bug-view-281813.html