### PR TITLE
fix: the camera info show incorrect

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceImage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceImage.cpp
@@ -18,6 +18,7 @@ DeviceImage::DeviceImage()
 {
     m_CanEnable = true;
     m_CanUninstall = true;
+    m_forcedDisplay = true;
 }
 
 void DeviceImage::setInfoFromLshw(const QMap<QString, QString> &mapInfo)


### PR DESCRIPTION
fix the camera info show incorrect

Log: fix the camera info show incorrect

Bug: https://pms.uniontech.com/bug-view-290539.html