### PR TITLE
fix: optimize GPU device display and resolution parsing

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
@@ -90,7 +90,7 @@ void DeviceGpu::setLshwInfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "memory", m_MemAddress);
     // setAttribute(mapInfo, "physical id", m_PhysID);
 
-    if (driverIsKernelIn(m_Driver)) {
+    if (driverIsKernelIn(m_Driver) || m_Driver.isEmpty()) {
         m_CanUninstall = false;
     }
 
@@ -149,7 +149,7 @@ bool DeviceGpu::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "VID_PID", m_VID_PID);
     m_PhysID = m_VID_PID;
 
-    if (driverIsKernelIn(m_Driver)) {
+    if (driverIsKernelIn(m_Driver) || m_Driver.isEmpty()) {
         m_CanUninstall = false;
     }
 

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -591,6 +591,7 @@ void DeviceGenerator::getGpuInfoFromHwinfo()
             continue;
 
         DeviceGpu *device = new DeviceGpu();
+        device->setForcedDisplay(true);
         device->setHwinfoInfo(*it);
         DeviceManager::instance()->addGpuDevice(device);
         addBusIDFromHwinfo((*it)["SysFS BusID"]);

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -75,7 +75,7 @@ void ThreadExecXrandr::loadXrandrInfo(QList<QMap<QString, QString>> &lstMap, con
     foreach (const QString &line, lines) {
         if (line.startsWith("Screen")) {
             lstMap.append(QMap<QString, QString>());
-            QRegularExpression re(".*([0-9]{1,5}\\sx\\s[0-9]{1,5}).*([0-9]{1,5}\\sx\\s[0-9]{1,5}).*([0-9]{1,5}\\sx\\s[0-9]{1,5}).*");
+            QRegularExpression re(".*\\s([0-9]{1,5}\\sx\\s[0-9]{1,5}).*\\s([0-9]{1,5}\\sx\\s[0-9]{1,5}).*\\s([0-9]{1,5}\\sx\\s[0-9]{1,5}).*");
             QRegularExpressionMatch match = re.match(line);
             if (match.hasMatch()) {
                 lstMap[lstMap.count() - 1].insert("minResolution", match.captured(1));


### PR DESCRIPTION
- Fix resolution parsing regex pattern in xrandr info
- Add empty driver check for GPU uninstall status
- Force display GPU devices from hwinfo

Log: optimize GPU device display and resolution parsing
Bug: https://pms.uniontech.com/bug-view-290469.html