### PR TITLE
chore: centralize Qt6 version declaration and cleanup dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ if(CMAKE_BUILD_TYPE  STREQUAL "Debug")
     add_definitions(-DDISABLE_POLKIT)
 endif()
 
+# 设置 QT_VERSION 变量
+set(QT_VERSION_MAJOR 6)
+
 add_subdirectory(${CMAKE_SOURCE_DIR}/deepin-devicemanager)
 add_subdirectory(${CMAKE_SOURCE_DIR}/deepin-devicemanager-server)
 

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends: debhelper (>= 11),
  libqapt3-qt6-runtime,
  libpolkit-qt6-1-dev,
  deepin-desktop-base,
- libdeepin-service-framework-dev,
+ libdeepin-service-framework-dev (> 1.0.9),
  qt6-base-dev,
  qt6-base-dev-tools,
  qt6-base-private-dev,
@@ -24,18 +24,7 @@ Build-Depends: debhelper (>= 11),
  libdtk6widget-dev,
  libdtk6core-dev,
  qt6-svg-dev,
- qtbase5-dev,
- libqt6sql6,
- libdtkwidget-dev,
- libdtkgui-dev,
- qtbase5-private-dev,
- libdtkcore-dev (>= 5.2.2.2),
- libqapt-dev,
- libqapt3-runtime,
- libpolkit-qt5-1-dev,
- qttools5-dev,
- qttools5-dev-tools,
- libqt5sql5
+ libqt6sql6
 Standards-Version: 4.1.3
 
 Package: deepin-devicemanager

--- a/deepin-devicemanager-server/CMakeLists.txt
+++ b/deepin-devicemanager-server/CMakeLists.txt
@@ -3,8 +3,6 @@ project(deepin-devicemanager-server C CXX)
 add_subdirectory(deepin-deviceinfo)
 add_subdirectory(deepin-devicecontrol)
 
-set(QT_VERSION_MAJOR 5)
-
 #TEST--------------------------------------------------
 if (CMAKE_COVERAGE_ARG STREQUAL "CMAKE_COVERAGE_ARG_ON")
    add_subdirectory(./tests)

--- a/deepin-devicemanager-server/deepin-devicecontrol/CMakeLists.txt
+++ b/deepin-devicemanager-server/deepin-devicecontrol/CMakeLists.txt
@@ -31,9 +31,6 @@ endforeach()
 
 file(GLOB_RECURSE SRC_CPP ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
 file(GLOB_RECURSE SRC_H ${CMAKE_CURRENT_LIST_DIR}/src/*.h)
-
-# 设置 QT_VERSION 变量
-set(QT_VERSION_MAJOR 5)
   
 macro(SET_QT_VERSION)
   if(${QT_VERSION_MAJOR} EQUAL 6)

--- a/deepin-devicemanager-server/deepin-deviceinfo/CMakeLists.txt
+++ b/deepin-devicemanager-server/deepin-deviceinfo/CMakeLists.txt
@@ -34,9 +34,6 @@ file(GLOB_RECURSE SRC_H ${CMAKE_CURRENT_LIST_DIR}/src/*.h)
 
 link_libraries("udev")
 
-# 设置 QT_VERSION 变量
-set(QT_VERSION_MAJOR 5)
-
 # 定义一个宏来根据QT_VERSION选择性执行代码
 macro(SET_QT_VERSION)
   if(${QT_VERSION_MAJOR} EQUAL 6)

--- a/deepin-devicemanager-server/tests/CMakeLists.txt
+++ b/deepin-devicemanager-server/tests/CMakeLists.txt
@@ -46,9 +46,6 @@ endforeach()
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 
-# 设置 QT_VERSION 变量
-set(QT_VERSION_MAJOR 5)
-
 # 定义一个宏来根据QT_VERSION选择性执行代码
 macro(SET_QT_VERSION)
   if(${QT_VERSION_MAJOR} EQUAL 6)

--- a/deepin-devicemanager/CMakeLists.txt
+++ b/deepin-devicemanager/CMakeLists.txt
@@ -59,9 +59,6 @@ if (MAJOR_VERSION MATCHES "23")
     add_definitions(-DOS_BUILD_V23)
 endif()
 
-# 设置 QT_VERSION_MAJOR 变量
-set(QT_VERSION_MAJOR 6)
-
 #compile flags
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra")


### PR DESCRIPTION
* Move QT_VERSION_MAJOR=6 to root CMakeLists.txt
* Remove redundant QT_VERSION_MAJOR declarations from sub-projects
* Remove Qt5 related dependencies
* Update libdeepin-service-framework-dev to version >1.0.9

Log: centralize Qt6 version declaration and cleanup dependencies