### PR TITLE
feat: migrate driver installation from deb to apt

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/aptinstaller.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/aptinstaller.cpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2019 ~ 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "aptinstaller.h"
+#include "utils.h"
+#include "DDLog.h"
+
+#include <QTimer>
+#include <QRegularExpression>
+#include <QFileInfo>
+
+using namespace DDLog;
+
+AptInstaller::AptInstaller(QObject *parent)
+    : QObject(parent)
+    , m_process(new QProcess(this))
+    , m_bValid(true)
+    , m_iRuningTestCount(0)
+{
+    // 连接进程信号
+    connect(m_process, &QProcess::readyReadStandardOutput, this, [this]() {
+        QString output = QString::fromLocal8Bit(m_process->readAllStandardOutput());
+        parseAptOutput(output);
+    });
+    
+    connect(m_process, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
+            this, [this](int exitCode, QProcess::ExitStatus exitStatus) {
+        bool success = (exitCode == 0 && exitStatus == QProcess::NormalExit);
+        emit installFinished(success);
+        if (!success) {
+            emit errorOccurred(QString("Process failed with exit code: %1").arg(exitCode));
+        }
+    });
+}
+
+bool AptInstaller::isValid()
+{
+    return m_bValid;
+}
+
+bool AptInstaller::isArchMatched(const QString &path)
+{
+    QProcess process;
+    process.start("dpkg", {"-I", path});
+    process.waitForFinished();
+    
+    QString output = process.readAllStandardOutput();
+    QString systemArch = QSysInfo::currentCpuArchitecture();
+    
+    // 检查包的架构信息
+    QRegularExpression re("Architecture:\\s*(\\w+)");
+    auto match = re.match(output);
+    if (match.hasMatch()) {
+        QString pkgArch = match.captured(1);
+        return (pkgArch == "all" || pkgArch == systemArch);
+    }
+    return false;
+}
+
+bool AptInstaller::isDebValid(const QString &path)
+{
+    QFileInfo fileInfo(path);
+    if (!fileInfo.exists() || !path.endsWith(".deb")) {
+        return false;
+    }
+    
+    QProcess process;
+    process.start("dpkg", {"-I", path});
+    process.waitForFinished();
+    
+    return process.exitCode() == 0;
+}
+
+void AptInstaller::doOperate(const QString &package, bool isInstall)
+{
+    QStringList args;
+    if (isInstall) {
+        args << "install" << "-y" << package;
+    } else {
+        args << "remove" << "-y" << package;
+    }
+    
+    m_process->start("apt", args);
+}
+
+void AptInstaller::installPackage(const QString &filepath)
+{
+    if (Utils::isDpkgLocked()) {
+        if (m_iRuningTestCount < MAX_DPKGRUNING_TEST) {
+            QTimer::singleShot(TEST_TIME_INTERVAL, this, [this, filepath]() {
+                installPackage(filepath);
+                m_iRuningTestCount++;
+            });
+            return;
+        } else {
+            emit errorOccurred("Dpkg locked, time out");
+            emit installFinished(false);
+            return;
+        }
+    }
+    
+    if (!m_bValid) {
+        return;
+    }
+    
+    doOperate(filepath, true);
+}
+
+void AptInstaller::uninstallPackage(const QString &packagename)
+{
+    if (Utils::isFileLocked("/var/lib/dpkg/lock")) {
+        if (m_iRuningTestCount < MAX_DPKGRUNING_TEST) {
+            QTimer::singleShot(TEST_TIME_INTERVAL, this, [this, packagename]() {
+                uninstallPackage(packagename);
+                m_iRuningTestCount++;
+            });
+            return;
+        } else {
+            emit errorOccurred("Dpkg locked, time out");
+            emit installFinished(false);
+            return;
+        }
+    }
+    
+    doOperate(packagename, false);
+}
+
+void AptInstaller::parseAptOutput(const QString &output)
+{
+    // 解析apt输出以更新进度
+    static QRegularExpression progressRe("\\b(\\d+)%");
+    auto match = progressRe.match(output);
+    if (match.hasMatch()) {
+        int progress = match.captured(1).toInt();
+        emit progressChanged(progress);
+    }
+} 

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/aptinstaller.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/aptinstaller.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2019 ~ 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef APTINSTALLER_H
+#define APTINSTALLER_H
+
+#include <QObject>
+#include <QProcess>
+
+class AptInstaller : public QObject {
+    Q_OBJECT
+public:
+    explicit AptInstaller(QObject *parent = nullptr);
+    
+    // 检查是否可用
+    bool isValid();
+    
+    // 检查架构是否匹配
+    bool isArchMatched(const QString &path);
+    
+    // 检查deb包是否有效
+    bool isDebValid(const QString &path);
+
+public slots:
+    void installPackage(const QString &filepath);
+    void uninstallPackage(const QString &packagename);
+
+signals:
+    void installFinished(bool success);
+    void errorOccurred(const QString &errmsg);
+    void progressChanged(int progress);
+
+private:
+    void doOperate(const QString &package, bool isInstall);
+    bool checkDpkgLock();
+    void parseAptOutput(const QString &output);
+    
+private:
+    QProcess *m_process;
+    bool m_bValid;
+    int m_iRuningTestCount;
+    static const int MAX_DPKGRUNING_TEST = 20;
+    static const int TEST_TIME_INTERVAL = 2000;
+};
+
+#endif // APTINSTALLER_H 

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/driverinstallerapt.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/driverinstallerapt.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2019 ~ 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "driverinstallerapt.h"
+#include "utils.h"
+#include "DDLog.h"
+
+#include <QProcess>
+#include <QTimer>
+#include <QDebug>
+#include <unistd.h>
+#include <fstream>
+
+using namespace DDLog;
+
+const int MAX_DPKGRUNING_TEST = 20;
+const int TEST_TIME_INTERVAL = 2000;
+
+DriverInstallerApt::DriverInstallerApt(QObject *parent)
+    : QObject(parent)
+    , m_process(nullptr)
+    , m_iRuningTestCount(0)
+    , m_Cancel(false)
+{
+}
+
+DriverInstallerApt::~DriverInstallerApt()
+{
+    if (m_process) {
+        m_process->kill();
+        delete m_process;
+        m_process = nullptr;
+    }
+}
+
+void DriverInstallerApt::installPackage(const QString &package, const QString &version)
+{
+    // 检查dpkg是否正在运行
+    if (Utils::isDpkgLocked()) {
+        if (m_iRuningTestCount < MAX_DPKGRUNING_TEST) {
+            QTimer::singleShot(TEST_TIME_INTERVAL, this, [this, package, version] {
+                m_iRuningTestCount++;
+                installPackage(package, version);
+            });
+            return;
+        } else {
+            emit errorOccurred(0);
+            emit installProgressFinished(false);
+            return;
+        }
+    }
+
+    m_Cancel = false;
+    m_iRuningTestCount = 0;
+    doOperate(package, version);
+}
+
+void DriverInstallerApt::undoInstallDriver()
+{
+    m_Cancel = true;
+    if (m_process && m_process->state() == QProcess::Running) {
+        m_process->kill();
+        qCInfo(appLog) << "DRIVER_LOG **************************** 取消操作";
+    }
+}
+
+void DriverInstallerApt::aptClean()
+{
+    executeCommand("lastore-apt-clean");
+}
+
+QString DriverInstallerApt::executeCommand(const QString &cmd)
+{
+    QProcess process;
+    process.start("bash", QStringList() << "-c" << cmd);
+    process.waitForFinished();
+    return QString::fromUtf8(process.readAllStandardOutput());
+}
+
+void DriverInstallerApt::doOperate(const QString &package, const QString &version)
+{
+    // 清理apt缓存
+    aptClean();
+    
+    // 更新软件源
+    executeCommand("apt update");
+
+    // 检查包是否存在
+    QString checkCmd = QString("apt-cache show %1=%2").arg(package).arg(version);
+    if (executeCommand(checkCmd).isEmpty()) {
+        emit errorOccurred(1);  // 包不存在
+        qCInfo(appLog) << "DRIVER_LOG : ************************** 安装包不存在";
+        return;
+    }
+
+    // 创建安装进程
+    if (m_process) {
+        delete m_process;
+    }
+    m_process = new QProcess(this);
+
+    // 设置环境变量，避免交互
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.insert("DEBIAN_FRONTEND", "noninteractive");
+    m_process->setProcessEnvironment(env);
+
+    // 监控输出获取进度
+    connect(m_process, &QProcess::readyReadStandardOutput, this, [this] {
+        QString output = m_process->readAllStandardOutput();
+        if (output.contains("%")) {
+            QString progress = output.split("%").first();
+            progress = progress.split(" ").last().trimmed();
+            bool ok;
+            int progressValue = progress.toInt(&ok);
+            if (ok) {
+                emit installProgressChanged(progressValue);
+            }
+        }
+    });
+
+    // 监控安装结果
+    connect(m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this, package](int exitCode, QProcess::ExitStatus exitStatus) {
+        if (m_Cancel) {
+            emit errorOccurred(2);  // 用户取消
+        } else if (exitCode == 0) {
+            emit installProgressFinished(true);
+        } else {
+            if (package.contains("nvidia-driver")) {
+                emit installProgressFinished(true);
+            } else if (!isNetworkOnline()) {
+                emit errorOccurred(3);  // 网络错误
+            } else {
+                emit errorOccurred(0);  // 其他错误
+            }
+        }
+        qCInfo(appLog) << "DRIVER_LOG : ************************** 安装结束 退出码" << exitCode;
+    });
+
+    // 执行安装命令
+    QString cmd = QString("apt-get install -y %1=%2").arg(package).arg(version);
+    m_process->start("bash", QStringList() << "-c" << cmd);
+}
+
+bool DriverInstallerApt::isNetworkOnline(uint sec)
+{
+    QProcess process;
+    process.setStandardOutputFile("netlog.bat", QIODevice::WriteOnly);
+    process.start("ping", QStringList() << "www.baidu.com" << "-c" << "2" << "-w" << "2");
+    process.waitForFinished(-1);
+    
+    if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
+        return false;
+    }
+    
+    if (sec > 0) {
+        usleep(sec);
+    }
+
+    std::ifstream infile("netlog.bat");
+    std::string line;
+    std::vector<std::string> lines;
+    
+    while (std::getline(infile, line)) {
+        lines.push_back(line);
+    }
+    infile.close();
+
+    if (lines.size() > 1) {
+        std::string data = lines[lines.size() - 2];
+        size_t pos = data.find("received,");
+        if (pos != std::string::npos) {
+            data = data.substr(pos + 10, 3);
+            return atoi(data.c_str()) != 0;
+        }
+    }
+    return false;
+} 

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/driverinstallerapt.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/driverinstallerapt.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2019 ~ 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DISABLE_DRIVER
+
+#ifndef DRIVERINSTALLER_APT_H
+#define DRIVERINSTALLER_APT_H
+
+#include <QObject>
+
+class QProcess;
+
+class DriverInstallerApt : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DriverInstallerApt(QObject *parent = nullptr);
+    ~DriverInstallerApt();
+
+public slots:
+    /**
+     * @brief installPackage 安装包
+     * @param package 包名
+     * @param version 包版本
+     */
+    void installPackage(const QString &package, const QString &version);
+
+    /**
+     * @brief undoInstallDriver 停止任务
+     */
+    void undoInstallDriver();
+
+signals:
+    void errorOccurred(int error);
+    void installProgressChanged(int progress);//安装进度
+    void installProgressFinished(bool bsuccess);
+
+private:
+    /**
+     * @brief aptClean 清理apt缓存
+     */
+    void aptClean();
+
+    /**
+     * @brief isNetworkOnline 判断网络是否在线
+     * @param sec 超时时间（微秒）
+     * @return 是否在线
+     */
+    bool isNetworkOnline(uint sec = 2000000);
+
+    /**
+     * @brief doOperate 执行安装操作
+     * @param package 包名
+     * @param version 版本号
+     */
+    void doOperate(const QString &package, const QString &version);
+
+    /**
+     * @brief executeCommand 执行shell命令
+     * @param cmd 命令字符串
+     * @return 命令输出
+     */
+    QString executeCommand(const QString &cmd);
+
+private:
+    QProcess *m_process;        // apt进程指针
+    int m_iRuningTestCount;     // dpkg运行测试计数
+    bool m_Cancel;              // 取消标志
+};
+
+#endif // DRIVERINSTALLER_APT_H
+#endif // DISABLE_DRIVER 

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.h
@@ -14,8 +14,8 @@
 #include <cups.h>
 
 class ModCore;
-class DebInstaller;
-class DriverInstaller;
+class AptInstaller;
+class DriverInstallerApt;
 class QThread;
 
 class DriverManager : public QObject
@@ -75,9 +75,9 @@ signals:
 
 private:
     ModCore *mp_modcore = nullptr;
-    DebInstaller *mp_debinstaller = nullptr;
+    AptInstaller *mp_debinstaller = nullptr;
     QThread *mp_deboperatethread = nullptr;
-    DriverInstaller *mp_driverInstaller = nullptr;
+    DriverInstallerApt *mp_driverInstaller = nullptr;
     QThread *mp_driverOperateThread = nullptr;
 
     int m_installprocess = 0;

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enablesqlmanager.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enablesqlmanager.cpp
@@ -9,7 +9,7 @@
 #include <QLoggingCategory>
 #include <QDir>
 #include <QSqlError>
-#define DB_PATH "/usr/share/deepin-devicemanager/"
+#define DB_PATH "/var/lib/deepin-devicemanager/"
 #define DB_FILE "enable.db"
 #define DB_CONNECT_NAME "device-enable"
 #define DB_TABLE_AUTHORIZED "authorized"

--- a/deepin-devicemanager/src/DriverControl/DriverScanner.cpp
+++ b/deepin-devicemanager/src/DriverControl/DriverScanner.cpp
@@ -33,7 +33,7 @@ void DriverScanner::run()
             // 检测本地安装版本
             if (!info->packages().isEmpty()) {
                 QProcess process;
-                process.start("apt", QStringList()  << "policy " << info->packages());
+                process.start("apt", QStringList()  << "policy" << info->packages());
                 process.waitForFinished(-1);
 
                 QString output = process.readAllStandardOutput();

--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -890,7 +890,10 @@ void PageDriverManager::addToBackupIndex(int index)
 
 void PageDriverManager::removeFromDriverIndex(int index)
 {
-    m_ListDriverIndex.removeAt(m_ListDriverIndex.indexOf(index));
+    auto ret = m_ListDriverIndex.indexOf(index);
+    if (ret >= 0) {
+        m_ListDriverIndex.removeAt(ret);
+    }
 
     // 移除时 如果一个都没有 则一键安装按钮置灰
     if (m_ListDriverIndex.isEmpty()) {
@@ -900,7 +903,10 @@ void PageDriverManager::removeFromDriverIndex(int index)
 
 void PageDriverManager::removeFromBackupIndex(int index)
 {
-    m_ListBackupIndex.removeAt(m_ListBackupIndex.indexOf(index));
+    auto ret = m_ListBackupIndex.indexOf(index);
+    if (ret >= 0) {
+        m_ListBackupIndex.removeAt(ret);
+    }
 
     if (m_ListBackupIndex.isEmpty()) {
         mp_DriverBackupInfoPage->headWidget()->setBackupBtnEnable(false);

--- a/deepin-devicemanager/src/Tool/commontools.cpp
+++ b/deepin-devicemanager/src/Tool/commontools.cpp
@@ -160,5 +160,5 @@ QString CommonTools::getUrl()
 
 QString CommonTools::getBackupPath()
 {
-    return "/usr/share/deepin-devicemanager/";
+    return "/var/lib/deepin-devicemanager/";
 }


### PR DESCRIPTION
* Replace DebInstaller with AptInstaller for package management
* Replace DriverInstaller with DriverInstallerApt for driver installation
* Move database path from /usr/share to /var/lib for better FHS compliance
* Fix array index bounds checking in driver manager pages

Log: migrate driver installation from deb to apt
Task: https://pms.uniontech.com/task-view-373295.html