### PR TITLE
fix: update deviceinfo library name to standard lib prefix

### DIFF
--- a/deepin-devicemanager-server/deepin-deviceinfo/deepin-deviceinfo.json
+++ b/deepin-devicemanager-server/deepin-deviceinfo/deepin-deviceinfo.json
@@ -1,6 +1,6 @@
 {
     "name": "org.deepin.DeviceInfo",
-    "libPath": "deepin-deviceinfo.so",
+    "libPath": "libdeepin-deviceinfo.so",
     "group": "app",
     "policyStartType": "Resident",
     "startDelay": 3,


### PR DESCRIPTION
Change library name to follow standard naming convention

Log: update deviceinfo library name to standard lib prefix