### PR TITLE
feat: add V25 version support for driver repository

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/httpdriverinterface.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/httpdriverinterface.cpp
@@ -81,22 +81,45 @@ QString HttpDriverInterface::getRequestBoard(QString strManufacturer, QString st
         return QString();
     }
     QString arch = Common::getArchStore();
-    QString strUrl = Utils::getUrl() + "?arch=" + arch;
-    int iType = DTK_CORE_NAMESPACE::DSysInfo::uosType();
-    int iEditionType = DTK_CORE_NAMESPACE::DSysInfo::uosEditionType();
-    strUrl += "&system=" + QString::number(iType) + '-' + QString::number(iEditionType);
+    QString build = Utils::getOsBuild();
+    QString major, minor, strUrl;
+    if (Utils::getVersion(major, minor) && major == "25") {
+        // V25版本的URL构建逻辑
+        strUrl = Utils::getUrl() + "?deb_manufacturer=" + strManufacturer;
+        if (!strProducts.isEmpty()) {
+            strUrl += "&desc=" + strProducts;
+        }
+        strUrl += "&arch=" + arch;
+        if (!build.isEmpty()) {
+            QString system = build;
+            if (build[1] == "1") //专业版通过【产品线类型-产品线版本】方式进行系统构建匹配
+                system = QString("%1-%2").arg(build[1]).arg(build[3]);
+            strUrl += "&system=" + system;
+        }
+        strUrl += "&majorVersion=" + major;
+        strUrl += "&minorVersion=" + minor;
+    } else {
+        // 其他版本的URL构建逻辑
+        strUrl = Utils::getUrl() + "?arch=" + arch;
+        if (!build.isEmpty()) {
+            QString system = build;
+            if (build[1] == "1") //专业版通过【产品线类型-产品线版本】方式进行系统构建匹配
+                system = QString("%1-%2").arg(build[1]).arg(build[3]);
+            strUrl += "&system=" + system;
+        }
 
-    if (!strManufacturer.isEmpty()) {
-        strUrl += "&deb_manufacturer=" + strManufacturer;
-    }
-    if (!strProducts.isEmpty()) {
-        strUrl += "&product=" + strProducts;
-    }
-    if (0 < iClassP) {
-        strUrl += "&class_p=" + QString::number(iClassP);
-    }
-    if (0 < iClass) {
-        strUrl += "&class=" + QString::number(iClass);
+        if (!strManufacturer.isEmpty()) {
+            strUrl += "&deb_manufacturer=" + strManufacturer;
+        }
+        if (!strProducts.isEmpty()) {
+            strUrl += "&product=" + strProducts;
+        }
+        if (0 < iClassP) {
+            strUrl += "&class_p=" + QString::number(iClassP);
+        }
+        if (0 < iClass) {
+            strUrl += "&class=" + QString::number(iClass);
+        }
     }
     qCInfo(appLog) << strUrl;
     return getRequestJson(strUrl);

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/utils.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/utils.cpp
@@ -77,6 +77,48 @@ QString Utils::machineArch()
     return  strArch;
 }
 
+QString Utils::getOsBuild()
+{
+    QFile file("/etc/os-version");
+    if (!file.open(QIODevice::ReadOnly))
+        return "";
+    QString info = file.readAll().data();
+    QStringList lines = info.split("\n");
+    foreach (const QString &line, lines) {
+        if (line.startsWith("OsBuild")) {
+            QStringList words = line.split("=");
+            if (2 == words.size()) {
+                return words[1].trimmed();
+            }
+        }
+    }
+    return "";
+}
+
+bool Utils::getVersion(QString &major, QString &minor)
+{
+    QFile file("/etc/os-version");
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+    QString info = file.readAll().data();
+    QStringList lines = info.split("\n");
+    foreach (const QString &line, lines) {
+        if (line.startsWith("MajorVersion")) {
+            QStringList words = line.split("=");
+            if (2 == words.size()) {
+                major = words[1].trimmed();
+            }
+        }
+        if (line.startsWith("MinorVersion")) {
+            QStringList words = line.split("=");
+            if (2 == words.size()) {
+                minor = words[1].trimmed();
+            }
+        }
+    }
+    return !major.isEmpty() && !minor.isEmpty();
+}
+
 bool Utils::addModBlackList(const QString &moduleName)
 {
     QProcess process;

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/utils.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/utils.h
@@ -15,6 +15,8 @@ public:
     static QString getModuleFilePath(const QString &moduleName);
     static QString kernelRelease();
     static QString machineArch();
+    static QString getOsBuild();
+    static bool getVersion(QString &major, QString &minor);
     static bool addModBlackList(const QString &moduleName);
     static bool unInstallPackage(const QString &packageName);
     // 判断Deb是否为驱动包

--- a/deepin-devicemanager-server/deepin-deviceinfo/src/mainjob.cpp
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/mainjob.cpp
@@ -150,7 +150,12 @@ void MainJob::initDriverRepoSource()
         return;
     }
 
-    file.write("deb https://pro-driver-packages.uniontech.com eagle non-free\n");
+    QString major, minor;
+    if (getVersion(major, minor) && major == "25") {
+        file.write("deb https://pro-driver-packages.uniontech.com/driver-V25 snipe non-free\n");
+    } else {
+        file.write("deb https://pro-driver-packages.uniontech.com eagle non-free\n");
+    }
     file.close();
 
     QString cmd = "apt update";
@@ -187,3 +192,28 @@ void MainJob::executeClientInstruction(const QString &instructions)
     }
     s_ServerIsUpdating = false;
 }
+
+bool MainJob::getVersion(QString &major, QString &minor)
+{
+    QFile file("/etc/os-version");
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+    QString info = file.readAll().data();
+    QStringList lines = info.split("\n");
+    foreach (const QString &line, lines) {
+        if (line.startsWith("MajorVersion")) {
+            QStringList words = line.split("=");
+            if (2 == words.size()) {
+                major = words[1].trimmed();
+            }
+        }
+        if (line.startsWith("MinorVersion")) {
+            QStringList words = line.split("=");
+            if (2 == words.size()) {
+                minor = words[1].trimmed();
+            }
+        }
+    }
+    return !major.isEmpty() && !minor.isEmpty();
+}
+

--- a/deepin-devicemanager-server/deepin-deviceinfo/src/mainjob.h
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/mainjob.h
@@ -68,6 +68,14 @@ private:
      */
     void executeClientInstruction(const QString &instructions);
 
+    /**
+     * @brief getVersion
+     * @param major
+     * @param minor
+     * @return
+     */
+    bool getVersion(QString &major, QString &minor);
+
 private:
     ThreadPool            *m_pool = nullptr;                  //<! 生成文件的线程池
     bool                   m_firstUpdate;                      //<! 是否是第一次更新

--- a/deepin-devicemanager/src/DriverControl/HttpDriverInterface.cpp
+++ b/deepin-devicemanager/src/DriverControl/HttpDriverInterface.cpp
@@ -97,29 +97,47 @@ QString HttpDriverInterface::getRequestBoard(QString strManufacturer, QString st
         return QString();
     }
     QString arch = Common::getArchStore();
-    QString strUrl = CommonTools::getUrl() + "?arch=" + arch;
     QString build = getOsBuild();
-    if (!build.isEmpty()) {
-        QString system = build;
+    QString major, minor, strUrl;
+    if (getVersion(major, minor) && major =="25") {
+        strUrl = CommonTools::getUrl() + "?deb_manufacturer=" + strManufacturer;
+        if (!strModels.isEmpty()) {
+            strUrl += "&desc=" + strModels;
+        }
+        strUrl += "&arch=" + arch;
+        if (!build.isEmpty()) {
+            QString system = build;
+            if (build[1] == "1") //专业版通过【产品线类型-产品线版本】方式进行系统构建匹配
+                system = QString("%1-%2").arg(build[1]).arg(build[3]);
+            strUrl += "&system=" + system;
+        }
+        strUrl += "&majorVersion=" + major;
+        strUrl += "&minorVersion=" + minor;
+    } else {
+        strUrl = CommonTools::getUrl() + "?arch=" + arch;
+        if (!build.isEmpty()) {
+            QString system = build;
 
-        if (build[1] == "1") //专业版通过【产品线类型-产品线版本】方式进行系统构建匹配
-            system = QString("%1-%2").arg(build[1]).arg(build[3]);
+            if (build[1] == "1") //专业版通过【产品线类型-产品线版本】方式进行系统构建匹配
+                system = QString("%1-%2").arg(build[1]).arg(build[3]);
 
-        strUrl += "&system=" + system;
+            strUrl += "&system=" + system;
+        }
+
+        if (!strManufacturer.isEmpty()) {
+            strUrl += "&deb_manufacturer=" + strManufacturer;
+        }
+        if (!strModels.isEmpty()) {
+            strUrl += "&product=" + strModels;
+        }
+        if (0 < iClassP) {
+            strUrl += "&class_p=" + QString::number(iClassP);
+        }
+        if (0 < iClass) {
+            strUrl += "&class=" + QString::number(iClass);
+        }
     }
 
-    if (!strManufacturer.isEmpty()) {
-        strUrl += "&deb_manufacturer=" + strManufacturer;
-    }
-    if (!strModels.isEmpty()) {
-        strUrl += "&product=" + strModels;
-    }
-    if (0 < iClassP) {
-        strUrl += "&class_p=" + QString::number(iClassP);
-    }
-    if (0 < iClass) {
-        strUrl += "&class=" + QString::number(iClass);
-    }
     return getRequestJson(strUrl);
 }
 
@@ -263,6 +281,30 @@ QString HttpDriverInterface::getOsBuild()
         }
     }
     return "";
+}
+
+bool HttpDriverInterface::getVersion(QString &major, QString &minor)
+{
+    QFile file("/etc/os-version");
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+    QString info = file.readAll().data();
+    QStringList lines = info.split("\n");
+    foreach (const QString &line, lines) {
+        if (line.startsWith("MajorVersion")) {
+            QStringList words = line.split("=");
+            if (2 == words.size()) {
+                major = words[1].trimmed();
+            }
+        }
+        if (line.startsWith("MinorVersion")) {
+            QStringList words = line.split("=");
+            if (2 == words.size()) {
+                minor = words[1].trimmed();
+            }
+        }
+    }
+    return !major.isEmpty() && !minor.isEmpty();
 }
 
 bool HttpDriverInterface::convertJsonToDeviceList(QString strJson, QList<RepoDriverInfo> &lstDriverInfo)

--- a/deepin-devicemanager/src/DriverControl/HttpDriverInterface.h
+++ b/deepin-devicemanager/src/DriverControl/HttpDriverInterface.h
@@ -53,6 +53,7 @@ protected:
 private:
     int packageInstall(const QString& package_name, const QString& version);
     QString getOsBuild();
+    bool getVersion(QString &major, QString &minor);
 public:
     signals:
     void sigRequestFinished(bool sucess, QString msg);


### PR DESCRIPTION
- Add version check logic for V25 system
- Update driver repository URL for V25 version
- Modify URL construction for driver requests
- Add getVersion and getOsBuild utility functions

Log: add V25 version support for driver repository