### PR TITLE
fix: trim vendor ID and add VIDPID fallback parsing

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
@@ -571,7 +571,7 @@ const QString DeviceBaseInfo::getVendorOrModelId(const QString &sysPath, bool fl
     QString vendor = vendorFile.readAll();
     vendorFile.close();
 
-    return vendor;
+    return vendor.trimmed();
 }
 
 const QString DeviceBaseInfo::getDriverVersion()

--- a/deepin-devicemanager/src/DriverControl/HttpDriverInterface.cpp
+++ b/deepin-devicemanager/src/DriverControl/HttpDriverInterface.cpp
@@ -243,17 +243,25 @@ void HttpDriverInterface::checkDriverInfo(QString strJson, DriverInfo *driverInf
 int HttpDriverInterface::packageInstall(const QString &package_name, const QString &version)
 {
     // 0:没有包 1:版本不一致 2:版本一致
-    QString outInfo = Common::executeClientCmd("apt", QStringList() << "policy" << package_name, QString(), -1);
+    QString outInfo = Common::executeClientCmd("apt", QStringList() << "policy" << package_name, QString(), -1, false);
     if (outInfo.isEmpty())
         return 0;
     QStringList infoList = outInfo.split("\n");
-    if (infoList.size() <= 2 || infoList[1].contains("（") || infoList[1].contains("("))
+    int index = 0;
+    for (int i = 0; i < infoList.size(); i++)
+    {
+        if (infoList[i].startsWith(package_name)) {
+            index = i;
+            break;
+        }
+    }
+    if (infoList.size() <= (2 + index) || infoList[1 + index].contains("（") || infoList[1 + index].contains("("))
         return 0;
-    if (infoList[1].contains(version))
+    if (infoList[1 + index].contains(version))
         return 2;
 
     QRegularExpression rxlen("(\\d+\\S*)");
-    QRegularExpressionMatch match = rxlen.match(infoList[1]);
+    QRegularExpressionMatch match = rxlen.match(infoList[1 + index]);
     QString curVersion;
     if (match.hasMatch()) {
         curVersion = match.captured(1);

--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -808,6 +808,17 @@ void PageDriverManager::scanDevicesInfo(const QString &deviceType, DriverType dr
             info->m_ModelId = device->getVendorOrModelId(device->sysPath(), false);    // model id
             info->m_DriverName = device->driver();                 // 驱动名称
             info->m_Version = device->getDriverVersion();          // 驱动版本
+            if (info->m_VendorId.size() == 4 && !info->m_VendorId.startsWith("0x")) {
+                info->m_VendorId = "0x" + info->m_VendorId;
+            }
+            if (info->m_ModelId.size() == 4 && !info->m_ModelId.startsWith("0x")) {
+                info->m_ModelId = "0x" + info->m_ModelId;
+            }
+            QString vidAndPid = device->getVIDAndPID();
+            if ((info->m_VendorId.isEmpty() || info->m_ModelId.isEmpty()) && vidAndPid.size() == 10 && vidAndPid.startsWith("0x")) {
+                info->m_VendorId = vidAndPid.mid(0,6);
+                info->m_ModelId = "0x" + vidAndPid.mid(6,4);
+            }
 
             qCInfo(appLog) << "m_Name" << info->m_Name;
             qCInfo(appLog) << "m_VendorId" << info->m_VendorId;
@@ -826,7 +837,6 @@ void PageDriverManager::scanDevicesInfo(const QString &deviceType, DriverType dr
                 if (network->isWireless()) {
                     info->m_Type = DR_WiFi;
                 }
-
             }
 
             addDriverInfo(info);

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -38,6 +38,6 @@ public:
      */
     static int specialComType;
 
-    static QByteArray executeClientCmd(const QString& cmd, const QStringList& args = QStringList(), const QString& workPath = QString(), int msecsWaiting = 30000);
+    static QByteArray executeClientCmd(const QString& cmd, const QStringList& args = QStringList(), const QString& workPath = QString(), int msecsWaiting = 30000, bool useEnv = true);
 };
 #endif // COMMONFUNCTION_H


### PR DESCRIPTION
- Add trimming for vendor ID to remove whitespace
- Add fallback logic to parse VIDPID when vendor/model IDs are empty

Log: trim vendor ID and add VIDPID fallback parsing