### PR TITLE
chore: Bump version to 6.0.39

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-devicemanager (6.0.39) unstable; urgency=medium
+
+  * chore: update translations.
+
+ -- renbin <renbin@uniontech.com>  Thu, 17 Apr 2025 10:07:28 +0800
+
 deepin-devicemanager (6.0.38) unstable; urgency=medium
 
   * chore: New version 6.0.38.


### PR DESCRIPTION
Bump version to 6.0.39

Log: Bump version to 6.0.39

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect the new version 6.0.39