### PR TITLE
fix: the monitor display info in special machine

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -200,9 +200,9 @@ bool DeviceMonitor::setInfoFromXradr(const QString &main, const QString &edid, c
                     if (pos > 0 && curRate.size() > pos && !Common::boardVendorType().isEmpty()) {
                         curRate = QString::number(ceil(curRate.left(pos).toDouble())) + curRate.right(curRate.size() - pos);
                     }
-                    m_CurrentResolution = QString("%1@%2").arg(reScreenSize.cap(1)).arg(curRate);
+                    m_CurrentResolution = QString("%1@%2").arg(reScreenSize.cap(1)).arg(curRate).replace("x", "×", Qt::CaseInsensitive);
                 } else
-                    m_CurrentResolution = QString("%1").arg(reScreenSize.cap(1));
+                    m_CurrentResolution = QString("%1").arg(reScreenSize.cap(1)).replace("x", "×", Qt::CaseInsensitive);
             }
         }
         return false;
@@ -275,12 +275,12 @@ void DeviceMonitor::initFilterKey()
 void DeviceMonitor::loadBaseDeviceInfo()
 {
     // 添加基本信息
-    if (Common::specialComType != 6)
+    if (Common::specialComType != 6 && Common::specialComType != 5) {
         addBaseDeviceInfo(("Name"), m_Name);
-    addBaseDeviceInfo(("Vendor"), m_Vendor);
-    if (Common::specialComType != 6)
+        addBaseDeviceInfo(("Vendor"), m_Vendor);
         addBaseDeviceInfo(("Type"), m_Model);
-    addBaseDeviceInfo(("Display Input"), m_DisplayInput);
+        addBaseDeviceInfo(("Display Input"), m_DisplayInput);
+    }
     addBaseDeviceInfo(("Interface Type"), m_Interface);
 }
 
@@ -353,12 +353,12 @@ bool DeviceMonitor::setMainInfoFromXrandr(const QString &info, const QString &ra
                 m_RefreshRate = QString("%1").arg(curRate);
             }
             if (Common::specialComType == 5 || Common::specialComType == 6) {
-                m_CurrentResolution = QString("%1").arg(reScreenSize.cap(1));
+                m_CurrentResolution = QString("%1").arg(reScreenSize.cap(1)).replace("x", "×", Qt::CaseInsensitive);
             } else {
-                m_CurrentResolution = QString("%1 @%2").arg(reScreenSize.cap(1)).arg(curRate);
+                m_CurrentResolution = QString("%1 @%2").arg(reScreenSize.cap(1)).arg(curRate).replace("x", "×", Qt::CaseInsensitive);
             }
         } else
-            m_CurrentResolution = QString("%1").arg(reScreenSize.cap(1));
+            m_CurrentResolution = QString("%1").arg(reScreenSize.cap(1)).replace("x", "×", Qt::CaseInsensitive);
     }
 
     return true;
@@ -419,7 +419,7 @@ void DeviceMonitor::caculateScreenSize()
         m_Height = re.cap(2).toInt();
 
         double inch = std::sqrt((m_Width / 2.54) * (m_Width / 2.54) + (m_Height / 2.54) * (m_Height / 2.54)) / 10.0;
-        m_ScreenSize = QString("%1 %2(%3mm X %4mm)").arg(QString::number(inch, '0', 1)).arg(translateStr("inch")).arg(m_Width).arg(m_Height);
+        m_ScreenSize = QString("%1 %2(%3mm×%4mm)").arg(QString::number(inch, '0', 1)).arg(translateStr("inch")).arg(m_Width).arg(m_Height);
     }
 }
 
@@ -449,6 +449,6 @@ bool DeviceMonitor::caculateScreenSize(const QString &edid)
         return true;
 
     double inch = std::sqrt(height * height + width * width) / 2.54 / 10;
-    m_ScreenSize = QString("%1 %2(%3mm X %4mm)").arg(QString::number(inch, '0', 1)).arg(translateStr("inch")).arg(width).arg(height);
+    m_ScreenSize = QString("%1 %2(%3mm×%4mm)").arg(QString::number(inch, '0', 1)).arg(translateStr("inch")).arg(width).arg(height);
     return true;
 }

--- a/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
@@ -446,7 +446,7 @@ static void parseEDID(QStringList allEDIDS,QString input)
             QMap<QString, QString> mapInfo;
             mapInfo.insert("Vendor",edidParser.vendor());
             mapInfo.insert("Model",edidParser.model());
-            mapInfo.insert("Date",edidParser.releaseDate());
+            //mapInfo.insert("Date",edidParser.releaseDate());
             mapInfo.insert("Size",edidParser.screenSize());
             mapInfo.insert("Display Input",input);
 

--- a/deepin-devicemanager/src/Tool/EDIDParser.cpp
+++ b/deepin-devicemanager/src/Tool/EDIDParser.cpp
@@ -192,7 +192,7 @@ void EDIDParser::parseScreenSize()
     }
 
     double inch = sqrt((m_Width / 2.54) * (m_Width / 2.54) + (m_Height / 2.54) * (m_Height / 2.54))/10;
-    m_ScreenSize = QString("%1 %2(%3mm X %4mm)").arg(QString::number(inch, '0', 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
+    m_ScreenSize = QString("%1 %2(%3mm×%4mm)").arg(QString::number(inch, '0', 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
 }
 
 QString EDIDParser::binToDec(QString strBin)   //二进制转十进制

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -330,8 +330,8 @@ void ThreadExecXrandr::getResolutionFromDBus(QMap<QString, QString> &lstMap)
     }
 
     if (maxResolutionWidth != -1) {
-        lstMap.insert("maxResolution", QString("%1 x %2").arg(maxResolutionWidth).arg(maxResolutionHeight));
-        lstMap.insert("minResolution", QString("%1 x %2").arg(minResolutionWidth).arg(minResolutionHeight));
+        lstMap.insert("maxResolution", QString("%1×%2").arg(maxResolutionWidth).arg(maxResolutionHeight));
+        lstMap.insert("minResolution", QString("%1×%2").arg(minResolutionWidth).arg(minResolutionHeight));
     }
 }
 
@@ -409,7 +409,7 @@ void ThreadExecXrandr::getResolutionRateFromDBus(QList<QMap<QString, QString> > 
             curResolutionHeight = resolution.height;
             resRate = resolution.refreshRate;
             QMap<QString,QString>infoMap;
-            QString tmpS = QString("%1 x %2 @").arg(curResolutionWidth).arg(curResolutionHeight)  + QString::number(resRate, 'f', 2);
+            QString tmpS = QString("%1×%2@").arg(curResolutionWidth).arg(curResolutionHeight)  + QString::number(resRate, 'f', 2);
             infoMap.insert("CurResolution", tmpS + "Hz");
             infoMap.insert("Name", tname.toString());
             infoMap.insert("Display Input", tname.toString());


### PR DESCRIPTION
fix the monitor display info in special machine

Log: fix the monitor display info in special machine
Bug: https://pms.uniontech.com/bug-view-310413.html

## Summary by Sourcery

Update monitor display information formatting and conditionally hide details for specific machine types.

Bug Fixes:
- Replace 'x'/'X' with '×' in resolution and screen size displays.
- Do not display Name, Vendor, Type, and Display Input for special computer types 5 and 6.
- Remove the manufacturing date from monitor details.