### PR TITLE
fix: the audio device registe two pci device can't be disable

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -587,7 +587,18 @@ void CmdTool::getMulHwinfoInfo(const QString &info)
         getMapInfoFromHwinfo(item, mapInfo);
         if (mapInfo["Hardware Class"] == "sound" || mapInfo["Device"].contains("USB Audio")) {
             // mapInfo["Device"].contains("USB Audio") 是为了处理未识别的USB声卡 Bug-118773
-            addMapInfo("hwinfo_sound", mapInfo);
+            const QList<QMap<QString, QString>> &lstMap = m_cmdInfo["hwinfo_sound"];
+            QList<QMap<QString, QString> >::const_iterator it = lstMap.begin();
+            bool canAdd = true;
+            for (; it != lstMap.end(); ++it) {
+                auto item = *it;
+                if (item.value("Device") == mapInfo["Device"] && item.value("Hardware Class") != "sound") {
+                    canAdd = false;
+                }
+            }
+            if (canAdd) {
+                addMapInfo("hwinfo_sound", mapInfo);
+            }
         } else if (mapInfo["Hardware Class"].contains("network")) {
             addMapInfo("hwinfo_network", mapInfo);
         } else if ("keyboard" == mapInfo["Hardware Class"]) {


### PR DESCRIPTION
the audio device registe two pci device can't be disable

Log: fix the audio device registe two pci device can't be disable
Bug: https://pms.uniontech.com/bug-view-314495.html
Change-Id: I40efcebcf8e8e5942b768c7fc5d394ab100494be

## Summary by Sourcery

Bug Fixes:
- Prevent adding a sound device entry if a non-sound entry for the same device already exists.