### PR TITLE
fix: the audio device may cause crush

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -592,7 +592,7 @@ void CmdTool::getMulHwinfoInfo(const QString &info)
             bool canAdd = true;
             for (; it != lstMap.end(); ++it) {
                 auto item = *it;
-                if (item.value("Device") == mapInfo["Device"] && item.value("Hardware Class") != "sound") {
+                if (item.value("Device") == mapInfo["Device"] && mapInfo.value("Hardware Class") != "sound") {
                     canAdd = false;
                 }
             }


### PR DESCRIPTION
fix the audio device may cause crush

Log: fix the audio device may cause crush.
Bug: https://pms.uniontech.com/bug-view-314495.html
Change-Id: Ic86b50fca4e37ad5317a37334a13273a51fba772

## Summary by Sourcery

Bug Fixes:
- Fix an issue where sound devices could be incorrectly skipped during hardware information gathering.