### PR TITLE
refactor: unify palette handling with DPaletteHelper

### DIFF
--- a/deepin-devicemanager/src/Page/PageListView.cpp
+++ b/deepin-devicemanager/src/Page/PageListView.cpp
@@ -9,6 +9,7 @@
 
 // Dtk头文件
 #include <DGuiApplicationHelper>
+#include <DPaletteHelper>
 
 // Qt库文件
 #include <QHBoxLayout>
@@ -95,23 +96,14 @@ void PageListView::setCurType(QString type)
 void PageListView::paintEvent(QPaintEvent *event)
 {
     // 让背景色适合主题颜色
-    // TODO qt6 中使用 QPalette 替代 DPalette
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    DPalette pa;
-    pa = DGuiApplicationHelper::instance()->palette(this);
+    DPalette pa = DPaletteHelper::instance()->palette(this);
     pa.setBrush(DPalette::ItemBackground, pa.brush(DPalette::Base));
-    pa.setBrush(DPalette::Background, pa.brush(DPalette::Base));
-#else
-    QPalette pa = this->palette(); // 使用 QPalette 替代 Dtk::Gui::DPalette
-    pa.setBrush(QPalette::Window, pa.brush(QPalette::Base)); // 统一使用 QPalette
-#endif
-
-    // 设置调色板
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    DGuiApplicationHelper::instance()->setPalette(this, pa);
+    pa.setBrush(QPalette::Background, pa.brush(QPalette::Base));
 #else
-    this->setPalette(pa);
+    pa.setColor(QPalette::Window, pa.color(QPalette::Base));
 #endif
+    DPaletteHelper::instance()->setPalette(this, pa);
 
     return DWidget::paintEvent(event);
 }

--- a/deepin-devicemanager/src/Widget/BtnLabel.cpp
+++ b/deepin-devicemanager/src/Widget/BtnLabel.cpp
@@ -11,6 +11,7 @@
 #include <DDialog>
 #include <DFontSizeManager>
 #include <DGuiApplicationHelper>
+#include <DPaletteHelper>
 #include <DApplication>
 #include <QLoggingCategory>
 using namespace DDLog;
@@ -74,13 +75,10 @@ void BtnLabel::paintEvent(QPaintEvent* e)
     }
 
     DFontSizeManager::instance()->bind(this, DFontSizeManager::T8);
-    DPalette pa = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette();
+
+    DPalette pa = DPaletteHelper::instance()->palette(this);
     pa.setColor(DPalette::Text, pa.color(cg, DPalette::TextTips));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    this->setPalette(pa);
-#else
-    DGuiApplicationHelper::instance()->setPalette(this, pa);
-#endif
+    DPaletteHelper::instance()->setPalette(this, pa);
 
     return DLabel::paintEvent(e);
 }
@@ -104,11 +102,7 @@ void TipsLabel::paintEvent(QPaintEvent* e)
     DFontSizeManager::instance()->bind(this, DFontSizeManager::T8);
     DPalette pa = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette();
     pa.setColor(DPalette::Text, pa.color(cg, DPalette::TextTips));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    this->setPalette(pa);
-#else
-    DGuiApplicationHelper::instance()->setPalette(this, pa);
-#endif
+    DPaletteHelper::instance()->setPalette(this, pa);
 
     return DLabel::paintEvent(e);
 }
@@ -130,11 +124,7 @@ void TitleLabel::paintEvent(QPaintEvent* e)
 
     DPalette pa = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette();
     pa.setColor(DPalette::Text, pa.color(cg, DPalette::TextTitle));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    this->setPalette(pa);
-#else
-    DGuiApplicationHelper::instance()->setPalette(this, pa);
-#endif
+    DPaletteHelper::instance()->setPalette(this, pa);
 
     return DLabel::paintEvent(e);
 }

--- a/deepin-devicemanager/src/Widget/DeviceListView.cpp
+++ b/deepin-devicemanager/src/Widget/DeviceListView.cpp
@@ -8,6 +8,7 @@
 // Dtk头文件
 #include <DGuiApplicationHelper>
 #include <DApplication>
+#include <DPaletteHelper>
 
 // Qt库文件
 #include <qdrawutil.h>
@@ -163,18 +164,9 @@ void DeviceListView::clearItem()
 void DeviceListView::paintEvent(QPaintEvent *event)
 {
     // 让背景色适合主题颜色
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    // Qt 6 中的处理
-    QPalette pa = DApplication::palette();
-    pa.setBrush(QPalette::Window, pa.brush(QPalette::Base));
-    setPalette(pa);
-#else
-    // Qt 5 中的处理
-    DPalette pa;
-    pa = DGuiApplicationHelper::instance()->palette(this);
+    DPalette pa = DPaletteHelper::instance()->palette(this);
     pa.setBrush(DPalette::ItemBackground, pa.brush(DPalette::Base));
-    DGuiApplicationHelper::instance()->setPalette(this, pa);
-#endif
+    DPaletteHelper::instance()->setPalette(this, pa);
 
     DListView::paintEvent(event);
 }

--- a/deepin-devicemanager/src/Widget/GetDriverNameWidget.cpp
+++ b/deepin-devicemanager/src/Widget/GetDriverNameWidget.cpp
@@ -9,6 +9,7 @@
 #include <DFrame>
 #include <DLabel>
 #include <DGuiApplicationHelper>
+#include <DPaletteHelper>
 #include <DFontSizeManager>
 #include <DStackedWidget>
 
@@ -59,15 +60,10 @@ void GetDriverNameWidget::init()
     mp_tipLabel->setMinimumHeight(25);
 
     DFontSizeManager::instance()->bind(mp_tipLabel, DFontSizeManager::T8, QFont::Medium);
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    DPalette pa = DGuiApplicationHelper::instance()->palette(mp_tipLabel);
+
+    DPalette pa = DPaletteHelper::instance()->palette(mp_tipLabel);
     pa.setColor(DPalette::WindowText, pa.color(DPalette::TextWarning));
-    DGuiApplicationHelper::instance()->setPalette(mp_tipLabel, pa);
-#else
-    DPalette pa = mp_tipLabel->palette();
-    pa.setColor(DPalette::WindowText, pa.color(DPalette::TextWarning));
-    mp_tipLabel->setPalette(pa);
-#endif
+    DPaletteHelper::instance()->setPalette(mp_tipLabel, pa);
 
     // 上方布局
     QHBoxLayout *hLayout1 = new QHBoxLayout;

--- a/deepin-devicemanager/src/Widget/GetDriverPathWidget.cpp
+++ b/deepin-devicemanager/src/Widget/GetDriverPathWidget.cpp
@@ -7,6 +7,7 @@
 #include "MacroDefinition.h"
 
 #include <DGuiApplicationHelper>
+#include <DPaletteHelper>
 
 GetDriverPathWidget::GetDriverPathWidget(QWidget *parent)
     : DWidget(parent)
@@ -71,21 +72,16 @@ void GetDriverPathWidget::init()
     mp_tipLabel->setElideMode(Qt::ElideRight);
     mp_tipLabel->setMinimumHeight(20);
 
-    // TODO 
-    QPalette pa = mp_titleLabel->palette();
+
+    DPalette pa = DPaletteHelper::instance()->palette(mp_titleLabel);
+    pa.setBrush(DPalette::WindowText, pa.color(DPalette::TextTips));
     QColor color = DGuiApplicationHelper::adjustColor(pa.color(QPalette::Active, QPalette::BrightText), 0, 0, 0, 0, 0, 0, -30);
     pa.setColor(QPalette::WindowText, color);
     mp_titleLabel->setPalette(pa);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    pa = DGuiApplicationHelper::instance()->palette(mp_tipLabel);
+    pa = DPaletteHelper::instance()->palette(mp_titleLabel);
     pa.setColor(DPalette::WindowText, pa.color(DPalette::TextWarning));
-    DGuiApplicationHelper::instance()->setPalette(mp_tipLabel, pa);
-#else
-    pa = mp_tipLabel->palette();
-    pa.setColor(QPalette::WindowText, pa.color(QPalette::WindowText));
-    mp_tipLabel->setPalette(pa);
-#endif
+    DPaletteHelper::instance()->setPalette(mp_titleLabel, pa);
 
     this->setLayout(mainLayout);
 

--- a/deepin-devicemanager/src/Widget/TextBrowser.cpp
+++ b/deepin-devicemanager/src/Widget/TextBrowser.cpp
@@ -11,6 +11,7 @@
 
 // Dtk头文件
 #include <DGuiApplicationHelper>
+#include <DPaletteHelper>
 #include <DApplication>
 #include <DFontSizeManager>
 #include <DMenu>
@@ -139,15 +140,9 @@ void TextBrowser::fillClipboard()
 
 void TextBrowser::paintEvent(QPaintEvent *event)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    DPalette pa = DGuiApplicationHelper::instance()->palette(this);
+    DPalette pa = DPaletteHelper::instance()->palette(this);
     pa.setBrush(DPalette::WindowText, pa.color(DPalette::TextTips));
-    DGuiApplicationHelper::instance()->setPalette(this, pa);
-#else
-    QPalette pa = palette();
-    pa.setBrush(QPalette::WindowText, pa.color(QPalette::PlaceholderText));
-    setPalette(pa);
-#endif
+    DPaletteHelper::instance()->setPalette(this, pa);
 
     int height = int(document()->size().height());
     setFixedHeight(height);


### PR DESCRIPTION
1. Replace DGuiApplicationHelper palette calls with DPaletteHelper
across multiple files
2. Remove QT_VERSION conditional checks for palette handling
3. Simplify and standardize palette management code
4. Ensure consistent theme adaptation across all UI components

The changes standardize how palettes are handled in the application by
using DPaletteHelper instead of mixing DGuiApplicationHelper and direct
QPalette calls. This provides:
1. More consistent theme behavior
2. Cleaner code by removing version-specific branches
3. Better maintainability with a single approach
4. Proper support for both Qt5 and Qt6 through DPaletteHelper's
abstraction

refactor: 使用 DPaletteHelper 统一管理调色板

1. 在多个文件中用 DPaletteHelper 替换 DGuiApplicationHelper 的调色板调用
2. 移除调色板处理中的 QT_VERSION 条件检查
3. 简化和标准化调色板管理代码
4. 确保所有UI组件的主题适配一致

这些变更通过使用 DPaletteHelper 替代混合使用 DGuiApplicationHelper 和直
接 QPalette 调用，标准化了应用程序中的调色板处理方式。这带来了：
1. 更一致的主题行为
2. 通过移除版本特定分支使代码更简洁
3. 单一方法提高可维护性
4. 通过 DPaletteHelper 的抽象层同时支持 Qt5 和 Qt6

pms: BUG-305615
