### PR TITLE
fix: modify the mouse device name

### DIFF
--- a/deepin-devicemanager/src/Page/PageListView.cpp
+++ b/deepin-devicemanager/src/Page/PageListView.cpp
@@ -28,7 +28,7 @@ PageListView::PageListView(DWidget *parent)
     hLayout->setContentsMargins(0, 0, 0, 0);
     setLayout(hLayout);
 
-    this->setFixedWidth(152);
+    this->setFixedWidth(172);
     // 初始化右键菜单
     mp_ListView->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(mp_ListView, SIGNAL(customContextMenuRequested(const QPoint &)),

--- a/deepin-devicemanager/translations/deepin-devicemanager.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager.ts
@@ -841,7 +841,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="217"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
         <source>Mouse</source>
-        <translation>Mouse</translation>
+        <translation>Mouse and Pointer Devices</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="222"/>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
@@ -1852,7 +1852,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="221"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Mouse</source>
-        <translation>鼠标</translation>
+        <translation>鼠标与指针设备</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="226"/>


### PR DESCRIPTION
modify the mouse device name

Log: modify the mouse device name
Bug: https://pms.uniontech.com/task-view-376575.html
Change-Id: I37339a5ec25d6fbe5b4cb4f209ba1f7fa7f87cec

## Summary by Sourcery

Increase the page list view width and update the mouse device category name to include pointer devices in both English and Chinese.

Bug Fixes:
- Rename the “Mouse” category label to “Mouse and Pointer Devices” in English and Chinese translations.

Enhancements:
- Increase the fixed width of the page list view from 152 to 172 pixels.