### PR TITLE
fix the USB audio device can't be disable

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
@@ -140,9 +140,7 @@ bool ControlInterface::enable(const QString &hclass, const QString &name, const 
 
     // 先从数据库中查找路径，防止设备更换usb接口
     QString sPath = EnableSqlManager::getInstance()->authorizedPath(value);
-    if (sPath.isEmpty()) {
-        sPath = path;
-    }
+    sPath = path;
 
     // 判断是内置设备，还是外设，内置设备通过remove文件禁用，外设通过authorized文件禁用
     bool res = false;

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enablesqlmanager.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enablesqlmanager.h
@@ -90,14 +90,14 @@ public:
      * @param key
      * @return
      */
-    bool uniqueIDExisted(const QString &key);
+    bool uniqueIDExisted(const QString &key, const QString path = "");
 
     /**
      * @brief uniqueIDExistedForEnable
      * @param key
      * @return
      */
-    bool uniqueIDExistedEX(const QString &key);
+    bool uniqueIDExistedEX(const QString &key, const QString path = "");
 
     /**
      * @brief isUniqueIdEnabled 判断设备是否被禁用了

--- a/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
@@ -1249,6 +1249,11 @@ void DeviceBaseInfo::generatorTranslate()
     <<  tr("Processor");
 }
 
+void DeviceBaseInfo::setSysPath(const QString &newSysPath)
+{
+    m_SysPath = newSysPath;
+}
+
 void DeviceBaseInfo::setUniqueID(const QString &UniqueID)
 {
     m_UniqueID = UniqueID;

--- a/deepin-devicemanager/src/DeviceManager/DeviceInfo.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInfo.h
@@ -395,6 +395,8 @@ public:
     TomlFixMethod setInfoFromTomlBase(const QMap<QString, QString> &mapInfo);
 
     void setUniqueID(const QString &UniqueID);
+    void setSysPath(const QString &newSysPath);
+
 protected:
     /**
      * @brief:初始化过滤信息

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -1112,28 +1112,76 @@ void DeviceManager::delAudioDevice(DeviceAudio *const device)
 void DeviceManager::deleteDisableDuplicate_AudioDevice(void)
 {
     QHash<QString, DeviceAudio*> enabledDevices;
+    QHash<QString, int> enableDevicePriority;
     for (auto it = m_ListDeviceAudio.begin(); it != m_ListDeviceAudio.end(); ++it) {
         DeviceAudio* audio = dynamic_cast<DeviceAudio*>(*it);
         if (!audio) {
             continue;
         }
-        if (audio->enable()  || !enabledDevices.contains(audio->uniqueID())) {
-            QString usbDir = "/sys" + audio->sysPath();
-            if (QFileInfo::exists(usbDir) || !audio->driver().contains("usb")) {
-                enabledDevices[audio->uniqueID()] = audio;
+        if (audio->enable() || !enabledDevices.contains(audio->uniqueID())) {
+            enabledDevices[audio->uniqueID()] = audio;
+            if (!enableDevicePriority.contains(audio->uniqueID())) {
+                if (audio->enable() || ! audio->driver().contains("usb")) {
+                    enableDevicePriority.insert(audio->uniqueID(), 2);
+                } else {
+                    enableDevicePriority.insert(audio->uniqueID(), 1);
+                }
+            } else {
+                enableDevicePriority[audio->uniqueID()] = enableDevicePriority[audio->uniqueID()] + 1;
             }
         } else {
             if (enabledDevices.contains(audio->uniqueID()) && enabledDevices[audio->uniqueID()]->enable()) {
+                if (!enableDevicePriority.contains(audio->uniqueID())) {
+                    if (audio->enable()) {
+                        enableDevicePriority.insert(audio->uniqueID(), 2);
+                    } else {
+                        enableDevicePriority.insert(audio->uniqueID(), 1);
+                    }
+                } else {
+                    enableDevicePriority[audio->uniqueID()] = enableDevicePriority[audio->uniqueID()] + 1;
+                }
+                audio->setSysPath(enabledDevices[audio->uniqueID()]->sysPath());
                 delete enabledDevices[audio->uniqueID()];
-
                 enabledDevices[audio->uniqueID()] = audio;
             }
         }
     }
+    qWarning()<<"delete before: "<< m_ListDeviceAudio.size();
+    qWarning() << enableDevicePriority;
     m_ListDeviceAudio.clear();
-    for(auto it : enabledDevices.values()){
-        m_ListDeviceAudio.push_back(it);
+    for(auto it : enabledDevices.keys()){
+        if (enableDevicePriority.value(it) <= 1) {
+            continue;
+        }
+        m_ListDeviceAudio.push_back(enabledDevices.value(it));
+
+        setAudioDeviceEnable(enabledDevices.value(it), enabledDevices.value(it)->enable());
     }
+    qWarning()<<"delete after: "<< m_ListDeviceAudio.size();
+}
+
+void DeviceManager::setAudioDeviceEnable(DeviceAudio * const devivce, bool enable)
+{
+    EnableDeviceStatus status ;
+
+    int i = 0;
+    do{
+        status = devivce->setEnable(enable);
+        if (status == EDS_Success) {
+            break;
+        }
+        qWarning() << "retry: " << ++i;
+    }while (i < 3);
+
+    qWarning() << [](EnableDeviceStatus status) {
+        switch(status) {
+        case EDS_Cancle: return "Device enable operation was cancelled";
+        case EDS_NoSerial: return "Device enable failed: No serial number available";
+        case EDS_Faild: return "-----Device enable failed due to unknown error";
+        case EDS_Success: return "Device enabled successfully";
+        default: return "Unknown device enable status";
+        }
+    }(status);
 }
 
 DeviceBaseInfo *DeviceManager::getAudioDevice(const QString &path)

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.h
@@ -331,6 +331,8 @@ public:
      */
     void deleteDisableDuplicate_AudioDevice(void);
 
+    void setAudioDeviceEnable(DeviceAudio *const devivce, bool enable);
+
     /**
      * @brief getAudioDevice 获取音频设备
      * @param path

--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -585,7 +585,7 @@ void CmdTool::getMulHwinfoInfo(const QString &info)
             continue;
         QMap<QString, QString> mapInfo;
         getMapInfoFromHwinfo(item, mapInfo);
-        if (mapInfo["Hardware Class"] == "sound" || mapInfo["Device"].contains("USB Audio")) {
+        if (mapInfo["Hardware Class"] == "sound" || (mapInfo["Device"].contains("USB Audio") && mapInfo["Device"].contains("snd-usb-audio"))) {
             // mapInfo["Device"].contains("USB Audio") 是为了处理未识别的USB声卡 Bug-118773
             addMapInfo("hwinfo_sound", mapInfo);
         } else if (mapInfo["Hardware Class"].contains("network")) {

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -755,7 +755,7 @@ void DeviceGenerator::getAudioInfoFromHwinfo()
         DeviceManager::instance()->addAudioDevice(device);
         addBusIDFromHwinfo((*it)["SysFS BusID"]);
     }
-    DeviceManager::instance()->deleteDisableDuplicate_AudioDevice();
+//    DeviceManager::instance()->deleteDisableDuplicate_AudioDevice();
 }
 
 void DeviceGenerator::getAudioInfoFrom_sysFS()


### PR DESCRIPTION
fix the USB audio device can't be disable

Log: fix the USB audio device can't be disable
Bug: https://pms.uniontech.com/bug-view-316525.html
Change-Id: I2e8d4f70d3b5c8d029c92386025ed974a1797bb5

## Summary by Sourcery

Revamp USB audio device disable functionality by refining duplicate filtering and enable logic, enhancing SQL handling, and tightening device detection heuristics

Bug Fixes:
- Fix disabling USB audio devices by overhauling duplicate removal in DeviceManager and ensuring disable commands are retried and applied
- Correct ControlInterface to always use the live device path for enable/disable operations
- Improve USB audio detection in CmdTool to only select devices matching both "USB Audio" and "snd-usb-audio"

Enhancements:
- Add setAudioDeviceEnable with up to three retries and detailed status logging for audio enable/disable operations
- Implement priority tracking in deleteDisableDuplicate_AudioDevice to filter duplicates and reapply device enable state
- Update EnableSqlManager to include device path in unique ID existence checks and log SQL preparation failures
- Introduce DeviceBaseInfo::setSysPath to allow runtime sysPath updates
- Disable automatic duplicate removal invocation in DeviceGenerator for manual control