### PR TITLE
fix: filter the invalid power device

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DevicePower.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DevicePower.cpp
@@ -66,7 +66,9 @@ TomlFixMethod DevicePower::setInfoFromTomlOneByOne(const QMap<QString, QString> 
 bool DevicePower::setInfoFromUpower(const QMap<QString, QString> &mapInfo)
 {
     // 设置upower中获取的信息
-    if (mapInfo["Device"].contains("line_power", Qt::CaseInsensitive)) {
+    if (mapInfo["Device"].contains("line_power", Qt::CaseInsensitive) ||
+        mapInfo["state"].contains("empty", Qt::CaseInsensitive) ||
+        mapInfo["state"].contains("unknown", Qt::CaseInsensitive)) {
         return false;
     }
 


### PR DESCRIPTION
filter the invalid power device

Log: filter the invalid power device
Task: https://pms.uniontech.com/task-view-376787.html

## Summary by Sourcery

Bug Fixes:
- Skip devices whose state contains "empty" or "unknown" in DevicePower::setInfoFromUpower to filter invalid power entries.