### PR TITLE
fix: the invalded device show incorrect

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -655,11 +655,6 @@ void DeviceManager::tomlDeviceSet(DeviceType deviceType)
             DeviceBaseInfo *newDevice = createDevice(deviceType);
             tomlDeviceMapSet(deviceType, newDevice, tomlMapLst[j]);
             tomlDeviceAdd(deviceType, newDevice); //加
-        } else if ((deviceType != DT_Bios) && (deviceType != DT_Computer) && !fixSameOne) {
-            fixSameOne = true;  //标记为该项信息有用过 ，则不再增加了
-            DeviceBaseInfo *device = createDevice(deviceType);
-            tomlDeviceMapSet(deviceType, device, tomlMapLst[j]);
-            tomlDeviceAdd(deviceType, device); //不存在 就加
         }
     } //end of for (int j = 0;...
 }


### PR DESCRIPTION
fix the invalded device show incorrect

Log: fix the invalded device show incorrect
Bug: https://pms.uniontech.com/bug-view-256787.html
Change-Id: I57c51ef8462b11a369a9f0276f039552a9ea2825

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate entries for invalid devices by removing the redundant else-if branch in tomlDeviceSet