### PR TITLE
Fix: the monitor device incorrect order

### DIFF
--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -117,6 +117,10 @@ void ThreadExecXrandr::loadXrandrVerboseInfo(QList<QMap<QString, QString>> &lstM
             // 新的显示屏
             QMap<QString, QString> newMap;
             newMap.insert("mainInfo", (*it).trimmed());
+            auto mainInfoList = (*it).trimmed().split(" ");
+            if (mainInfoList.size() > 0) {
+                newMap.insert("port", mainInfoList.at(0));
+            }
             lstMap.append(newMap);
             continue;
         }
@@ -231,9 +235,12 @@ void ThreadExecXrandr::getMonitorInfoFromXrandrVerbose()
 {
     QList<QMap<QString, QString>> lstMap;
     loadXrandrVerboseInfo(lstMap, "xrandr --verbose");
-    if (Common::specialComType == Common::SpecialComputerType::NormalCom) {
-        std::reverse(lstMap.begin(), lstMap.end());
-    }
+    std::sort(lstMap.begin(), lstMap.end(), [](const QMap<QString, QString> &monintor1, const QMap<QString, QString> &monintor2) {
+        if (monintor1.contains("port") && monintor2.contains("port"))
+            return monintor1.value("port") < monintor2.value("port");
+        else
+            return false;
+    });
     QList<QMap<QString, QString> >::const_iterator it = lstMap.begin();
     for (; it != lstMap.end(); ++it) {
         if ((*it).size() < 1)


### PR DESCRIPTION
-- fix the monitor device incorrect order

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-317457.html

## Summary by Sourcery

Parse the display port from Xrandr output and sort monitor entries by that port name instead of reversing the list.

Bug Fixes:
- Sort monitors based on their port names to ensure correct device order.

Enhancements:
- Extract and store the 'port' identifier when parsing xrandr verbose output.