### PR TITLE
fix: the cpu model in special machine.

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
@@ -251,6 +251,12 @@ void DeviceCpu::setInfoFromDmidecode(const QMap<QString, QString> &mapInfo)
         setAttribute(mapInfo, "product", m_Name);
     }
 
+    if (Common::specialComType > 0) {
+        if (mapInfo.contains("Version")) {
+            setAttribute(mapInfo, "Version", m_Name);
+        }
+    }
+
     // 获取设备基本信息
     setAttribute(mapInfo, "Manufacturer", m_Vendor);
     setAttribute(mapInfo, "Max Speed", m_Frequency, false);

--- a/deepin-devicemanager/src/DeviceManager/DeviceCpu.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCpu.h
@@ -6,7 +6,7 @@
 #ifndef DEVICECPU_H
 #define DEVICECPU_H
 #include "DeviceInfo.h"
-
+#include "commonfunction.h"
 /**
  * @brief The DeviceCpu class
  * 用来描述CPU的类


### PR DESCRIPTION
fix the cpu model.

Log: fix the cpu model.
Bug: https://pms.uniontech.com/task-view-377187.html

## Summary by Sourcery

Use the dmidecode Version field to correctly set CPU model names on special machines

Bug Fixes:
- Set CPU model from dmidecode 'Version' field when specialComType is enabled
- Include commonfunction.h to support specialComType condition