### PR TITLE
fix: remove useless info.

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceBios.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceBios.cpp
@@ -186,9 +186,9 @@ void DeviceBios::initFilterKey()
     addFilterKey("Asset Tag");
     addFilterKey("Features");
     addFilterKey("Location In Chassis");
-    addFilterKey("Chassis Handle");
+//    addFilterKey("Chassis Handle");
     addFilterKey("Type");
-    addFilterKey("Contained Object Handles");
+//    addFilterKey("Contained Object Handles");
 
     addFilterKey("Product Name");
     addFilterKey("Serial Number");

--- a/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
@@ -66,12 +66,12 @@ void DeviceCpu::loadBaseDeviceInfo()
     // 添加基本信息
     addBaseDeviceInfo(("Name"), m_Name);
     addBaseDeviceInfo(("Vendor"), m_Vendor);
-    addBaseDeviceInfo(("CPU ID"), m_PhysicalID);
-    addBaseDeviceInfo(("Core ID"), m_CoreID);
+//    addBaseDeviceInfo(("CPU ID"), m_PhysicalID);
+//    addBaseDeviceInfo(("Core ID"), m_CoreID);
     addBaseDeviceInfo(("Threads"), m_ThreadNum);
     if (!m_FrequencyIsCur)
         addBaseDeviceInfo(("Max Frequency"), m_MaxFrequency);
-    addBaseDeviceInfo(("BogoMIPS"), m_BogoMIPS);
+//    addBaseDeviceInfo(("BogoMIPS"), m_BogoMIPS);
     addBaseDeviceInfo(("Architecture"), m_Architecture);
     addBaseDeviceInfo(("CPU Family"), m_Familly);
     addBaseDeviceInfo(("Model"), m_Model);

--- a/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
@@ -106,7 +106,7 @@ bool DeviceMemory::setInfoFromDmidecode(const QMap<QString, QString> &mapInfo)
 void DeviceMemory::initFilterKey()
 {
     // 初始化可显示属性
-    addFilterKey("Array Handle");  // 数组程序-2
+//    addFilterKey("Array Handle");  // 数组程序-2
     addFilterKey("Error Information Handle"); //错误信息程序-2
     addFilterKey("Form Factor"); // 尺寸型号-2
     addFilterKey("Set");    // 设置-2

--- a/deepin-devicemanager/src/DeviceManager/DevicePower.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DevicePower.cpp
@@ -146,9 +146,9 @@ const QString DevicePower::getOverviewInfo()
 void DevicePower::initFilterKey()
 {
     // 初始化可显示属性
-    addFilterKey("native-path");
+//    addFilterKey("native-path");
     addFilterKey("power supply");
-    addFilterKey("updated");
+//    addFilterKey("updated");
     addFilterKey("has history");
     addFilterKey("has statistics");
     addFilterKey("rechargeable");
@@ -167,7 +167,7 @@ void DevicePower::initFilterKey()
     addFilterKey("percentage");
 //    addFilterKey("temperature"));    // 温度已经常规显示-2
     addFilterKey("technology");
-    addFilterKey("icon-name");
+//    addFilterKey("icon-name");
     addFilterKey("online");
     addFilterKey("daemon-version");
     addFilterKey("on-battery");


### PR DESCRIPTION
remove useless info.

Log: remove useless info.
Task: https://pms.uniontech.com/task-view-377197.html
Change-Id: I38069249ec2ad433e5401a921347d36ae06320c2

## Summary by Sourcery

Remove redundant device information fields across multiple device manager modules

Enhancements:
- Comment out display of CPU ID, Core ID, and BogoMIPS in CPU device info
- Disable 'native-path', 'updated', and 'icon-name' filter keys in power device info
- Disable 'Chassis Handle' and 'Contained Object Handles' filter keys in BIOS device info
- Disable 'Array Handle' filter key in memory device info