### PR TITLE
fix: adjust the storage display order.

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -913,6 +913,55 @@ void DeviceManager::checkDiskSize()
     }
 }
 
+void DeviceManager::orderDiskByType()
+{
+    // 自定义排序
+    auto compareDevices = [](DeviceBaseInfo* baseInfo1, DeviceBaseInfo* baseInfo2) {
+        DeviceStorage *storageA = dynamic_cast<DeviceStorage *>(baseInfo1);
+        DeviceStorage *storageB = dynamic_cast<DeviceStorage *>(baseInfo2);
+
+        if (storageA == nullptr || storageB == nullptr) {
+            return false;
+        }
+
+        // 判断是否为 USB 设备（包括 USB 接口的 SSD）
+        auto isUSBDevice = [](DeviceStorage *device) {
+            return device->interface().contains("USB") ||
+                   (device->interface().contains("USB") && device->mediaType().contains("SSD"));
+        };
+
+        // 1. 首先按照 UFS 优先
+        if (storageA->interface().contains("UFS") && !storageB->interface().contains("UFS"))
+            return true;
+        if (!storageA->interface().contains("UFS") && storageB->interface().contains("UFS"))
+            return false;
+
+        // 2. 然后按照 SSD、HDD 排序（排除 USB 接口的 SSD）
+        if (!isUSBDevice(storageA) && !isUSBDevice(storageB)) {
+            if (storageA->mediaType().contains("SSD") && !storageB->mediaType().contains("SSD"))
+                return true;
+            if (!storageA->mediaType().contains("SSD") && storageB->mediaType().contains("SSD"))
+                return false;
+            if (storageA->mediaType().contains("HDD") && !storageB->mediaType().contains("HDD"))
+                return true;
+            if (!storageA->mediaType().contains("HDD") && storageB->mediaType().contains("HDD"))
+                return false;
+        }
+
+        // 3. 最后按照 USB 设备排序（包括 USB 接口的 SSD）
+        if (isUSBDevice(storageA) && !isUSBDevice(storageB))
+            return false;  // USB 设备排在后面
+        if (!isUSBDevice(storageA) && isUSBDevice(storageB))
+            return true;
+
+        // 如果所有条件都相同，保持原有顺序
+        return false;
+    };
+
+    // 使用自定义比较函数对列表进行排序
+    std::sort(m_ListDeviceStorage.begin(), m_ListDeviceStorage.end(), compareDevices);
+}
+
 bool DeviceManager::setStorageDeviceMediaType(const QString &name, const QString &value)
 {
     // 设置存储设备介质类型

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.h
@@ -213,6 +213,11 @@ public:
      */
     virtual void checkDiskSize();
 
+    /**
+     * @brief orderDiskByType:按照磁盘类型UFS、SSD、HDD、移动存储设备的顺序显示
+     */
+    virtual void orderDiskByType();
+
     // GPU设备相关 **************************************************************************************
     /**
      * @brief addGpuDevice:添加显卡

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -275,6 +275,16 @@ QString DeviceStorage::getSerialID(QString &strDeviceLink)
     return strSerialNumber;
 }
 
+const QString &DeviceStorage::mediaType() const
+{
+    return m_MediaType;
+}
+
+const QString &DeviceStorage::interface() const
+{
+    return m_Interface;
+}
+
 bool DeviceStorage::addInfoFromlshw(const QMap<QString, QString> &mapInfo)
 {
 
@@ -522,16 +532,12 @@ const QString DeviceStorage::getOverviewInfo()
 {
     QString overViewInfo = QString("%1 (%2)").arg(m_Name).arg(m_Size);
 
-    // 见内网gerrit项目 os-config 中机型的 specialComType , 示例配置文件位置如下：
-    // os-config/hardware/机型/etc/dsg/configs/overrides/org.deepin.devicemanager/org.deepin.devicemanager/4000-org.deepin.devicemanager.override.json
-    if (Common::specialComType == 5){
-        if (m_Interface.contains("UFS", Qt::CaseInsensitive)) {
-            overViewInfo = QString("%1 %2").arg(m_Size).arg("UFS");
-        } else if (m_Interface.contains("USB", Qt::CaseInsensitive)) {
-            overViewInfo = QString("%1 %2").arg(m_Size).arg("USB");
-        } else {
-            overViewInfo = QString("%1 %2").arg(m_Size).arg(m_MediaType);
-        }
+    if (m_Interface.contains("UFS", Qt::CaseInsensitive)) {
+        overViewInfo = QString("%1 %2").arg(m_Size).arg("UFS");
+    } else if (m_Interface.contains("USB", Qt::CaseInsensitive)) {
+        overViewInfo = QString("%1 %2").arg(m_Size).arg("USB");
+    } else {
+        overViewInfo = QString("%1 %2").arg(m_Size).arg(m_MediaType);
     }
 
     return overViewInfo;

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.h
@@ -152,6 +152,10 @@ public:
      */
     const QString getOverviewInfo() override;
 
+    QString interface() const;
+
+    QString mediaType() const;
+
 protected:
 
     /**

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -231,6 +231,8 @@ void DeviceGenerator::generatorDiskDevice()
     getDiskInfoFromLsblk();
     getDiskInfoFromSmartCtl();
     DeviceManager::instance()->mergeDisk();
+
+    DeviceManager::instance()->orderDiskByType();
 }
 
 void DeviceGenerator::generatorGpuDevice()


### PR DESCRIPTION
adjust the storage display order.

Log: adjust the storage display order.
Task: https://pms.uniontech.com/task-view-377189.html

## Summary by Sourcery

Sort storage devices by type priority and unify the display format for storage overviews

New Features:
- Introduce an explicit disk ordering method to display storage devices in the sequence UFS, SSD, HDD, then USB
- Invoke the new ordering logic after merging disks in DeviceGenerator

Enhancements:
- Add interface() and mediaType() accessors to DeviceStorage
- Simplify storage overview display to always show size and type without specialComType branching