### PR TITLE
fix: update device description to Universal Flash Storage

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.h
@@ -152,9 +152,9 @@ public:
      */
     const QString getOverviewInfo() override;
 
-    QString interface() const;
+    const QString &interface() const;
 
-    QString mediaType() const;
+    const QString &mediaType() const;
 
 protected:
 

--- a/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
@@ -278,8 +278,7 @@ void HWGenerator::generatorDiskDevice()
                 tempMap["Vendor"] = "nouse";
             if (name.contains("SDINFDO4-256G",Qt::CaseInsensitive))
                 tempMap["Name"] = "nouse";
-            // 应HW的要求，将描述固定为   Universal Flash Storage
-            tempMap["Description"] = "Universal Flash Storage";
+
             if (Common::specialComType == 2) {
                 tempMap["Interface"] = "UFS 3.1";
             }


### PR DESCRIPTION
Update device description to fixed value "Universal Flash Storage".

Log: Update device description to fixed value "Universal Flash Storage"
Bug: https://pms.uniontech.com/bug-view-315353.html
Change-Id: Ic3bc6ccf6f8dacce33b734de2c5e14ed4e0b24db

## Summary by Sourcery

Bug Fixes:
- Remove hardcoded assignment of "Universal Flash Storage" to the device description.