### PR TITLE
fix: format the overview of memory display

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
@@ -214,11 +214,13 @@ const QString DeviceMemory::getOverviewInfo()
     QString nameStr = m_Name != "" ? m_Name : m_Vendor;
     if (nameStr == "--")
         nameStr.clear();
-    ov += QString("%1(%2 %3 %4)") \
+    ov += QString("%1(%2%3 %4)") \
           .arg(m_Size) \
-          .arg(nameStr) \
+          .arg(nameStr + (nameStr.isEmpty() ? "" : " ")) \
           .arg(m_Type) \
           .arg(m_Speed);
+
+    ov = ov.trimmed();
 
     return ov;
 }


### PR DESCRIPTION
format the overview of memory display

Log: format the overview of memory display
Bug: https://pms.uniontech.com/bug-view-320787.html

## Summary by Sourcery

Fix formatting of the memory overview display string to remove extraneous spaces and ensure consistent spacing.

Bug Fixes:
- Adjust spacing around memory size, name, type, and speed in getOverviewInfo()
- Trim trailing whitespace from the overview string