### PR TITLE
fix: Icon fail to display correctly in the help manual

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-devicemanager (6.0.43) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Tue, 24 Jun 2025 17:51:19 +0800
+
 deepin-devicemanager (6.0.42) unstable; urgency=medium
 
   * chore: New version 6.0.42.

--- a/deepin-devicemanager/assets/deepin-devicemanager/device-manager/en_US/device-manager.md
+++ b/deepin-devicemanager/assets/deepin-devicemanager/device-manager/en_US/device-manager.md
@@ -1,5 +1,4 @@
-# device-manager_EN.md
-# Device Manager | deepin-devicemanager
+# Device Manager|deepin-devicemanager|
 
 ## Overview
 

--- a/deepin-devicemanager/assets/deepin-devicemanager/device-manager/zh_HK/device-manager.md
+++ b/deepin-devicemanager/assets/deepin-devicemanager/device-manager/zh_HK/device-manager.md
@@ -1,5 +1,4 @@
-# device-manager_香港繁體.md
-# 裝置管理員 | deepin-devicemanager
+# 裝置管理員|deepin-devicemanager|
 
 ## 概述
 

--- a/deepin-devicemanager/assets/deepin-devicemanager/device-manager/zh_TW/device-manager.md
+++ b/deepin-devicemanager/assets/deepin-devicemanager/device-manager/zh_TW/device-manager.md
@@ -1,5 +1,4 @@
-# device-manager_台灣繁體.md
-# 裝置管理員 | deepin-devicemanager
+# 裝置管理員|deepin-devicemanager|
 
 ## 概述
 


### PR DESCRIPTION
as title

Log: fix bug

## Summary by Sourcery

Clean up the Device Manager help manual formatting to ensure icons render correctly

Documentation:
- Fix the main heading syntax and remove duplicate title lines in the manual
- Remove the redundant ‘Exit’ step at the end of the instructions