### PR TITLE
chore: More logs for device manager

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceAudio.cpp
@@ -27,6 +27,7 @@ DeviceAudio::DeviceAudio()
     , m_Chip("")
     , m_DriverModules("")
 {
+    qCDebug(appLog) << "DeviceAudio constructor called.";
     // 初始化可显示属性
     initFilterKey();
 
@@ -40,6 +41,7 @@ bool DeviceAudio::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
 {
     qCDebug(appLog) << "setInfoFromHwinfo start";
     if (mapInfo.find("path") != mapInfo.end()) {
+        qCDebug(appLog) << "Path found in mapInfo, setting basic attributes.";
         setAttribute(mapInfo, "name", m_Name);
         setAttribute(mapInfo, "driver", m_Driver);
         m_SysPath = mapInfo["path"];
@@ -62,6 +64,7 @@ bool DeviceAudio::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "SysFS ID", m_SysPath);
     setAttribute(mapInfo, "Module Alias", m_UniqueID);
     setAttribute(mapInfo, "SysFS ID", m_BusInfo);
+    qCDebug(appLog) << "Basic device info attributes set.";
 
     setAttribute(mapInfo, "Device", m_Name);
     setAttribute(mapInfo, "Vendor", m_Vendor);
@@ -72,6 +75,7 @@ bool DeviceAudio::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
 
     // 此处不能用 && 因为 m_DriverModules 可能为空
     if (driverIsKernelIn(m_DriverModules) || driverIsKernelIn(m_Driver)) {
+        qCDebug(appLog) << "Driver is kernel in, setting m_CanUninstall to false.";
         m_CanUninstall = false;
     }
 
@@ -98,8 +102,10 @@ bool DeviceAudio::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
     //2. 确定了是该设备信息，则获取设备的基本信息
     setAttribute(mapInfo, "product", m_Name);
     setAttribute(mapInfo, "vendor", m_Vendor);
-    if (m_Vendor == "0000")
+    if (m_Vendor == "0000") {
+        qCDebug(appLog) << "Vendor is 0000, setting to empty.";
         m_Vendor = "";
+    }
 
     setAttribute(mapInfo, "", m_Model);
 
@@ -108,8 +114,10 @@ bool DeviceAudio::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
      * 这不符合常理，所以当版本号为00时，默认版本号获取不到
     */
     setAttribute(mapInfo, "version", m_Version);
-    if (m_Version == "00")
+    if (m_Version == "00") {
+        qCDebug(appLog) << "Version is 00, setting to empty.";
         m_Version = "";
+    }
 
     // 获取设备的基本信息
 //    setAttribute(mapInfo, "bus info", m_BusInfo);
@@ -130,6 +138,7 @@ bool DeviceAudio::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
 
 TomlFixMethod DeviceAudio::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceAudio::setInfoFromTomlOneByOne started.";
     TomlFixMethod ret = TOML_None;
 //  must cover the  loadOtherDeviceInfo
     // 添加基本信息
@@ -142,10 +151,12 @@ TomlFixMethod DeviceAudio::setInfoFromTomlOneByOne(const QMap<QString, QString> 
     ret = setTomlAttribute(mapInfo, "IRQ", m_Irq);
 //3. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceAudio::setInfoFromTomlOneByOne finished.";
     return ret;
 }
 bool DeviceAudio::setInfoFrom_sysFS(QMap<QString, QString> &mapInfo, int ii)
 {
+    qCDebug(appLog) << "DeviceAudio::setInfoFrom_sysFS started for card: " << ii;
     //4. get from cat /sys/class/sound
     QString hwCxDx;
     QString hwCard_path;
@@ -155,42 +166,53 @@ bool DeviceAudio::setInfoFrom_sysFS(QMap<QString, QString> &mapInfo, int ii)
 
     QFileInfo info1(Cardx_path);
     if (info1.isSymLink()) {       // returns true
+        qCDebug(appLog) << "Card path is a symlink, resolving target.";
         m_BusInfo =  info1.symLinkTarget();
         m_SysPath =  info1.symLinkTarget();
     }
     QString tmps = "/sound/" + Cardx;
     m_SysPath = m_SysPath.remove(tmps);
     m_SysPath = m_SysPath.remove("/sys");
+    qCDebug(appLog) << "SysPath after processing: " << m_SysPath;
 
     QString vid = DeviceBaseInfo::get_string(Cardx_path + "/device/vendor");
     QString pid = DeviceBaseInfo::get_string(Cardx_path + "/device/device");
+    qCDebug(appLog) << "Vendor ID: " << vid << ", Product ID: " << pid;
 
     for (int n = 0; n < 11; n++) { //这里最多假定为device编号最大为 0-9
-
+        qCDebug(appLog) << "Checking hwC-D path for n: " << n;
         hwCxDx = QString("hwC%1D%2").arg(ii).arg(n);
         hwCard_path =   "/sys/class/sound/"  + hwCxDx;
         QDir dir(hwCard_path);
         if (dir.exists()) {
+            qCDebug(appLog) << "hwCard_path exists: " << hwCard_path;
             QFile file(hwCard_path + "/vendor_id");
             if (file.open(QIODevice::ReadOnly)) {
+                qCDebug(appLog) << "vendor_id file opened successfully, breaking loop.";
                 file.close();
                 break;
             }
         }
-        if (9 == n)
+        if (9 == n) {
+            qCWarning(appLog) << "No valid hwC-D path found after 10 tries.";
             return false;
+        }
     }
 
     if (vid.isEmpty() || pid.isEmpty()) {                    // 如果/cardx/device/device 先取作数据
+        qCDebug(appLog) << "VID or PID is empty, setting m_VID_PID from vendor_id.";
         m_VID_PID = DeviceBaseInfo::get_string(hwCard_path + "/vendor_id");  //没有 则取 chip vendor_id
-    } else
+    } else {
+        qCDebug(appLog) << "VID and PID are present, concatenating for m_VID_PID.";
         m_VID_PID = vid.trimmed() + pid.remove("0x", Qt::CaseSensitive).trimmed();
+    }
 
     m_Chip = DeviceBaseInfo::get_string(hwCard_path + "/vendor_name") + " " + DeviceBaseInfo::get_string(hwCard_path + "/chip_name");
     m_Vendor = DeviceBaseInfo::get_string(hwCard_path + "/vendor_name");
     m_Name =  DeviceBaseInfo::get_string(Cardx_path + "/id") + " " + QString("/card%1").arg(ii);
     m_Model = m_VID_PID;
     m_Driver = "driveby " + DeviceBaseInfo::get_string(hwCard_path + "/vendor_name");  //debug
+    qCDebug(appLog) << "Chip: " << m_Chip << ", Vendor: " << m_Vendor << ", Name: " << m_Name << ", Model: " << m_Model << ", Driver: " << m_Driver;
 
     // setAttribute(mapInfo, "SysFS ID", m_SysPath);
 
@@ -198,6 +220,7 @@ bool DeviceAudio::setInfoFrom_sysFS(QMap<QString, QString> &mapInfo, int ii)
     mapInfo.insert("VID_PID", m_VID_PID);
     mapInfo.insert("SysFS ID", m_SysPath);
     mapInfo.insert("chip", m_Chip);
+    qCDebug(appLog) << "Map info updated with VID_PID, SysFS ID, and chip.";
 
     //2. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
@@ -205,11 +228,13 @@ bool DeviceAudio::setInfoFrom_sysFS(QMap<QString, QString> &mapInfo, int ii)
     // 设置不可禁用
     m_CanEnable = false;
     m_CanUninstall = false;
+    qCDebug(appLog) << "DeviceAudio::setInfoFrom_sysFS finished.";
     return true;
 }
 
 bool DeviceAudio::setInfoFromCatDevices(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceAudio::setInfoFromCatDevices started.";
     //1. 获取设备的基本信息
     setAttribute(mapInfo, "Name", m_Name);
     setAttribute(mapInfo, "Vendor", m_Vendor);
@@ -222,30 +247,36 @@ bool DeviceAudio::setInfoFromCatDevices(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "", m_Clock);
     setAttribute(mapInfo, "", m_Capabilities);
     setAttribute(mapInfo, "", m_Description);
+    qCDebug(appLog) << "Basic attributes set from CatDevices.";
 
     //2. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
 
     //3. get from cat /input/devices
     m_IsCatDevice = true;
+    qCDebug(appLog) << "DeviceAudio::setInfoFromCatDevices finished.";
 
     return true;
 }
 
 void DeviceAudio::setInfoFromCatAudio(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceAudio::setInfoFromCatAudio started.";
     //1. 获取设备的基本信息
     setAttribute(mapInfo, "Name", m_Name);
     setAttribute(mapInfo, "driver", m_Driver);
     setAttribute(mapInfo, "Vendor", m_Vendor);
     setAttribute(mapInfo, "Model", m_Model);
+    qCDebug(appLog) << "Basic attributes set from CatAudio.";
 
     //2. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceAudio::setInfoFromCatAudio finished.";
 }
 
 bool DeviceAudio::setAudioChipFromDmesg(const QString &info)
 {
+    qCDebug(appLog) << "DeviceAudio::setAudioChipFromDmesg started with info: " << info;
     // 设置声卡芯片型号
     m_Chip = info;
     return true;
@@ -253,33 +284,43 @@ bool DeviceAudio::setAudioChipFromDmesg(const QString &info)
 
 const QString &DeviceAudio::chip_name()const
 {
+    qCDebug(appLog) << "DeviceAudio::chip_name called.";
     return m_Chip;
 }
 
 
 const QString &DeviceAudio::name()const
 {
+    qCDebug(appLog) << "DeviceAudio::name called.";
     return m_Name;
 }
 
 const QString &DeviceAudio::vendor() const
 {
+    qCDebug(appLog) << "DeviceAudio::vendor called.";
     return m_Vendor;
 }
 
 const QString &DeviceAudio::driver() const
 {
-    if (! m_DriverModules.isEmpty())
+    qCDebug(appLog) << "DeviceAudio::driver called.";
+    if (! m_DriverModules.isEmpty()) {
+        qCDebug(appLog) << "Returning driver from m_DriverModules.";
         return m_DriverModules;
+    }
+    qCDebug(appLog) << "Returning driver from m_Driver.";
     return m_Driver;
 }
 const QString &DeviceAudio::uniqueID() const
 {
+    qCDebug(appLog) << "DeviceAudio::uniqueID called.";
     return m_SysPath;
 }
 EnableDeviceStatus DeviceAudio::setEnable(bool e)
 {
+    qCDebug(appLog) << "DeviceAudio::setEnable called with status: " << e;
     if (!m_SysPath.contains("usb")) {
+        qCDebug(appLog) << "SysPath does not contain 'usb', setting UniqueID to Name.";
         m_UniqueID = m_Name;
     }
     m_HardwareClass = "sound";
@@ -290,7 +331,10 @@ EnableDeviceStatus DeviceAudio::setEnable(bool e)
     }
     bool res  = DBusEnableInterface::getInstance()->enable(m_HardwareClass, m_Name, m_SysPath, m_UniqueID, e, m_Driver);
     if (res) {
+        qCDebug(appLog) << "DBus enable call successful, setting m_Enable to " << e;
         m_Enable = e;
+    } else {
+        qCDebug(appLog) << "DBus enable call failed.";
     }
     // 设置设备状态
     qCDebug(appLog) << "Set enable status:" << e << "result:" << res;
@@ -299,24 +343,30 @@ EnableDeviceStatus DeviceAudio::setEnable(bool e)
 
 bool DeviceAudio::enable()
 {
+    // qCDebug(appLog) << "DeviceAudio::enable called, returning current enable status: " << m_Enable;
     // 获取设备状态
     return m_Enable;
 }
 
 QString DeviceAudio::subTitle()
 {
+    // qCDebug(appLog) << "DeviceAudio::subTitle called, returning: " << m_Name;
     // 设备信息子标题
     return m_Name;
 }
 
 const QString DeviceAudio::getOverviewInfo()
 {
+    qCDebug(appLog) << "DeviceAudio::getOverviewInfo called.";
     // 获取概况信息
-    return m_Name.isEmpty() ? m_Model : m_Name;
+    QString overviewInfo = m_Name.isEmpty() ? m_Model : m_Name;
+    qCDebug(appLog) << "Overview info: " << overviewInfo;
+    return overviewInfo;
 }
 
 void DeviceAudio::initFilterKey()
 {
+    qCDebug(appLog) << "DeviceAudio::initFilterKey called.";
     // 添加可显示的属性
     addFilterKey(tr("Device Name"));
     addFilterKey(QObject::tr("SubVendor"));
@@ -334,10 +384,12 @@ void DeviceAudio::initFilterKey()
     addFilterKey(QObject::tr("Bus"));
     addFilterKey(QObject::tr("Version"));
     addFilterKey(QObject::tr("Driver"));
+    qCDebug(appLog) << "Filter keys initialized.";
 }
 
 void DeviceAudio::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceAudio::loadBaseDeviceInfo called.";
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name);
     addBaseDeviceInfo(tr("Vendor"), m_Vendor);
@@ -345,10 +397,12 @@ void DeviceAudio::loadBaseDeviceInfo()
     addBaseDeviceInfo(tr("Description"), m_Description);
     addBaseDeviceInfo(tr("Revision"), m_Version);
     addBaseDeviceInfo(tr("KernelModeDriver"), m_Driver);
+    qCDebug(appLog) << "Base device info loaded.";
 }
 
 void DeviceAudio::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceAudio::loadOtherDeviceInfo called.";
     // 添加其他信息,成员变量
     addOtherDeviceInfo(tr("Module Alias"), m_Modalias);
     addOtherDeviceInfo(tr("Physical ID"), m_PhysID);
@@ -358,30 +412,37 @@ void DeviceAudio::loadOtherDeviceInfo()
     addOtherDeviceInfo(tr("IRQ"), m_Irq);
     // 将QMap<QString, QString>内容转存为QList<QPair<QString, QString>>
     mapInfoToList();
+    qCDebug(appLog) << "Other device info loaded.";
 }
 
 void DeviceAudio::loadTableHeader()
 {
+    qCDebug(appLog) << "DeviceAudio::loadTableHeader called.";
     // 表头信息
     m_TableHeader.append(tr("Name"));
     m_TableHeader.append(tr("Vendor"));
+    qCDebug(appLog) << "Table header loaded.";
 }
 
 void DeviceAudio::loadTableData()
 {
+    qCDebug(appLog) << "DeviceAudio::loadTableData called.";
     // 记载表格内容
     QString tName = m_Name;
 
     if (!available()) {
+        qCDebug(appLog) << "Device not available, updating tName.";
         tName = "(" + tr("Unavailable") + ") " + m_Name;
     }
 
     if (!enable()) {
+        qCDebug(appLog) << "Device disabled, updating tName.";
         tName = "(" + tr("Disable") + ") " + m_Name;
     }
 
     m_TableData.append(tName);
     m_TableData.append(m_Vendor);
+    qCDebug(appLog) << "Table data loaded.";
 }
 
 // sysfs sound 数据获取说明如下：

--- a/deepin-devicemanager/src/DeviceManager/DeviceBios.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceBios.cpp
@@ -24,6 +24,7 @@ DeviceBios::DeviceBios()
 
 TomlFixMethod DeviceBios::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceBios::setInfoFromTomlOneByOne started.";
     TomlFixMethod ret = TOML_None;
 
     ret = setTomlAttribute(mapInfo, "Version", m_Version, true);
@@ -31,9 +32,11 @@ TomlFixMethod DeviceBios::setInfoFromTomlOneByOne(const QMap<QString, QString> &
     ret = setTomlAttribute(mapInfo, "Chipset", m_ChipsetFamily, true);
     // ret = setTomlAttribute(mapInfo, "Vendor", m_Vendor,true);
     // m_IsBoard = true;
+    qCDebug(appLog) << "Toml attributes set for Version, Product Name, Chipset.";
 
     //3. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceBios::setInfoFromTomlOneByOne finished, return: " << ret;
     return ret;
 }
 
@@ -41,22 +44,27 @@ bool DeviceBios::setBiosInfo(const QMap<QString, QString> &mapInfo)
 {
     qCDebug(appLog) << "Start setting BIOS info";
 
-    if (mapInfo.size() < 2)
+    if (mapInfo.size() < 2) {
+        qCDebug(appLog) << "mapInfo size less than 2, returning false.";
         return false;
+    }
 
     // 获取BIOS信息
     m_Name = QObject::tr("BIOS Information");
     m_tomlName = ("BIOS Information");
     setAttribute(mapInfo, "Vendor", m_Vendor);
     setAttribute(mapInfo, "Version", m_Version);
+    qCDebug(appLog) << "BIOS info attributes set.";
 
     // 获取BIOS其他信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceBios::setBiosInfo finished.";
     return true;
 }
 
 bool DeviceBios::setBiosLanguageInfo(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Start setting bios language info";
     getOtherMapInfo(mapInfo);
     return true;
 }
@@ -65,8 +73,10 @@ bool DeviceBios::setBaseBoardInfo(const QMap<QString, QString> &mapInfo)
 {
     qCDebug(appLog) << "Start setting base board info";
 
-    if (mapInfo.size() < 2)
+    if (mapInfo.size() < 2) {
+        qCDebug(appLog) << "mapInfo size less than 2, returning false.";
         return false;
+    }
 
     // 获取主板信息
     m_Name = QObject::tr("Base Board Information");
@@ -76,95 +86,120 @@ bool DeviceBios::setBaseBoardInfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Product Name", m_ProductName);
     setAttribute(mapInfo, "Board name", m_ProductName, false);
     setAttribute(mapInfo, "chipset", m_ChipsetFamily);
+    qCDebug(appLog) << "Base board info attributes set.";
 
     // 该信息为主板信息
     m_IsBoard = true;
+    qCDebug(appLog) << "m_IsBoard set to true.";
 
     // 获取其他信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceBios::setBaseBoardInfo finished.";
     return true;
 }
 
 bool DeviceBios::setSystemInfo(const QMap<QString, QString> &mapInfo)
 {
-    if (mapInfo.size() < 2)
+    qCDebug(appLog) << "DeviceBios::setSystemInfo started.";
+    if (mapInfo.size() < 2) {
+        qCDebug(appLog) << "mapInfo size less than 2, returning false.";
         return false;
+    }
 
     // 获取系统信息
     m_Name = QObject::tr("System Information");
     m_tomlName = ("System Information");
     setAttribute(mapInfo, "Manufacturer", m_Vendor);
     setAttribute(mapInfo, "Version", m_Version);
+    qCDebug(appLog) << "System info attributes set.";
 
     // 获取其他信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceBios::setSystemInfo finished.";
     return true;
 }
 
 bool DeviceBios::setChassisInfo(const QMap<QString, QString> &mapInfo)
 {
-    if (mapInfo.size() < 2)
+    qCDebug(appLog) << "DeviceBios::setChassisInfo started.";
+    if (mapInfo.size() < 2) {
+        qCDebug(appLog) << "mapInfo size less than 2, returning false.";
         return false;
+    }
 
     // 获取机箱信息
     m_Name = QObject::tr("Chassis Information");
     m_tomlName = ("Chassis Information");
     setAttribute(mapInfo, "Manufacturer", m_Vendor);
     setAttribute(mapInfo, "Version", m_Version);
+    qCDebug(appLog) << "Chassis info attributes set.";
 
     // 获取其他信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceBios::setChassisInfo finished.";
     return true;
 }
 
 bool DeviceBios::setMemoryInfo(const QMap<QString, QString> &mapInfo)
 {
-    if (mapInfo.size() < 2)
+    qCDebug(appLog) << "DeviceBios::setMemoryInfo started.";
+    if (mapInfo.size() < 2) {
+        qCDebug(appLog) << "mapInfo size less than 2, returning false.";
         return false;
+    }
 
     // 获取内存插槽信息
     m_Name = QObject::tr("Physical Memory Array");
     m_tomlName = ("Physical Memory Array");
     setAttribute(mapInfo, "Manufacturer", m_Vendor);
     setAttribute(mapInfo, "Version", m_Version);
+    qCDebug(appLog) << "Memory info attributes set.";
 
     // 获取其他信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceBios::setMemoryInfo finished.";
     return true;
 }
 
 const QString &DeviceBios::name()const
 {
+    // qCDebug(appLog) << "DeviceBios::name called, returning: " << m_Name;
     return m_Name;
 }
 
 const QString &DeviceBios::tomlname()
 {
+    // qCDebug(appLog) << "DeviceBios::tomlname called, returning: " << m_tomlName;
     return m_tomlName;
 }
 
 const QString &DeviceBios::driver() const
 {
+    // qCDebug(appLog) << "DeviceBios::driver called, returning: " << m_Driver;
     return m_Driver;
 }
 
 const QString &DeviceBios::vendor()const
 {
+    // qCDebug(appLog) << "DeviceBios::vendor called, returning: " << m_Vendor;
     return m_Vendor;
 }
 
 const QString &DeviceBios::version()const
 {
+    // qCDebug(appLog) << "DeviceBios::version called, returning: " << m_Version;
     return m_Version;
 }
 
 bool DeviceBios::isBoard()const
 {
+    // qCDebug(appLog) << "DeviceBios::isBoard called, returning: " << m_IsBoard;
     return m_IsBoard;
 }
 
 QString DeviceBios::subTitle()
 {
+    // qCDebug(appLog) << "DeviceBios::subTitle called, returning: " << m_Name;
     return m_Name;
 }
 
@@ -173,14 +208,18 @@ const QString DeviceBios::getOverviewInfo()
     qCDebug(appLog) << "Getting BIOS overview info";
 
     // 获取主板概况信息
-    if (isBoard())
+    if (isBoard()) {
+        qCDebug(appLog) << "Is board, returning product name: " << m_ProductName;
         return m_ProductName;
-    else
+    } else {
+        qCDebug(appLog) << "Not board, returning empty string.";
         return QString("");
+    }
 }
 
 void DeviceBios::initFilterKey()
 {
+    qCDebug(appLog) << "DeviceBios::initFilterKey called.";
 
     // 添加可显示属性
     addFilterKey(QObject::tr("Release Date"));
@@ -244,11 +283,12 @@ void DeviceBios::initFilterKey()
     addFilterKey(QObject::tr("Language Description Format"));
     addFilterKey(QObject::tr("Installable Languages"));
     addFilterKey(QObject::tr("Currently Installed Language"));
-
+    qCDebug(appLog) << "Filter keys initialized.";
 }
 
 void DeviceBios::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceBios::loadBaseDeviceInfo called.";
     // 添加基本信息
     addBaseDeviceInfo(tr("Vendor"), m_Vendor);
     addBaseDeviceInfo(tr("Version"), m_Version);
@@ -257,17 +297,19 @@ void DeviceBios::loadBaseDeviceInfo()
 
 void DeviceBios::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "Loading other device info";
     // 将QMap<QString, QString>内容转存为QList<QPair<QString, QString>>
     mapInfoToList();
 }
 
 void DeviceBios::loadTableHeader()
 {
+    // qCDebug(appLog) << "Loading table header";
     // 主板界面无表格,清空表头
     m_TableHeader.clear();
 }
 
 void DeviceBios::loadTableData()
 {
-
+    // qCDebug(appLog) << "Loading table data";
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceCdrom.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCdrom.cpp
@@ -26,8 +26,10 @@ bool DeviceCdrom::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
     qCDebug(appLog) << "Start setting CDROM info from lshw";
 
     // 通过总线信息判断是否是同一台设备
-    if (!matchToLshw(mapInfo))
+    if (!matchToLshw(mapInfo)) {
+        qCDebug(appLog) << "Device not matched in lshw info, returning false.";
         return false;
+    }
 
     // 获取设备的基本信息
     setAttribute(mapInfo, "product", m_Name, false);
@@ -39,6 +41,7 @@ bool DeviceCdrom::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "", m_Driver);
     setAttribute(mapInfo, "", m_MaxPower);
     setAttribute(mapInfo, "", m_Speed);
+    qCDebug(appLog) << "Basic attributes set from Lshw.";
 
     // 获取其他设备信息
     getOtherMapInfo(mapInfo);
@@ -48,14 +51,17 @@ bool DeviceCdrom::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
 
 TomlFixMethod DeviceCdrom::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceCdrom::setInfoFromTomlOneByOne started.";
     TomlFixMethod ret = TOML_None;
     ret = setTomlAttribute(mapInfo, "Model", m_Type);
     ret = setTomlAttribute(mapInfo, "Bus Info", m_BusInfo);
     ret = setTomlAttribute(mapInfo, "Capabilities", m_Capabilities);
     ret = setTomlAttribute(mapInfo, "Maximum Power", m_MaxPower);
     ret = setTomlAttribute(mapInfo, "Speed", m_Speed);
+    qCDebug(appLog) << "Toml attributes set.";
 //3. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceCdrom::setInfoFromTomlOneByOne finished, return: " << ret;
     return ret;
 }
 
@@ -73,6 +79,7 @@ void DeviceCdrom::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Driver", m_Driver);
     setAttribute(mapInfo, "", m_MaxPower);
     setAttribute(mapInfo, "Speed", m_Speed);
+    qCDebug(appLog) << "Basic attributes set from Hwinfo.";
 
     setAttribute(mapInfo, "Module Alias", m_Modalias);
     setAttribute(mapInfo, "VID_PID", m_VID_PID);
@@ -83,36 +90,43 @@ void DeviceCdrom::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
 
     // 获取其他设备信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceCdrom::setInfoFromHwinfo finished.";
 }
 
 const QString &DeviceCdrom::name()const
 {
+    // qCDebug(appLog) << "DeviceCdrom::name called, returning: " << m_Name;
     return m_Name;
 }
 
 const QString &DeviceCdrom::vendor() const
 {
+    // qCDebug(appLog) << "DeviceCdrom::vendor called, returning: " << m_Vendor;
     return m_Vendor;
 }
 
 const QString &DeviceCdrom::driver()const
 {
+    // qCDebug(appLog) << "DeviceCdrom::driver called, returning: " << m_Driver;
     return m_Driver;
 }
 
 QString DeviceCdrom::subTitle()
 {
+    // qCDebug(appLog) << "DeviceCdrom::subTitle called, returning: " << m_Name;
     return m_Name;
 }
 
 const QString DeviceCdrom::getOverviewInfo()
 {
+    // qCDebug(appLog) << "DeviceCdrom::getOverviewInfo called, returning: " << m_Name;
     return m_Name;
 }
 
 
 void DeviceCdrom::initFilterKey()
 {
+    qCDebug(appLog) << "DeviceCdrom::initFilterKey called.";
     // 添加可显示的属性
     addFilterKey(QObject::tr("Serial ID"));
     addFilterKey(QObject::tr("Driver Modules"));
@@ -128,11 +142,12 @@ void DeviceCdrom::initFilterKey()
     addFilterKey(QObject::tr("logical name"));
 //    addFilterKey(QObject::tr("bus info"));
     addFilterKey(QObject::tr("ansiversion"));
-
+    qCDebug(appLog) << "Filter keys initialized.";
 }
 
 void DeviceCdrom::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceCdrom::loadBaseDeviceInfo called.";
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name);
     addBaseDeviceInfo(tr("Vendor"), m_Vendor);
@@ -143,31 +158,38 @@ void DeviceCdrom::loadBaseDeviceInfo()
     addBaseDeviceInfo(tr("Driver"), m_Driver);
     addBaseDeviceInfo(tr("Maximum Power"), m_MaxPower);
     addBaseDeviceInfo(tr("Speed"), m_Speed);
+    qCDebug(appLog) << "Base device info loaded.";
 }
 
 void DeviceCdrom::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceCdrom::loadOtherDeviceInfo called.";
     addOtherDeviceInfo(tr("Module Alias"), m_Modalias);
     addOtherDeviceInfo(tr("Physical ID"), m_PhysID);
     // 将QMap<QString, QString>内容转存为QList<QPair<QString, QString>>
     mapInfoToList();
+    qCDebug(appLog) << "Other device info loaded.";
 }
 
 void DeviceCdrom::loadTableData()
 {
+    qCDebug(appLog) << "DeviceCdrom::loadTableData called.";
     // 加载表格内容
     QString tName = m_Name;
 
     if (!available()) {
+        qCDebug(appLog) << "Device not available, updating tName.";
         tName = "(" + tr("Unavailable") + ") " + m_Name;
     }
 
     if (!enable()) {
+        qCDebug(appLog) << "Device disabled, updating tName.";
         tName = "(" + tr("Disable") + ") " + m_Name;
     }
 
     m_TableData.append(tName);
     m_TableData.append(m_Vendor);
     m_TableData.append(m_Type);
+    qCDebug(appLog) << "Table data loaded.";
 }
 

--- a/deepin-devicemanager/src/DeviceManager/DeviceComputer.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceComputer.cpp
@@ -34,81 +34,104 @@ TomlFixMethod DeviceComputer::setInfoFromTomlOneByOne(const QMap<QString, QStrin
     ret = setTomlAttribute(mapInfo, "vendor", m_Vendor);
     ret = setTomlAttribute(mapInfo, "OS", m_OS);
     ret = setTomlAttribute(mapInfo, "OsDescription", m_OsDescription);
+    qCDebug(appLog) << "Toml attributes set: HomeUrl=" << m_HomeUrl << ", Type=" << m_Type << ", Vendor=" << m_Vendor << ", OS=" << m_OS << ", OsDescription=" << m_OsDescription;
 //3. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceComputer::setInfoFromTomlOneByOne finished, return: " << ret;
     return ret;
 }
 
 const QString &DeviceComputer::name() const
 {
+    // qCDebug(appLog) << "DeviceComputer::name called, returning: " << m_Name;
     return m_Name;
 }
 
 const QString &DeviceComputer::vendor() const
 {
+    // qCDebug(appLog) << "DeviceComputer::vendor called, returning: " << m_Vendor;
     return m_Vendor;
 }
 
 const QString &DeviceComputer::driver() const
 {
+    // qCDebug(appLog) << "DeviceComputer::driver called, returning: " << m_Driver;
     return m_Driver;
 }
 
 void DeviceComputer::setHomeUrl(const QString &value)
 {
+    // qCDebug(appLog) << "DeviceComputer::setHomeUrl called with value: " << value;
     // 设置主页网站
     m_HomeUrl = value;
 }
 
 void DeviceComputer::setOsDescription(const QString &value)
 {
+    // qCDebug(appLog) << "DeviceComputer::setOsDescription called with value: " << value;
     // 设置操作系统描述
     m_OsDescription = value;
 }
 
 void DeviceComputer::setOS(const QString &value)
 {
+    // qCDebug(appLog) << "DeviceComputer::setOS called with value: " << value;
     // 设置操作系统
     m_OS = value;
 }
 
 void DeviceComputer::setVendor(const QString &value)
 {
+    // qCDebug(appLog) << "DeviceComputer::setVendor called with value: " << value;
     // 设置制造商
     m_Vendor = value;
 }
 
 void DeviceComputer::setName(const QString &value)
 {
+    qCDebug(appLog) << "DeviceComputer::setName called with value: " << value;
     // 设置计算机名称
     m_Name = value;
-    if (m_Name.contains("None", Qt::CaseInsensitive))
+    if (m_Name.contains("None", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "Name contains 'None', setting to empty.";
         m_Name = "";
+    }
+    qCDebug(appLog) << "Name set to: " << m_Name;
 }
 
 void DeviceComputer::setType(const QString &value)
 {
+    // qCDebug(appLog) << "DeviceComputer::setType called with value: " << value;
     // 设置设备类型
     m_Type = value;
 }
 
 void DeviceComputer::setVendor(const QString &dm1Vendor, const QString &dm2Vendor)
 {
+    qCDebug(appLog) << "DeviceComputer::setVendor (overload) called with dm1Vendor: " << dm1Vendor << ", dm2Vendor: " << dm2Vendor;
     // 设置制造商
-    if (dm1Vendor.contains("System manufacturer"))
+    if (dm1Vendor.contains("System manufacturer")) {
+        qCDebug(appLog) << "dm1Vendor contains 'System manufacturer', setting vendor to dm2Vendor: " << dm2Vendor;
         m_Vendor = dm2Vendor;
-    else
+    } else {
+        qCDebug(appLog) << "dm1Vendor does not contain 'System manufacturer', setting vendor to dm1Vendor: " << dm1Vendor;
         m_Vendor = dm1Vendor;
+    }
+    qCDebug(appLog) << "Final vendor set to: " << m_Vendor;
 }
 
 void DeviceComputer::setName(const QString &dm1Name, const QString &dm2Name, const QString &dm1Family, const QString &dm1Version)
 {
+    qCDebug(appLog) << "DeviceComputer::setName (overload) called with dm1Name: " << dm1Name << ", dm2Name: " << dm2Name << ", dm1Family: " << dm1Family << ", dm1Version: " << dm1Version;
     // name
     QString pname;
-    if (dm1Name.contains("System Product Name"))
+    if (dm1Name.contains("System Product Name")) {
+        qCDebug(appLog) << "dm1Name contains 'System Product Name', setting pname to dm2Name: " << dm2Name;
         pname = dm2Name;
-    else
+    } else {
+        qCDebug(appLog) << "dm1Name does not contain 'System Product Name', setting pname to dm1Name: " << dm1Name;
         pname = dm1Name;
+    }
 
     // family
     QString family = dm1Family;
@@ -117,6 +140,7 @@ void DeviceComputer::setName(const QString &dm1Name, const QString &dm2Name, con
             || dm1Family.contains("Not Specified", Qt::CaseInsensitive) \
             || dm1Family.contains("x.x", Qt::CaseInsensitive) \
             || dm1Family.contains("Not Applicable", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "dm1Family matches exclusion criteria, setting family to empty.";
         family = "";
     }
 
@@ -127,6 +151,7 @@ void DeviceComputer::setName(const QString &dm1Name, const QString &dm2Name, con
             || dm1Version.contains("Not Specified", Qt::CaseInsensitive) \
             || dm1Version.contains("x.x", Qt::CaseInsensitive) \
             || dm1Version.contains("Not Applicable", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "dm1Version matches exclusion criteria, setting version to empty.";
         version = "";
     }
 
@@ -139,6 +164,7 @@ void DeviceComputer::setName(const QString &dm1Name, const QString &dm2Name, con
     family = family.remove(version, Qt::CaseInsensitive);
 
     m_Name = family + " " + version + " " + pname;
+    qCDebug(appLog) << "Final name set to: " << m_Name;
 }
 
 const QString DeviceComputer::getOverviewInfo()
@@ -156,27 +182,34 @@ const QString DeviceComputer::getOverviewInfo()
 
 const QString DeviceComputer::getOSInfo()
 {
-    return m_OsDescription + " " + m_OS;
+    // qCDebug(appLog) << "DeviceComputer::getOSInfo called.";
+    QString osInfo = m_OsDescription + " " + m_OS;
+    // qCDebug(appLog) << "OS Info: " << osInfo;
+    return osInfo;
 }
 
 void DeviceComputer::initFilterKey()
 {
-
+    qCDebug(appLog) << "DeviceComputer::initFilterKey called.";
+    // initFilterKey is intentionally empty based on existing code.
 }
 
 void DeviceComputer::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceComputer::loadBaseDeviceInfo called.";
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name);
 }
 
 void DeviceComputer::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceComputer::loadOtherDeviceInfo called.";
     // 将QMap<QString, QString>内容转存为QList<QPair<QString, QString>>
     mapInfoToList();
 }
 
 void DeviceComputer::loadTableData()
 {
+    // qCDebug(appLog) << "DeviceComputer::loadTableData called. No data to load based on existing function body.";
 
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
@@ -40,6 +40,7 @@ DeviceGpu::DeviceGpu()
 
 void DeviceGpu::initFilterKey()
 {
+    qCDebug(appLog) << "DeviceGpu::initFilterKey called.";
     // 添加可显示属性
     addFilterKey(QObject::tr("Device"));
     addFilterKey(QObject::tr("SubVendor"));
@@ -56,6 +57,7 @@ void DeviceGpu::initFilterKey()
     addFilterKey(QObject::tr("EGL client APIs"));
     addFilterKey(QObject::tr("GL version"));
     addFilterKey(QObject::tr("GLSL version"));
+    qCDebug(appLog) << "Filter keys initialized.";
 }
 
 void DeviceGpu::loadBaseDeviceInfo()
@@ -68,6 +70,7 @@ void DeviceGpu::loadBaseDeviceInfo()
     addBaseDeviceInfo(tr("Model"), m_Model);
     addBaseDeviceInfo(tr("Version"), m_Version);
     addBaseDeviceInfo(tr("Graphics Memory"), m_GraphicsMemory);
+    qCDebug(appLog) << "Base device info loaded.";
 }
 
 void DeviceGpu::setLshwInfo(const QMap<QString, QString> &mapInfo)
@@ -82,6 +85,7 @@ void DeviceGpu::setLshwInfo(const QMap<QString, QString> &mapInfo)
 
     // 设置属性
     if ((m_Name.isEmpty() || m_Name.startsWith("pci")) && mapInfo.contains("product") && !mapInfo["product"].startsWith("pci")) {
+        qCDebug(appLog) << "Setting model from Lshw product.";
         m_Model = mapInfo["product"];
     }
     setAttribute(mapInfo, "product", m_Name, m_Name.isEmpty() || (m_Name.startsWith("pci") && mapInfo.contains("product") && !mapInfo["product"].startsWith("pci")));
@@ -97,6 +101,7 @@ void DeviceGpu::setLshwInfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "ioport", m_IOPort);
     setAttribute(mapInfo, "memory", m_MemAddress);
     // setAttribute(mapInfo, "physical id", m_PhysID);
+    qCDebug(appLog) << "Lshw attributes set.";
 
     if (driverIsKernelIn(m_Driver) || m_Driver.isEmpty()) {
         qCDebug(appLog) << "Driver is kernel module or empty";
@@ -105,10 +110,12 @@ void DeviceGpu::setLshwInfo(const QMap<QString, QString> &mapInfo)
 
     // 获取其他属性
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceGpu::setLshwInfo finished.";
 }
 
 TomlFixMethod DeviceGpu::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceGpu::setInfoFromTomlOneByOne started.";
     TomlFixMethod ret = TOML_None;
     setTomlAttribute(mapInfo, "Model", m_Model);
     setTomlAttribute(mapInfo, "Graphics Memory", m_GraphicsMemory);
@@ -131,8 +138,10 @@ TomlFixMethod DeviceGpu::setInfoFromTomlOneByOne(const QMap<QString, QString> &m
     setTomlAttribute(mapInfo, "IRQ", m_IRQ);
     setTomlAttribute(mapInfo, "Width", m_Width);
     setAttribute(mapInfo, "Version", m_Version);
+    qCDebug(appLog) << "Toml attributes set.";
 //3. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceGpu::setInfoFromTomlOneByOne finished, return: " << ret;
     return ret;
 }
 
@@ -145,10 +154,12 @@ bool DeviceGpu::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Device", m_Name, true);
     // 如果subdevice有值则使用subdevice
     if (m_Name.isEmpty() || (mapInfo.contains("SubDevice") && mapInfo["Device"].startsWith("pci") && !mapInfo["SubDevice"].startsWith("pci"))) {
+        qCDebug(appLog) << "Setting name from SubDevice.";
         setAttribute(mapInfo, "SubDevice", m_Name, true);
     }
     setAttribute(mapInfo, "Model", m_Model);
     if (m_Model.isEmpty() && !m_Name.isEmpty() && !m_Name.startsWith("pci")) {
+        qCDebug(appLog) << "Model is empty, setting model to name.";
         m_Model = m_Name;
     }
     setAttribute(mapInfo, "Revision", m_Version, false);
@@ -159,6 +170,7 @@ bool DeviceGpu::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Module Alias", m_Modalias);
     setAttribute(mapInfo, "VID_PID", m_VID_PID);
     m_PhysID = m_VID_PID;
+    qCDebug(appLog) << "Hwinfo attributes set.";
 
     if (driverIsKernelIn(m_Driver) || m_Driver.isEmpty()) {
         qCDebug(appLog) << "Driver is kernel module or empty";
@@ -168,30 +180,38 @@ bool DeviceGpu::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     m_SysPath = mapInfo["SysFS ID"];
     QRegularExpression reUniqueId("[a-zA-Z0-9_+-]{4}\\.(.*)");
     if (reUniqueId.match(mapInfo["Unique ID"]).hasMatch()) {
+        qCDebug(appLog) << "Unique ID matched regex, setting m_UniqueID.";
         m_UniqueID = reUniqueId.match(mapInfo["Unique ID"]).captured(1);
     }
     // read gpu-info file
     if (!m_SysPath.isEmpty()) {
+        qCDebug(appLog) << "SysPath is not empty, attempting to read gpu-info file.";
         QString pathStr = "/sys" + m_SysPath + "/gpu-info";
         QFile file(pathStr);
         if (file.open(QIODevice::ReadOnly)) {
+            qCDebug(appLog) << "gpu-info file opened successfully.";
             QString allStr(file.readAll());
             QStringList items = allStr.split("\n\n");
             file.close();
             foreach (const QString &item, items) {
-                if (item.isEmpty())
+                if (item.isEmpty()) {
+                    // qCDebug(appLog) << "Skipping empty item in gpu-info.";
                     continue;
+                }
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
                 QStringList items = allStr.split(":", QString::SkipEmptyParts);
 #else
                 QStringList items = allStr.split(":", Qt::SkipEmptyParts);
 #endif
-                if (items.size() != 2)
+                if (items.size() != 2) {
+                    // qCDebug(appLog) << "Skipping item with incorrect size in gpu-info: " << item;
                     continue;
+                }
                 if (items.first().trimmed() == "VRAM total size") {
                     bool ok;
                     quint64 vramSize = items.last().trimmed().toULong(&ok, 16);
                     if (ok && vramSize >= 1048576) {
+                        // qCDebug(appLog) << "VRAM total size found and valid, converting.";
                         vramSize /= 1048576;
                         auto curSize = vramSize / 1024.0;
                         if (curSize > 1) {
@@ -199,38 +219,51 @@ bool DeviceGpu::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
                         } else {
                             m_GraphicsMemory = QString::number(vramSize) + "MB";
                         }
+                        // qCDebug(appLog) << "Graphics Memory set to: " << m_GraphicsMemory;
                     }
                 }
             }
+        } else {
+            qCDebug(appLog) << "Failed to open gpu-info file: " << pathStr;
         }
     }
     QString jjwFile = "/proc/gpuinfo_0";
     if (m_VID_PID.contains("0731") && QFile::exists(jjwFile)) {
+        qCDebug(appLog) << "VID_PID contains '0731' and jjwFile exists, attempting to read jjwFile.";
         QFile file(jjwFile);
         if (file.open(QIODevice::ReadOnly)) {
+            qCDebug(appLog) << "jjwFile opened successfully.";
             QString allStr(file.readAll());
             QStringList infos = allStr.split("\n");
             file.close();
             foreach (const QString &item, infos) {
-                if (item.isEmpty())
+                if (item.isEmpty()) {
+                    // qCDebug(appLog) << "Skipping empty item in jjwFile.";
                     continue;
+                }
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
                 QStringList items = item.split(":", QString::SkipEmptyParts);
 #else
                 QStringList items = item.split(":", Qt::SkipEmptyParts);
 #endif
-                if (items.size() != 2)
+                if (items.size() != 2) {
+                    // qCDebug(appLog) << "Skipping item with incorrect size in jjwFile: " << item;
                     continue;
+                }
                 if (items.first().trimmed() == "Memory Size") {
                     m_GraphicsMemory = items.last().trimmed();
+                    // qCDebug(appLog) << "Graphics Memory set from jjwFile: " << m_GraphicsMemory;
                     break;
                 }
             }
+        } else {
+            qCDebug(appLog) << "Failed to open jjwFile: " << jjwFile;
         }
     }
 
     // // 获取 匹配到lshw的Key
     setHwinfoLshwKey(mapInfo);
+    qCDebug(appLog) << "DeviceGpu::setHwinfoInfo finished.";
 
     // getOtherMapInfo(mapInfo);
     return true;
@@ -238,26 +271,38 @@ bool DeviceGpu::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
 
 void DeviceGpu::setXrandrInfo(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceGpu::setXrandrInfo started.";
     // 设置分辨率属性
     m_MinimumResolution = mapInfo["minResolution"];
     m_CurrentResolution = mapInfo["curResolution"];
     m_MaximumResolution = mapInfo["maxResolution"];
+    qCDebug(appLog) << "Resolutions set: Min=" << m_MinimumResolution << ", Cur=" << m_CurrentResolution << ", Max=" << m_MaximumResolution;
 
     // 设置显卡支持的接口
-    if (mapInfo.find("HDMI") != mapInfo.end())
+    if (mapInfo.find("HDMI") != mapInfo.end()) {
+        qCDebug(appLog) << "HDMI found, setting m_HDMI.";
         m_HDMI = mapInfo["HDMI"];
+    }
 
-    if (mapInfo.find("VGA") != mapInfo.end())
+    if (mapInfo.find("VGA") != mapInfo.end()) {
+        qCDebug(appLog) << "VGA found, setting m_VGA.";
         m_VGA = mapInfo["VGA"];
+    }
 
-    if (mapInfo.find("DP") != mapInfo.end())
+    if (mapInfo.find("DP") != mapInfo.end()) {
+        qCDebug(appLog) << "DP found, setting m_DisplayPort.";
         m_DisplayPort = mapInfo["DP"];
+    }
 
-    if (mapInfo.find("eDP") != mapInfo.end())
+    if (mapInfo.find("eDP") != mapInfo.end()) {
+        qCDebug(appLog) << "eDP found, setting m_eDP.";
         m_eDP = mapInfo["eDP"];
+    }
 
-    if (mapInfo.find("DVI") != mapInfo.end())
+    if (mapInfo.find("DVI") != mapInfo.end()) {
+        qCDebug(appLog) << "DVI found, setting m_DVI.";
         m_DVI = mapInfo["DVI"];
+    }
 
     if (mapInfo.find("DigitalOutput") != mapInfo.end())
         m_Digital = mapInfo["DigitalOutput"];   // bug-105482添加新接口类型
@@ -311,26 +356,31 @@ void DeviceGpu::setGpuInfo(const QMap<QString, QString> &mapInfo)
 
 const QString &DeviceGpu::name() const
 {
+    // qCDebug(appLog) << "DeviceGpu::name called, returning: " << m_Name;
     return m_Name;
 }
 
 const QString &DeviceGpu::vendor() const
 {
+    // qCDebug(appLog) << "DeviceGpu::vendor called, returning: " << m_Vendor;
     return m_Vendor;
 }
 
 const QString &DeviceGpu::driver() const
 {
+    // qCDebug(appLog) << "DeviceGpu::driver called, returning: " << m_Driver;
     return m_Driver;
 }
 
 QString DeviceGpu::subTitle()
 {
+    // qCDebug(appLog) << "DeviceGpu::subTitle called, returning: " << m_Model;
     return m_Model;
 }
 
 const QString DeviceGpu::getOverviewInfo()
 {
+    // qCDebug(appLog) << "Getting GPU overview info";
     // 获取概况信息
     return m_Name.isEmpty() ? m_Model : m_Name;
 }
@@ -372,12 +422,15 @@ void DeviceGpu::loadOtherDeviceInfo()
 
 void DeviceGpu::loadTableData()
 {
+    qCDebug(appLog) << "Loading table data";
     // 加载表格内容
     QString tName = m_Name;
     if (!available()) {
+        qCDebug(appLog) << "Device not available, updating tName.";
         tName = "(" + tr("Unavailable") + ") " + m_Name;
     }
     m_TableData.append(tName);
     m_TableData.append(m_Vendor);
     m_TableData.append(m_Model);
+    qCDebug(appLog) << "Table data loaded.";
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceImage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceImage.cpp
@@ -19,6 +19,7 @@ DeviceImage::DeviceImage()
     , m_MaximumPower("")
     , m_Speed("")
 {
+    qCDebug(appLog) << "DeviceImage constructor initialized.";
     m_CanEnable = true;
     m_CanUninstall = true;
 }
@@ -39,9 +40,12 @@ void DeviceImage::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "driver", m_Driver, false);
     setAttribute(mapInfo, "maxpower", m_MaximumPower);
     setAttribute(mapInfo, "speed", m_Speed);
+    qCDebug(appLog) << "Basic attributes set from Lshw.";
     if (driverIsKernelIn(m_Driver)) {
+        qCDebug(appLog) << "Driver is kernel in, setting m_CanUninstall to false.";
         m_CanUninstall = false;
     }
+    qCDebug(appLog) << "DeviceImage::setInfoFromLshw finished.";
 }
 
 TomlFixMethod DeviceImage::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
@@ -61,6 +65,7 @@ TomlFixMethod DeviceImage::setInfoFromTomlOneByOne(const QMap<QString, QString> 
     ret = setTomlAttribute(mapInfo, "Serial Number", m_SerialID);
 //3. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "DeviceImage::setInfoFromTomlOneByOne finished, return: " << ret;
     return ret;
 }
 
@@ -69,6 +74,7 @@ void DeviceImage::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     qCDebug(appLog) << "setInfoFromHwinfo";
 
     if (mapInfo.find("unique_id") != mapInfo.end()) {
+        qCDebug(appLog) << "Unique ID found in mapInfo.";
         m_UniqueID = mapInfo["unique_id"];
         m_Name = mapInfo["name"];
         m_SysPath = mapInfo["path"];
@@ -81,13 +87,16 @@ void DeviceImage::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
         return;
     }
     if (mapInfo.find("Enable") != mapInfo.end()) {
+        qCDebug(appLog) << "Enable flag found in mapInfo, setting m_Enable to false.";
         m_Enable = false;
     }
     setAttribute(mapInfo, "Serial ID", m_SerialID);
     setAttribute(mapInfo, "Unique ID", m_UniqueID);
     // 防止Serial ID为空
-    if (m_SerialID.isEmpty())
+    if (m_SerialID.isEmpty()) {
+        qCDebug(appLog) << "Serial ID is empty, setting from Unique ID.";
         m_SerialID = m_UniqueID;
+    }
     setAttribute(mapInfo, "SysFS ID", m_SysPath);
     setAttribute(mapInfo, "Device", m_Name);
     setAttribute(mapInfo, "Vendor", m_Vendor);
@@ -101,85 +110,107 @@ void DeviceImage::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "VID_PID", m_VID_PID);
     m_PhysID = m_VID_PID;
     if (driverIsKernelIn(m_Driver)) {
+        qCDebug(appLog) << "Driver is kernel in, setting m_CanUninstall to false.";
         m_CanUninstall = false;
     }
+    qCDebug(appLog) << "Hwinfo attributes set. Name=" << m_Name << ", Vendor=" << m_Vendor << ", Model=" << m_Model << ", Version=" << m_Version << ", SysPath=" << m_SysPath << ", Driver=" << m_Driver;
 
     // 获取映射到 lshw设备信息的 关键字
     //1-2:1.0
     setHwinfoLshwKey(mapInfo);
+    qCDebug(appLog) << "DeviceImage::setInfoFromHwinfo finished.";
 }
 
 const QString &DeviceImage::name()const
 {
+    // qCDebug(appLog) << "DeviceImage::name called, returning: " << m_Name;
     return m_Name;
 }
 
 const QString &DeviceImage::vendor() const
 {
+    // qCDebug(appLog) << "DeviceImage::vendor called, returning: " << m_Vendor;
     return m_Vendor;
 }
 
 const QString &DeviceImage::driver()const
 {
+    // qCDebug(appLog) << "DeviceImage::driver called, returning: " << m_Driver;
     return m_Driver;
 }
 
 QString DeviceImage::subTitle()
 {
+    // qCDebug(appLog) << "DeviceImage::subTitle called, returning: " << m_Name;
     return m_Name;
 }
 
 const QString DeviceImage::getOverviewInfo()
 {
+    // qCDebug(appLog) << "DeviceImage::getOverviewInfo called.";
     QString ov = QString("%1 (%2)") \
                  .arg(m_Name) \
                  .arg(m_Model);
-
+    // qCDebug(appLog) << "Overview info: " << ov;
     return ov;
 }
 
 EnableDeviceStatus DeviceImage::setEnable(bool e)
 {
+    qCDebug(appLog) << "DeviceImage::setEnable called with status: " << e;
     if (m_SerialID.isEmpty()) {
+        qCWarning(appLog) << "SerialID is empty, returning EDS_NoSerial.";
         return EDS_NoSerial;
     }
 
     if (m_UniqueID.isEmpty() || m_SysPath.isEmpty()) {
+        qCWarning(appLog) << "UniqueID or SysPath empty, returning EDS_Faild.";
         return EDS_Faild;
     }
     bool res  = DBusEnableInterface::getInstance()->enable("camera", m_Name, m_SysPath, m_UniqueID, e, m_Driver);
     if (res) {
+        qCDebug(appLog) << "DBus enable call successful, setting m_Enable to " << e;
         m_Enable = e;
-        if(e)
+        if(e) {
+            qCDebug(appLog) << "Enable is true, refreshing info.";
             DBusInterface::getInstance()->refreshInfo();
+        }
+    } else {
+        qCDebug(appLog) << "DBus enable call failed.";
     }
     // 设置设备状态
+    qCDebug(appLog) << "Set enable status:" << e << ", result:" << res;
     return res ? EDS_Success : EDS_Faild;
 }
 
 bool DeviceImage::enable()
 {
+    // qCDebug(appLog) << "DeviceImage::enable called, returning current enable status: " << m_Enable;
     // 获取设备状态
     return m_Enable;
 }
 
 void DeviceImage::initFilterKey()
 {
+    // qCDebug(appLog) << "DeviceImage::initFilterKey called. No filter keys added based on existing function body.";
 
 }
 
 void DeviceImage::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceImage::loadBaseDeviceInfo called.";
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name);
     addBaseDeviceInfo(tr("Vendor"), m_Vendor);
     addBaseDeviceInfo(tr("Version"), m_Version);
     addBaseDeviceInfo(tr("Model"), m_Model);
     addBaseDeviceInfo(tr("Bus Info"), m_BusInfo);
+    qCDebug(appLog) << "Base device info loaded.";
 }
 
 void DeviceImage::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceImage::loadOtherDeviceInfo called.";
     // 添加其他信息,成员变量
     addOtherDeviceInfo(tr("Module Alias"), m_Modalias);
     addOtherDeviceInfo(tr("Physical ID"), m_PhysID);
@@ -187,27 +218,34 @@ void DeviceImage::loadOtherDeviceInfo()
     addOtherDeviceInfo(tr("Maximum Power"), m_MaximumPower);
     addOtherDeviceInfo(tr("Driver"), m_Driver);
     addOtherDeviceInfo(tr("Capabilities"), m_Capabilities);
-    if (m_SerialID != m_UniqueID)
+    if (m_SerialID != m_UniqueID) {
+        qCDebug(appLog) << "SerialID is different from UniqueID, adding Serial Number.";
         addOtherDeviceInfo(tr("Serial Number"), m_SerialID);
+    }
 
     // 将QMap<QString, QString>内容转存为QList<QPair<QString, QString>>
     mapInfoToList();
+    qCDebug(appLog) << "Other device info loaded.";
 }
 
 void DeviceImage::loadTableData()
 {
+    qCDebug(appLog) << "DeviceImage::loadTableData called.";
     // 记载表格内容
     QString tName = m_Name;
 
     if (!available()) {
+        qCDebug(appLog) << "Device not available, updating tName.";
         tName = "(" + tr("Unavailable") + ") " + m_Name;
     }
 
     if (!enable()) {
+        qCDebug(appLog) << "Device disabled, updating tName.";
         tName = "(" + tr("Disable") + ") " + m_Name;
     }
 
     m_TableData.append(tName);
     m_TableData.append(m_Vendor);
     m_TableData.append(m_Model);
+    qCDebug(appLog) << "Table data loaded.";
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
@@ -38,127 +38,175 @@ DeviceBaseInfo::DeviceBaseInfo(QObject *parent)
     , m_forcedDisplay(false)
     , m_Driver("")
 {
+    qCDebug(appLog) << "DeviceBaseInfo constructor initialized.";
 }
 
 DeviceBaseInfo::~DeviceBaseInfo()
 {
-
+    qCDebug(appLog) << "DeviceBaseInfo destructor called.";
 }
 
 const QList<QPair<QString, QString>> &DeviceBaseInfo::getOtherAttribs()
 {
+    qCDebug(appLog) << "DeviceBaseInfo::getOtherAttribs called.";
     // 获取其他设备信息列表
     m_LstOtherInfo.clear();
     loadOtherDeviceInfo();
+    qCDebug(appLog) << "Other attributes loaded. Count: " << m_LstOtherInfo.count();
     return m_LstOtherInfo;
 }
 
 const QList<QPair<QString, QString> > &DeviceBaseInfo::getBaseAttribs()
 {
+    qCDebug(appLog) << "DeviceBaseInfo::getBaseAttribs called.";
     // 获取基本信息列表
     m_LstBaseInfo.clear();
     loadBaseDeviceInfo();
+    qCDebug(appLog) << "Base attributes loaded. Count: " << m_LstBaseInfo.count();
     return m_LstBaseInfo;
 }
 
 const QStringList &DeviceBaseInfo::getTableHeader()
 {
+    qCDebug(appLog) << "DeviceBaseInfo::getTableHeader called.";
     // 获取表头
     if (m_TableHeader.size() == 0) {
+        qCDebug(appLog) << "Table header is empty, loading.";
         loadTableHeader();
         m_TableHeader.append(m_CanEnable ? "yes" : "no");
     }
-
+    qCDebug(appLog) << "Table header: " << m_TableHeader;
     return m_TableHeader;
 }
 
 const QStringList &DeviceBaseInfo::getTableData()
 {
+    qCDebug(appLog) << "DeviceBaseInfo::getTableData called.";
     // 获取表格数据
     m_TableData.clear();
     loadTableData();
+    qCDebug(appLog) << "Table data loaded. Count: " << m_TableData.count();
     return m_TableData;
 }
 
 QString DeviceBaseInfo::subTitle()
 {
+    qCDebug(appLog) << "DeviceBaseInfo::subTitle called, returning empty string as default.";
     return QString("");
 }
 
 bool DeviceBaseInfo::isValueValid(QString &value)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::isValueValid called for value: " << value;
     // 判断属性值是否有效
-    if (value.isEmpty())
+    if (value.isEmpty()) {
+        // qCDebug(appLog) << "Value is empty, returning false.";
         return false;
+    }
 
-    if (value == QObject::tr("Unknown"))
+    if (value == QObject::tr("Unknown")) {
+        // qCDebug(appLog) << "Value is 'Unknown', returning false.";
         return false;
+    }
 
-    if (value == QString("Unknown"))
+    if (value == QString("Unknown")) {
+        // qCDebug(appLog) << "Value is 'Unknown' (QString), returning false.";
         return false;
+    }
 
-    if (value.compare(QString("N/A"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("N/A"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'N/A', returning false.";
         return false;
+    }
 
-    if (value == QString(""))
+    if (value == QString("")) {
+        // qCDebug(appLog) << "Value is empty (QString), returning false.";
         return false;
+    }
 
-    if (value.compare(QString("Null"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("Null"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'Null', returning false.";
         return false;
+    }
 
-    if (value.compare(QString("none"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("none"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'none', returning false.";
         return false;
+    }
 
-    if (value.compare(QString("Not Provided"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("Not Provided"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'Not Provided', returning false.";
         return false;
+    }
 
-    if (value.compare(QString("Not Specified"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("Not Specified"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'Not Specified', returning false.";
         return false;
+    }
 
-    if (value.compare(QString("Default string"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("Default string"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'Default string', returning false.";
         return false;
+    }
 
-    if (value.compare(QString("Unspecified"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("Unspecified"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'Unspecified', returning false.";
         return false;
+    }
 
-    if (value.compare(QString("Not Present"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("Not Present"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'Not Present', returning false.";
         return false;
+    }
 
-    if (value.compare(QString("<OUT OF SPEC>"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("<OUT OF SPEC>"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is '<OUT OF SPEC>', returning false.";
         return false;
+    }
 
-    if (value.compare(QString("Other"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("Other"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'Other', returning false.";
         return false;
+    }
 
-    if (value.compare(QString("TBD"), Qt::CaseInsensitive) == 0)
+    if (value.compare(QString("TBD"), Qt::CaseInsensitive) == 0) {
+        // qCDebug(appLog) << "Value is 'TBD', returning false.";
         return false;
-
+    }
+    // qCDebug(appLog) << "Value is valid, returning true.";
     return true;
 }
 
 void DeviceBaseInfo::setForcedDisplay(const bool &flag)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::setForcedDisplay called with flag: " << flag;
     m_forcedDisplay = flag;
+    qCDebug(appLog) << "m_forcedDisplay set to: " << m_forcedDisplay;
 }
 
 void DeviceBaseInfo::toHtmlString(QDomDocument &doc)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::toHtmlString called.";
     // 设备信息转为Html
     baseInfoToHTML(doc, m_LstBaseInfo);
     baseInfoToHTML(doc, m_LstOtherInfo);
+    qCDebug(appLog) << "HTML string conversion finished.";
 }
 
 void DeviceBaseInfo::baseInfoToHTML(QDomDocument &doc, QList<QPair<QString, QString> > &infoLst)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::baseInfoToHTML called for info list.";
     // 设备信息转为HTML
     QDomElement table = doc.createElement("table");
     table.setAttribute("border", "0");
     table.setAttribute("width", "100%");
     table.setAttribute("cellpadding", "3");
+    qCDebug(appLog) << "HTML table element created.";
 
     // 添加HTML表格内容
     foreach (auto info, infoLst) {
         if (isValueValid(info.second)) {
+            // qCDebug(appLog) << "Adding valid info to HTML table: " << info.first << ": " << info.second;
             QDomElement tr = doc.createElement("tr");
 
             // 第一列
@@ -185,84 +233,109 @@ void DeviceBaseInfo::baseInfoToHTML(QDomDocument &doc, QList<QPair<QString, QStr
 
         doc.appendChild(table);
     }
+    qCDebug(appLog) << "Finished adding items to HTML table.";
 }
 
 void DeviceBaseInfo::subTitleToHTML(QDomDocument &doc)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::subTitleToHTML called.";
     // 子标题转为HTML格式
     if (false == this->subTitle().isEmpty()) {
+        qCDebug(appLog) << "Subtitle is not empty, adding to HTML: " << this->subTitle();
         QDomElement h3 = doc.createElement("h3");
         QDomText valueText = doc.createTextNode(this->subTitle());
         h3.appendChild(valueText);
         doc.appendChild(h3);
+    } else {
+        qCDebug(appLog) << "Subtitle is empty, skipping HTML addition.";
     }
 }
 
 void DeviceBaseInfo::toDocString(Docx::Document &doc)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::toDocString called.";
     // 设备信息转为doc
     baseInfoToDoc(doc, m_LstBaseInfo);
     baseInfoToDoc(doc, m_LstOtherInfo);
+    qCDebug(appLog) << "Doc string conversion finished.";
 }
 
 void DeviceBaseInfo::baseInfoToDoc(Docx::Document &doc, QList<QPair<QString, QString> > &infoLst)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::baseInfoToDoc called for info list.";
     // 设备信息保存为Doc
     foreach (auto item, infoLst) {
         QString value = item.second;
 
         // 判断属性值是否有效
-        if (false == isValueValid(value))
+        if (false == isValueValid(value)) {
+            // qCDebug(appLog) << "Skipping invalid info for Doc: " << item.first << ": " << item.second;
             continue;
+        }
 
         // 添加doc段落
         QString line = item.first + ":  " + item.second;
         doc.addParagraph(line);
+        // qCDebug(appLog) << "Added paragraph to Doc: " << line;
     }
+    qCDebug(appLog) << "Finished adding items to Doc.";
 }
 
 void DeviceBaseInfo::toXlsxString(QXlsx::Document &xlsx, QXlsx::Format &boldFont)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::toXlsxString called.";
     // 设备信息转为xlxs表格
     baseInfoToXlsx(xlsx, boldFont, m_LstBaseInfo);
     baseInfoToXlsx(xlsx, boldFont, m_LstOtherInfo);
+    qCDebug(appLog) << "Xlsx string conversion finished.";
 }
 
 void DeviceBaseInfo::baseInfoToXlsx(QXlsx::Document &xlsx, QXlsx::Format &boldFont, QList<QPair<QString, QString> > &infoLst)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::baseInfoToXlsx called for info list.";
     // 设置表格内容字体不加粗,字号10
     boldFont.setFontBold(false);
     boldFont.setFontSize(10);
+    qCDebug(appLog) << "Xlsx format set: bold=" << boldFont.fontBold() << ", size=" << boldFont.fontSize();
 
     foreach (auto item, infoLst) {
         QString value = item.second;
 
         // 判断属性值是否有效
-        if (false == isValueValid(value))
+        if (false == isValueValid(value)) {
+            // qCDebug(appLog) << "Skipping invalid info for Xlsx: " << item.first << ": " << item.second;
             continue;
+        }
 
         // 获取行数
         int _row = DeviceManager::instance()->currentXlsRow();
         xlsx.write(_row, 1, item.first, boldFont);
         xlsx.write(_row, 2, item.second, boldFont);
+        // qCDebug(appLog) << "Written to Xlsx at row " << _row << ": " << item.first << " = " << item.second;
     }
+    qCDebug(appLog) << "Finished writing items to Xlsx.";
 }
 
 void DeviceBaseInfo::toTxtString(QTextStream &out)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::toTxtString called.";
     // 设备信息转为txt
     baseInfoToTxt(out, m_LstBaseInfo);
     baseInfoToTxt(out, m_LstOtherInfo);
+    qCDebug(appLog) << "Txt string conversion finished.";
 }
 
 void DeviceBaseInfo::baseInfoToTxt(QTextStream &out, QList<QPair<QString, QString> > &infoLst)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::baseInfoToTxt called for info list.";
     foreach (auto item, infoLst) {
         QString value = item.second;
 
         // 判断属性值是否有效
-        if (false == isValueValid(value))
+        if (false == isValueValid(value)) {
+            // qCDebug(appLog) << "Skipping invalid info for Txt: " << item.first << ": " << item.second;
             continue;
+        }
 
         // 设置第一列占21个字符
         out.setFieldWidth(21);
@@ -271,146 +344,193 @@ void DeviceBaseInfo::baseInfoToTxt(QTextStream &out, QList<QPair<QString, QStrin
         out.setFieldWidth(0);
         out << item.second;
         out << "\n";
+        // qCDebug(appLog) << "Written to Txt: " << item.first << " = " << item.second;
     }
+    qCDebug(appLog) << "Finished writing items to Txt.";
 }
 
 void DeviceBaseInfo::tableInfoToTxt(QTextStream &out)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::tableInfoToTxt called.";
     // 获取表格内容
     getTableData();
 
     // 判断是否有表格内容
-    if (m_TableData.size() < 1)
+    if (m_TableData.size() < 1) {
+        qCDebug(appLog) << "Table data is empty, skipping Txt conversion.";
         return;
+    }
 
     // 设置占位宽度
     QString text = m_TableData[0];
     out.setFieldWidth(int(text.size() * 1.5));
     out.setFieldAlignment(QTextStream::FieldAlignment::AlignRight);
+    qCDebug(appLog) << "Txt field width set for table info.";
 
     foreach (auto item, m_TableData) {
         out.setFieldWidth(28);
         out << item;
+        // qCDebug(appLog) << "Written table item to Txt: " << item;
     }
 
     out.setFieldWidth(0);
     out << "\n";
+    qCDebug(appLog) << "Finished writing table info to Txt.";
 }
 
 void DeviceBaseInfo::tableHeaderToTxt(QTextStream &out)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::tableHeaderToTxt called.";
     // 获取表头
     getTableHeader();
 
     // 判断是否有表头
-    if (m_TableHeader.size() < 1)
+    if (m_TableHeader.size() < 1) {
+        qCDebug(appLog) << "Table header is empty, skipping Txt conversion.";
         return;
+    }
 
     // 设置占位宽度
     QString text = m_TableHeader[0];
     out.setFieldWidth(int(text.size() * 1.5));
     out.setFieldAlignment(QTextStream::FieldAlignment::AlignLeft);
+    qCDebug(appLog) << "Txt field width set for table header.";
 
     out << "\n";
     for (int col = 0; col < m_TableHeader.size() - 1; ++col) {
         out.setFieldWidth(30);
         out << m_TableHeader[col];
+        // qCDebug(appLog) << "Written table header item to Txt: " << m_TableHeader[col];
     }
     out.setFieldWidth(0);
     out << "\n";
+    qCDebug(appLog) << "Finished writing table header to Txt.";
 }
 
 void DeviceBaseInfo::tableInfoToHtml(QFile &html)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::tableInfoToHtml called.";
     // 获取表格内容
     getTableData();
 
     // 判断是否有表格内容
-    if (m_TableData.size() < 1)
+    if (m_TableData.size() < 1) {
+        qCDebug(appLog) << "Table data is empty, skipping HTML table info conversion.";
         return;
+    }
 
     // 写表格内容
     foreach (auto item, m_TableData) {
         html.write(QString("<td style=\"width:200px;text-align:left;\">" + item + "</td>").toUtf8().data());
+        // qCDebug(appLog) << "Written table info item to HTML: " << item;
     }
 
     html.write("</tr>\n");
+    qCDebug(appLog) << "Finished writing table info to HTML.";
 }
 
 void DeviceBaseInfo::tableHeaderToHtml(QFile &html)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::tableHeaderToHtml called.";
     // 获取表头信息
     getTableHeader();
 
     // 判断是否有表头
-    if (m_TableHeader.size() < 1)
+    if (m_TableHeader.size() < 1) {
+        qCDebug(appLog) << "Table header is empty, skipping HTML table header conversion.";
         return;
+    }
 
     html.write("<thead><tr>\n");
+    qCDebug(appLog) << "Written HTML table header start tags.";
 
     // 写表头内容
-    for (int col = 0; col < m_TableHeader.size() - 1; ++col)
+    for (int col = 0; col < m_TableHeader.size() - 1; ++col) {
         html.write(QString("<th style=\"width:200px;text-align:left; white-space:pre;\">" + m_TableHeader[col] + "</th>").toUtf8().data());
+        // qCDebug(appLog) << "Written table header item to HTML: " << m_TableHeader[col];
+    }
 
     html.write("</tr></thead>\n");
+    qCDebug(appLog) << "Finished writing table header to HTML.";
 }
 
 void DeviceBaseInfo::tableInfoToDoc(Docx::Table *tab, int &row)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::tableInfoToDoc called with row: " << row;
     // 表格信息保存为Doc
-    if (nullptr == tab)
+    if (nullptr == tab) {
+        qCDebug(appLog) << "Table pointer is null, returning.";
         return;
+    }
 
     // 获取表格数据
     getTableData();
 
-    if (m_TableData.size() < 1)
+    if (m_TableData.size() < 1) {
+        qCDebug(appLog) << "Table data is empty, skipping Doc table info conversion.";
         return;
+    }
 
     // 添加doc表格
     for (int col = 0; col < m_TableData.size(); ++col) {
         auto cel = tab->cell(row, col);
         cel->addText(m_TableData[col]);
+        // qCDebug(appLog) << "Added table info to Doc cell (" << row << ", " << col << "): " << m_TableData[col];
     }
+    qCDebug(appLog) << "Finished adding table info to Doc.";
 }
 
 void DeviceBaseInfo::tableHeaderToDoc(Docx::Table *tab)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::tableHeaderToDoc called.";
     // 表头保存为doc
     getTableHeader();
 
-    if (m_TableHeader.size() < 1)
+    if (m_TableHeader.size() < 1) {
+        qCDebug(appLog) << "Table header is empty, skipping Doc table header conversion.";
         return;
+    }
 
     // 添加表头信息
     for (int col = 0; col < m_TableHeader.size() - 1; ++col)  {
         tab->addColumn();
         auto cel = tab->cell(0, col);
         cel->addText(m_TableHeader[col]);
+        // qCDebug(appLog) << "Added table header to Doc cell (0, " << col << "): " << m_TableHeader[col];
     }
+    qCDebug(appLog) << "Finished adding table header to Doc.";
 }
 
 void DeviceBaseInfo::tableInfoToXlsx(QXlsx::Document &xlsx)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::tableInfoToXlsx called.";
     // 获取表格信息
     getTableData();
 
-    if (m_TableData.size() < 1)
+    if (m_TableData.size() < 1) {
+        qCDebug(appLog) << "Table data is empty, skipping Xlsx table info conversion.";
         return;
+    }
 
     // 添加表格信息
     int curRow = DeviceManager::instance()->currentXlsRow();
-    for (int col = 0; col < m_TableData.size(); ++col)
+    for (int col = 0; col < m_TableData.size(); ++col) {
         xlsx.write(curRow, col + 1, m_TableData[col]);
+        // qCDebug(appLog) << "Written table info to Xlsx at row " << curRow << ", col " << col + 1 << ": " << m_TableData[col];
+    }
+    qCDebug(appLog) << "Finished writing table info to Xlsx.";
 }
 
 void DeviceBaseInfo::tableHeaderToXlsx(QXlsx::Document &xlsx)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::tableHeaderToXlsx called.";
     // 获取表头
     getTableHeader();
 
-    if (m_TableHeader.size() < 1)
+    if (m_TableHeader.size() < 1) {
+        qCDebug(appLog) << "Table header is empty, skipping Xlsx table header conversion.";
         return;
+    }
 
     // 添加表头信息
     int curRow = DeviceManager::instance()->currentXlsRow();
@@ -419,16 +539,20 @@ void DeviceBaseInfo::tableHeaderToXlsx(QXlsx::Document &xlsx)
         boldFont.setFontSize(10);
         boldFont.setFontBold(true);
         xlsx.write(curRow, col + 1, m_TableHeader[col], boldFont);
+        // qCDebug(appLog) << "Written table header to Xlsx at row " << curRow << ", col " << col + 1 << ": " << m_TableHeader[col];
     }
+    qCDebug(appLog) << "Finished writing table header to Xlsx.";
 }
 
 void DeviceBaseInfo::setOtherDeviceInfo(const QString &key, const QString &value)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::setOtherDeviceInfo called for key: " << key << ", value: " << value;
     m_MapOtherInfo[key] = value;
 }
 
 TomlFixMethod DeviceBaseInfo::setInfoFromTomlBase(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::setInfoFromTomlBase started.";
     TomlFixMethod ret = TOML_None;
     TomlFixMethod ret1 = TOML_None;
     TomlFixMethod ret2 = TOML_None;
@@ -460,91 +584,115 @@ TomlFixMethod DeviceBaseInfo::setInfoFromTomlBase(const QMap<QString, QString> &
     return ret;
 }
 
-EnableDeviceStatus DeviceBaseInfo::setEnable(bool)
+EnableDeviceStatus DeviceBaseInfo::setEnable(bool e)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::setEnable called with status: " << e;
     return EDS_Success;
 }
 
 bool DeviceBaseInfo::enable()
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::enable called, returning current enable status: " << m_Enable;
     return m_Enable;
 }
 
 bool DeviceBaseInfo::available()
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::available called.";
     if (driver().isEmpty()) {
+        // qCDebug(appLog) << "Driver is empty, setting m_Available to false.";
         m_Available = false;
     }
+    // qCDebug(appLog) << "Returning available status: " << (m_forcedDisplay ? m_forcedDisplay : m_Available);
     return m_forcedDisplay ? m_forcedDisplay : m_Available;
 }
 
 bool DeviceBaseInfo::driverIsKernelIn(const QString &driver)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::driverIsKernelIn called for driver: " << driver;
     // 驱动为空情况:
     // 1. 驱动被卸载了 此时驱动属于核外驱动
     // 2. ps/2 笔记本触摸板 暂无法获取驱动 此时当成核内驱动处理
     // 3. 但是由于判断是否是ps/2或者笔记本触摸板在子类判断(无需放在基类)，因此此处为空时先返回false，而在子类(DeviceInput)调用后判断是否是ps/2鼠标
     if (driver.isEmpty()) {
+        qCDebug(appLog) << "Driver is empty, returning false.";
         return false;
     }
 
     // 英伟达驱动无法获取驱动模块，但是不属于核内驱动
     if ("nvidia" == driver) {
+        qCDebug(appLog) << "Driver is 'nvidia', returning false.";
         return false;
     }
 
     // 判断lsmod是否能查询
     QString outInfo = Common::executeClientCmd("modinfo", QStringList() << driver, QString(), -1);
-    return !outInfo.contains("filename:");
+    bool isKernelIn = !outInfo.contains("filename:");
+    qCDebug(appLog) << "Driver: " << driver << ", modinfo output contains filename: " << !isKernelIn << ", returning: " << isKernelIn;
+    return isKernelIn;
 }
 
 void DeviceBaseInfo::setCanEnale(bool can)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::setCanEnale called with can: " << can;
     m_CanEnable = can;
+    // qCDebug(appLog) << "m_CanEnable set to: " << m_CanEnable;
 }
 
 bool DeviceBaseInfo::canEnable()
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::canEnable called, returning: " << m_CanEnable;
     return m_CanEnable;
 }
 
 void DeviceBaseInfo::setEnableValue(bool e)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::setEnableValue called with e: " << e;
     m_Enable = e;
+    // qCDebug(appLog) << "m_Enable set to: " << m_Enable;
 }
 
 bool DeviceBaseInfo::canUninstall()
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::canUninstall called, returning: " << m_CanUninstall;
     return m_CanUninstall;
 }
 
 void DeviceBaseInfo::setCanUninstall(bool can)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::setCanUninstall called with can: " << can;
     m_CanUninstall = can;
+    // qCDebug(appLog) << "m_CanUninstall set to: " << m_CanUninstall;
 }
 
 void DeviceBaseInfo::setHardwareClass(const QString &hclass)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::setHardwareClass called with hclass: " << hclass;
     m_HardwareClass = hclass;
+    // qCDebug(appLog) << "m_HardwareClass set to: " << m_HardwareClass;
 }
 
 const QString &DeviceBaseInfo::hardwareClass() const
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::hardwareClass called, returning: " << m_HardwareClass;
     return m_HardwareClass;
 }
 
 const QString &DeviceBaseInfo::uniqueID() const
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::uniqueID called, returning: " << m_UniqueID;
     return m_UniqueID;
 }
 
 const QString &DeviceBaseInfo::sysPath() const
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::sysPath called, returning: " << m_SysPath;
     return m_SysPath;
 }
 
 const QString DeviceBaseInfo::getVendorOrModelId(const QString &sysPath, bool flag)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::getVendorOrModelId called with sysPath: " << sysPath << ", flag: " << flag;
     // 从文件中获取制造商ID信息
     QFile vendorFile;
     QString strVendorFile("/vendor");
@@ -552,33 +700,43 @@ const QString DeviceBaseInfo::getVendorOrModelId(const QString &sysPath, bool fl
     QString strSysFSLink = sysPath;
 
     if (sysPath.contains("usb")) {
+        qCDebug(appLog) << "SysPath contains 'usb', adjusting file names and sys path link.";
         strVendorFile = "/idVendor";
         strDeviceFile = "/idProduct";
         if (!QFile::exists("/sys" + strSysFSLink + strVendorFile)) {
+            qCDebug(appLog) << "Vendor file does not exist, adjusting sys path link.";
             strSysFSLink = strSysFSLink.mid(0, sysPath.lastIndexOf('/'));
         }
     }
 
     if (flag) {
+        qCDebug(appLog) << "Flag is true, setting file name for vendor: " << QString("/sys") + strSysFSLink + strVendorFile;
         vendorFile.setFileName(QString("/sys") + strSysFSLink + strVendorFile);
     } else {
+        qCDebug(appLog) << "Flag is false, setting file name for device: " << QString("/sys") + strSysFSLink + strDeviceFile;
         vendorFile.setFileName(QString("/sys") + strSysFSLink + strDeviceFile);
     }
 
-    if (false == vendorFile.open(QIODevice::ReadOnly))
+    if (false == vendorFile.open(QIODevice::ReadOnly)) {
+        qCWarning(appLog) << "Failed to open vendor/device file: " << vendorFile.fileName();
         return QString();
+    }
 
     QString vendor = vendorFile.readAll();
     vendorFile.close();
+    qCDebug(appLog) << "Read vendor/device info: " << vendor.trimmed();
 
     return vendor.trimmed();
 }
 
 const QString DeviceBaseInfo::getDriverVersion()
 {
+    qCDebug(appLog) << "DeviceBaseInfo::getDriverVersion called.";
     QString outInfo = Common::executeClientCmd("modinfo", QStringList() << driver(), QString(), -1);
-    if(outInfo.isEmpty())
+    if(outInfo.isEmpty()) {
+        qCDebug(appLog) << "Modinfo output is empty, returning empty string.";
         return  QString("");
+    }
 
     foreach (QString out, outInfo.split("\n")) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -587,40 +745,47 @@ const QString DeviceBaseInfo::getDriverVersion()
         QStringList item = out.split(":", Qt::SkipEmptyParts);
 #endif
         if (!item.isEmpty() && "version" == item[0].trimmed()) {
+            // qCDebug(appLog) << "Found driver version: " << item[1].trimmed();
             return item[1].trimmed();
         }
     }
-
+    qCDebug(appLog) << "Driver version not found, returning empty string.";
     return QString("");
 }
 
 const QString DeviceBaseInfo::getOverviewInfo()
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::getOverviewInfo called, returning empty string as default.";
     return QString("");
 }
 
 const QString &DeviceBaseInfo::getVID() const
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::getVID called, returning: " << m_VID;
     return m_VID;
 }
 
 const QString &DeviceBaseInfo::getPID() const
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::getPID called, returning: " << m_PID;
     return m_PID;
 }
 
 const QString &DeviceBaseInfo::getVIDAndPID() const
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::getVIDAndPID called, returning: " << m_VID_PID;
     return m_VID_PID;
 }
 
 const QString &DeviceBaseInfo::getModalias() const
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::getModalias called, returning: " << m_Modalias;
     return m_Modalias;
 }
 
 void DeviceBaseInfo::loadTableHeader()
 {
+    qCDebug(appLog) << "DeviceBaseInfo::loadTableHeader called. Adding default table headers.";
     // 添加表头信息
     m_TableHeader.append(tr("Name"));
     m_TableHeader.append(tr("Vendor"));
@@ -629,12 +794,14 @@ void DeviceBaseInfo::loadTableHeader()
 
 void DeviceBaseInfo::addFilterKey(const QString &key)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::addFilterKey called with key: " << key;
     // 添加可显示设备属性
     m_FilterKey.insert(key);
 }
 
 void DeviceBaseInfo::getOtherMapInfo(const QMap<QString, QString> &mapInfo)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::getOtherMapInfo called.";
     // 获取其他设备信息
     QMap<QString, QString>::const_iterator it = mapInfo.begin();
     for (; it != mapInfo.end(); ++it) {
@@ -642,63 +809,88 @@ void DeviceBaseInfo::getOtherMapInfo(const QMap<QString, QString> &mapInfo)
 
         // 可显示设备属性中存在该属性
         if (m_FilterKey.find(k) != m_FilterKey.end()) {
-            if (it.value().toLower().contains("nouse"))
+            if (it.value().toLower().contains("nouse")) {
+                // qCDebug(appLog) << "DeviceBaseInfo::getOtherMapInfo remove key: " << k;
                 m_MapOtherInfo.remove(k);
-            else
+            } else {
+                // qCDebug(appLog) << "DeviceBaseInfo::getOtherMapInfo insert key: " << k;
                 m_MapOtherInfo.insert(k, it.value().trimmed());
+            }
         }
     }
 }
 
 void DeviceBaseInfo::addBaseDeviceInfo(const QString &key, const QString &value)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::addBaseDeviceInfo called with key: " << key << ", value: " << value;
     // 添加基础设备信息
-    if (!value.isEmpty())
+    if (!value.isEmpty()) {
+        qCDebug(appLog) << "DeviceBaseInfo::addBaseDeviceInfo append key: " << key;
         m_LstBaseInfo.append(QPair<QString, QString>(key, value));
+    }
 }
 
 void DeviceBaseInfo::addOtherDeviceInfo(const QString &key, const QString &value)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::addOtherDeviceInfo called with key: " << key << ", value: " << value;
     // 添加其他设备信息
-    if (!value.isEmpty())
+    if (!value.isEmpty()) {
+        qCDebug(appLog) << "DeviceBaseInfo::addOtherDeviceInfo insert key: " << key;
         m_LstOtherInfo.insert(0, QPair<QString, QString>(key, value));
+    }
 }
 
 void DeviceBaseInfo::setAttribute(const QMap<QString, QString> &mapInfo, const QString &key, QString &variable, bool overwrite)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::setAttribute called with key: " << key << ", overwrite: " << overwrite;
     // map中存在该属性
-    if (mapInfo.find(key) == mapInfo.end())
+    if (mapInfo.find(key) == mapInfo.end()) {
+        qCDebug(appLog) << "DeviceBaseInfo::setAttribute map does not contain key: " << key;
         return;
+    }
 
     // 属性值不能为空
-    if (mapInfo[key] == "")
+    if (mapInfo[key] == "") {
+        qCDebug(appLog) << "DeviceBaseInfo::setAttribute attribute value is empty";
         return;
+    }
 
     // overwrite 为true直接覆盖
     if (overwrite) {
         variable = mapInfo[key].trimmed();
     } else {
-
+        qCDebug(appLog) << "DeviceBaseInfo::setAttribute overwrite is false";
         // overwrite 为false,如果当前属性值为空或unknown时可覆盖
-        if (variable.isEmpty())
+        if (variable.isEmpty()) {
+            qCDebug(appLog) << "DeviceBaseInfo::setAttribute variable is empty, set value from map";
             variable = mapInfo[key].trimmed();
+        }
 
-        if (variable.contains("Unknown", Qt::CaseInsensitive))
+        if (variable.contains("Unknown", Qt::CaseInsensitive)) {
+            qCDebug(appLog) << "DeviceBaseInfo::setAttribute variable contains Unknown, set value from map";
             variable = mapInfo[key].trimmed();
+        }
     }
+    qCDebug(appLog) << "DeviceBaseInfo::setAttribute end";
 }
 
 TomlFixMethod DeviceBaseInfo::setTomlAttribute(const QMap<QString, QString> &mapInfo, const QString &key, QString &variable, bool overwrite)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::setTomlAttribute called with key: " << key << ", overwrite: " << overwrite;
     // map中存在该属性
-    if (mapInfo.find(key) == mapInfo.end())
+    if (mapInfo.find(key) == mapInfo.end()) {
+        qCDebug(appLog) << "DeviceBaseInfo::setTomlAttribute map does not contain key: " << key;
         return TOML_None;
+    }
 
     // 属性值不能为空
-    if (mapInfo[key] == "")
+    if (mapInfo[key] == "") {
+        qCDebug(appLog) << "DeviceBaseInfo::setTomlAttribute attribute value is empty";
         return TOML_None;
+    }
     //如果有 关键字nouse 为直接接去掉清除
     if (mapInfo[key].toLower().contains("nouse")) {
+        qCDebug(appLog) << "DeviceBaseInfo::setTomlAttribute attribute value contains nouse";
         variable.clear();
         return TOML_nouse;
     }
@@ -706,15 +898,18 @@ TomlFixMethod DeviceBaseInfo::setTomlAttribute(const QMap<QString, QString> &map
     // overwrite 为true直接覆盖
     if (overwrite) {
         setAttribute(mapInfo, key, variable, true);
+        qCDebug(appLog) << "DeviceBaseInfo::setTomlAttribute overwrite is true, return TOML_Cover";
         return TOML_Cover;
     } else {
         setAttribute(mapInfo, key, variable, false);
+        qCDebug(appLog) << "DeviceBaseInfo::setTomlAttribute overwrite is false, return TOML_Cover";
         return TOML_Cover;
     }
 }
 
 void DeviceBaseInfo::mapInfoToList()
 {
+    qCDebug(appLog) << "DeviceBaseInfo::mapInfoToList called";
     // m_MapOtherInfo --> m_LstOtherInfo
     // QMap内容转为QList存储
     auto iter = m_MapOtherInfo.begin();
@@ -723,13 +918,16 @@ void DeviceBaseInfo::mapInfoToList()
         if (isValueValid(iter.value()))
             m_LstOtherInfo.append(QPair<QString, QString>(iter.key(), iter.value()));
     }
+    qCDebug(appLog) << "DeviceBaseInfo::mapInfoToList end";
 }
 
 void DeviceBaseInfo::setHwinfoLshwKey(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::setHwinfoLshwKey called";
     // 网卡使用物理地址+逻辑设备名作为匹配值
     if (mapInfo.find("HW Address") != mapInfo.end()) {
         m_HwinfoToLshw = (mapInfo.find("Device File") != mapInfo.end()) ? mapInfo["HW Address"] + mapInfo["Device File"] : mapInfo["HW Address"];
+        qCDebug(appLog) << "DeviceBaseInfo::setHwinfoLshwKey match HW Address";
         return;
     }
 
@@ -738,16 +936,19 @@ void DeviceBaseInfo::setHwinfoLshwKey(const QMap<QString, QString> &mapInfo)
             && mapInfo.find("SysFS BusID") != mapInfo.end()
             && !mapInfo["SysFS ID"].contains("usb")) {
         m_HwinfoToLshw = mapInfo["SysFS BusID"];
+        qCDebug(appLog) << "DeviceBaseInfo::setHwinfoLshwKey match SysFS BusID";
         return;
     }
 
     // usb总线设备
     QStringList words = mapInfo["SysFS BusID"].split(":");
     if (words.size() != 2) {
+        qCDebug(appLog) << "DeviceBaseInfo::setHwinfoLshwKey words size is not 2";
         return;
     }
     QStringList chs = words[0].split("-");
     if (chs.size() != 2) {
+        qCDebug(appLog) << "DeviceBaseInfo::setHwinfoLshwKey chs size is not 2";
         return;
     }
 
@@ -768,10 +969,12 @@ void DeviceBaseInfo::setHwinfoLshwKey(const QMap<QString, QString> &mapInfo)
         int second = match.captured(2).toInt();
         int third = match.captured(3).toInt();
         m_HwinfoToLshw = QString("usb@%1:%2.%3").arg(nums.at(first)).arg(nums.at(second)).arg(nums.at(third));
+        qCDebug(appLog) << "DeviceBaseInfo::setHwinfoLshwKey match";
     } else {
         int first = chs[0].toInt();
         int second = chs[1].toInt();
         m_HwinfoToLshw = QString("usb@%1:%2").arg(nums.at(first)).arg(nums.at(second));
+        qCDebug(appLog) << "DeviceBaseInfo::setHwinfoLshwKey not match";
     }
 #else
     QRegExp reg("([0-9a-zA-Z]+)-([0-9a-zA-Z]+)\\.([0-9a-zA-Z]+)");
@@ -780,53 +983,65 @@ void DeviceBaseInfo::setHwinfoLshwKey(const QMap<QString, QString> &mapInfo)
         int second = reg.cap(2).toInt();
         int third = reg.cap(3).toInt();
         m_HwinfoToLshw = QString("usb@%1:%2.%3").arg(nums.at(first)).arg(nums.at(second)).arg(nums.at(third));
+        qCDebug(appLog) << "DeviceBaseInfo::setHwinfoLshwKey match";
     } else {
         int first = chs[0].toInt();
         int second = chs[1].toInt();
         m_HwinfoToLshw = QString("usb@%1:%2").arg(nums.at(first)).arg(nums.at(second));
+        qCDebug(appLog) << "DeviceBaseInfo::setHwinfoLshwKey no match";
     }
 #endif
 }
 
 bool DeviceBaseInfo::matchToLshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::matchToLshw called";
     // 网卡设备与序列号匹配上 或者加上逻辑设备名
     if (mapInfo.find("logical name") != mapInfo.end() && mapInfo.find("serial") != mapInfo.end()) {
         if (m_HwinfoToLshw == mapInfo["serial"] + mapInfo["logical name"]) {
+            qCDebug(appLog) << "DeviceBaseInfo::matchToLshw match serial and logical name";
             return true;
         } else if (m_HwinfoToLshw == mapInfo["serial"]) {
+            qCDebug(appLog) << "DeviceBaseInfo::matchToLshw match serial";
             return true;
         }
     }
 
     if (mapInfo.find("bus info") == mapInfo.end()) {
+        qCDebug(appLog) << "DeviceBaseInfo::matchToLshw bus info not found";
         return false;
     }
     // 非usb设备
     if (mapInfo["bus info"].startsWith("pci")) {
         QStringList words = mapInfo["bus info"].split("@");
         if (2 == words.size() && words[1] == m_HwinfoToLshw) {
+            qCDebug(appLog) << "DeviceBaseInfo::matchToLshw match pci";
             return true;
         }
     }
 
     // USB 设备
     if (m_HwinfoToLshw == mapInfo["bus info"]) {
+        qCDebug(appLog) << "DeviceBaseInfo::matchToLshw match usb";
         return true;
     }
+    qCDebug(appLog) << "DeviceBaseInfo::matchToLshw no match";
     return false;
 }
 
 void DeviceBaseInfo::setPhysIDMapKey(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::setPhysIDMapKey called";
     if (mapInfo.find("VID_PID") != mapInfo.end()) {
         m_PhysIDMap = mapInfo["VID_PID"];
+        qCDebug(appLog) << "DeviceBaseInfo::setPhysIDMapKey match VID_PID";
         return;
     }
 }
 
 bool DeviceBaseInfo::PhysIDMapInfo(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceBaseInfo::PhysIDMapInfo called";
     // Modalias 或 "Module Alias" 匹配上  ，硬件 IDS 参考内核 Module Alias 规则标准
     if (mapInfo.find("Module Alias") != mapInfo.end()) {
         if (m_PhysIDMap == mapInfo["Module Alias"]) {
@@ -852,6 +1067,7 @@ bool DeviceBaseInfo::PhysIDMapInfo(const QMap<QString, QString> &mapInfo)
 
 const  QString DeviceBaseInfo::get_string(const QString &sysPathfile)
 {
+    // qCDebug(appLog) << "DeviceBaseInfo::get_string called with sysPathfile: " << sysPathfile;
     // 从文件中获取D信息
     QFile file(sysPathfile);
     if (!file.open(QIODevice::ReadOnly))
@@ -860,6 +1076,7 @@ const  QString DeviceBaseInfo::get_string(const QString &sysPathfile)
     QString info = file.readAll();
     info = info.trimmed();
     file.close();
+    // qCDebug(appLog) << "DeviceBaseInfo::get_string end";
     return info;
 }
 

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -139,130 +139,156 @@ void DeviceManager::clear()
 
 const QList<QPair<QString, QString>> &DeviceManager::getDeviceTypes()
 {
+    qCDebug(appLog) << "Getting device types";
     // 获取设备类型
     // 清空设备类型列表
     m_ListDeviceType.clear();
     bool addSeperator = false;
     // 添加概况信息
     if (true) {
+        qCDebug(appLog) << "Adding overview information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Overview"), "overview##Overview"));
         addSeperator = true;
     }
 
     // 添加cpu信息
     if (m_ListDeviceCPU.size() > 0) {
+        qCDebug(appLog) << "Adding CPU information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("CPU"), "cpu##CPU"));
         addSeperator = true;
     }
 
     if (m_CpuNum > 1) {
+        qCDebug(appLog) << "Adding CPU quantity information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("CPU quantity"), ""));
         addSeperator = true;
     }
 
     if (addSeperator) {
+        qCDebug(appLog) << "Adding separator";
         m_ListDeviceType.append(QPair<QString, QString>("Separator", "Separator##Separator"));
         addSeperator = false;
     }
 
     // 板载接口设备
     if (m_ListDeviceBios.size() > 0) {
+        qCDebug(appLog) << "Adding Motherboard information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Motherboard"), "motherboard##Bios"));
         addSeperator = true;
     }
 
     if (m_ListDeviceMemory.size() > 0) {
+        qCDebug(appLog) << "Adding Memory information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Memory"), "memory##Memory"));
         addSeperator = true;
     }
 
     if (m_ListDeviceGPU.size() > 0) {
+        qCDebug(appLog) << "Adding Display Adapter information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Display Adapter"), "displayadapter##GPU"));
         addSeperator = true;
     }
 
     if (m_ListDeviceAudio.size() > 0) {
+        qCDebug(appLog) << "Adding Sound Adapter information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Sound Adapter"), "audiodevice##Audio"));
         addSeperator = true;
     }
 
     if (m_ListDeviceStorage.size() > 0) {
+        qCDebug(appLog) << "Adding Storage information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Storage"), "storage##Storage"));
         addSeperator = true;
     }
 
     if (m_ListDeviceOtherPCI.size() > 0) {
+        qCDebug(appLog) << "Adding Other PCI Devices information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Other PCI Devices"), "otherpcidevices##OtherPCI"));
         addSeperator = true;
     }
 
     if (m_ListDevicePower.size() > 0) {
+        qCDebug(appLog) << "Adding Battery information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Battery"), "battery##Power"));
         addSeperator = true;
     }
 
     if (addSeperator) {
+        qCDebug(appLog) << "Adding separator";
         m_ListDeviceType.append(QPair<QString, QString>("Separator", "Separator##Separator"));
         addSeperator = false;
     }
 
     // 网络设备
     if (m_ListDeviceBluetooth.size() > 0) {
+        qCDebug(appLog) << "Adding Bluetooth information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Bluetooth"), "bluetooth##Bluetooth"));
         addSeperator = true;
     }
 
     if (m_ListDeviceNetwork.size() > 0) {
+        qCDebug(appLog) << "Adding Network Adapter information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Network Adapter"), "networkadapter##Network"));
         addSeperator = true;
     }
 
     if (addSeperator) {
+        qCDebug(appLog) << "Adding separator";
         m_ListDeviceType.append(QPair<QString, QString>("Separator", "Separator##Separator"));
         addSeperator = false;
     }
 
     // 输入设备
     if (m_ListDeviceMouse.size() > 0) {
+        qCDebug(appLog) << "Adding Mouse information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Mouse"), "mouse##Mouse"));
         addSeperator = true;
     }
 
     if (m_ListDeviceKeyboard.size() > 0) {
+        qCDebug(appLog) << "Adding Keyboard information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Keyboard"), "keyboard##Keyboard"));
         addSeperator = true;
     }
 
     if (addSeperator) {
+        qCDebug(appLog) << "Adding separator";
         m_ListDeviceType.append(QPair<QString, QString>("Separator", "Separator##Separator"));
     }
 
     // 外设设备
     if (m_ListDeviceMonitor.size() > 0) {
+        qCDebug(appLog) << "Adding Monitor information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Monitor"), "monitor##Monitor"));
     }
 
     if (m_ListDeviceCdrom.size() > 0) {
+        qCDebug(appLog) << "Adding CD-ROM information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("CD-ROM"), "cdrom##Cdrom"));
     }
 
     if (m_ListDevicePrint.size() > 0) {
+        qCDebug(appLog) << "Adding Printer information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Printer"), "printer##Print"));
     }
 
     if (m_ListDeviceImage.size() > 0) {
+        qCDebug(appLog) << "Adding Camera information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Camera"), "camera##Image"));
     }
 
     if (m_ListDeviceOthers.size() > 0) {
+        qCDebug(appLog) << "Adding Other Devices information";
         m_ListDeviceType.append(QPair<QString, QString>(tr("Other Devices", "Other Input Devices"), "otherdevices##Others"));
     }
 
+    qCDebug(appLog) << "Finished getting device types";
     return m_ListDeviceType;
 }
 
 void DeviceManager::setDeviceListClass()
 {
+    qCDebug(appLog) << "Setting device list class";
     // 添加设备类型与设备指针列表的映射关系
     m_DeviceClassMap[tr("CPU")] = m_ListDeviceCPU;
     m_DeviceClassMap[tr("Motherboard")] =  m_ListDeviceBios;
@@ -285,19 +311,23 @@ void DeviceManager::setDeviceListClass()
 
 bool DeviceManager::getDeviceList(const QString &name, QList<DeviceBaseInfo *> &lst)
 {
+    qCDebug(appLog) << "Getting device list for name:" << name;
     // name为概况Overview时,没有设备列表
     if (name == tr("Overview"))
         return false;
 
     // 获取设备指针列表
-    if (m_DeviceClassMap.find(name) != m_DeviceClassMap.end())
+    if (m_DeviceClassMap.find(name) != m_DeviceClassMap.end()) {
+        qCDebug(appLog) << "Found device list for name:" << name;
         lst = m_DeviceClassMap[name];
+    }
 
     return true;
 }
 
 QString DeviceManager::convertDeviceTomlClassName(DeviceType deviceType)
 {
+    qCDebug(appLog) << "Converting device type to TOML class name for deviceType:" << deviceType;
     //与oeminfoxxx.toml文件中的[hardclassname.submember] 保持一致，即 “toml+hardclassname”
     if (deviceType == DT_Null)      {return "";}
     if (deviceType == DT_Computer)  {return "tomlComputer";}
@@ -323,6 +353,7 @@ QString DeviceManager::convertDeviceTomlClassName(DeviceType deviceType)
 
 QList<DeviceBaseInfo *> *DeviceManager::convertDeviceListAddr(DeviceType deviceType)
 {
+    qCDebug(appLog) << "Converting device type to list address for deviceType:" << deviceType;
 //    if (deviceType == DT_Null)      {return &m_ListDeviceOthers;}
     if (deviceType == DT_Computer)  {return &m_ListDeviceComputer;}
     if (deviceType == DT_Cpu)       {return &m_ListDeviceCPU;}
@@ -346,6 +377,7 @@ QList<DeviceBaseInfo *> *DeviceManager::convertDeviceListAddr(DeviceType deviceT
 }
 QList<DeviceBaseInfo *> DeviceManager::convertDeviceList(DeviceType deviceType)
 {
+    qCDebug(appLog) << "Converting device type to list for deviceType:" << deviceType;
 //    if (deviceType == DT_Null)      {return m_ListDeviceOthers;}
     if (deviceType == DT_Computer)  {return m_ListDeviceComputer;}
     if (deviceType == DT_Cpu)       {return m_ListDeviceCPU;}
@@ -369,6 +401,7 @@ QList<DeviceBaseInfo *> DeviceManager::convertDeviceList(DeviceType deviceType)
 
 DeviceBaseInfo *DeviceManager::createDevice(DeviceType deviceType)
 {
+    qCDebug(appLog) << "Creating device for deviceType:" << deviceType;
     DeviceBaseInfo *vTemp;
     if (deviceType == DT_Computer)  {vTemp = new DeviceComputer();  return vTemp;}
     if (deviceType == DT_Cpu)       {vTemp = new DeviceCpu();  return vTemp;}
@@ -393,6 +426,7 @@ DeviceBaseInfo *DeviceManager::createDevice(DeviceType deviceType)
 
 TomlFixMethod DeviceManager::tomlDeviceSet(DeviceType deviceType,  DeviceBaseInfo *device, const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting TOML device for deviceType:" << deviceType;
     if (!device) {
         return TOML_None;
     }
@@ -480,7 +514,7 @@ TomlFixMethod DeviceManager::tomlDeviceSet(DeviceType deviceType,  DeviceBaseInf
 
 void DeviceManager::tomlDeviceSet(DeviceType deviceType)
 {
-
+    qCDebug(appLog) << "Setting TOML device for deviceType:" << deviceType;
     QString deviceTypeName = convertDeviceTomlClassName(deviceType);
     const QList<QMap<QString, QString>> &tomlMapLst = cmdInfo(deviceTypeName);
     for (int j = 0; j < tomlMapLst.size(); j++) { // 加载从toml中获取的信息
@@ -520,19 +554,24 @@ void DeviceManager::tomlDeviceSet(DeviceType deviceType)
 }
 QString DeviceManager::PhysID(const QMap<QString, QString> &mapInfo, const QString &key)
 {
+    qCDebug(appLog) << "Getting PhysID for key:" << key;
     if (mapInfo.contains(key)) {  //toml key
         QString value = mapInfo[key].trimmed();
         if (!value.isEmpty()) {
             value = value.toLower().remove("_nouse"); //"_nouse" 为toml方案中约定的去除该信息项的关键字
+            qCDebug(appLog) << "PhysID for key:" << key << "is:" << value;
             return value;
         }
     }
+    qCDebug(appLog) << "PhysID for key:" << key << "is empty";
     return "";
 }
 
 void DeviceManager::tomlDeviceDel(DeviceType deviceType, DeviceBaseInfo *const device)
 {
+    qCDebug(appLog) << "Deleting TOML device for deviceType:" << deviceType;
     if (!device) {
+        qCDebug(appLog) << "Device is null";
         return;
     }
     QList<DeviceBaseInfo *> *lst = convertDeviceListAddr(deviceType);
@@ -541,7 +580,9 @@ void DeviceManager::tomlDeviceDel(DeviceType deviceType, DeviceBaseInfo *const d
 
 void DeviceManager::tomlDeviceAdd(DeviceType deviceType, DeviceBaseInfo *const device)
 {
+    qCDebug(appLog) << "Adding TOML device for deviceType:" << deviceType;
     if (!device) {
+        qCDebug(appLog) << "Device is null";
         return;
     }
     QList<DeviceBaseInfo *> *lst = convertDeviceListAddr(deviceType);
@@ -550,14 +591,20 @@ void DeviceManager::tomlDeviceAdd(DeviceType deviceType, DeviceBaseInfo *const d
 
 bool DeviceManager::findByModalias(DeviceType deviceType, DeviceBaseInfo *device, const QString &modalias)
 {
-    if (modalias.isEmpty())
+    qCDebug(appLog) << "Finding by Modalias for deviceType:" << deviceType;
+    if (modalias.isEmpty()) {
+        qCDebug(appLog) << "Modalias is empty";
         return false;
+    }
     {
-        if (!device)
+        if (!device) {
+            qCDebug(appLog) << "Device is null";
             return false;
+        }
 
         QString tmp_Modalias =  device->getModalias();
         if ((0 == modalias.compare(tmp_Modalias, Qt::CaseInsensitive))) { //modalias相同即认为是同一设备
+            qCDebug(appLog) << "Modalias is the same";
             return true;
         }
 
@@ -569,56 +616,79 @@ bool DeviceManager::findByModalias(DeviceType deviceType, DeviceBaseInfo *device
             QString tmp_pid  = tmp_vidpid.mid(4, 4);
 
             if ((modalias.contains(tmp_vid, Qt::CaseInsensitive)) && (modalias.contains(tmp_pid, Qt::CaseInsensitive))) {
+                qCDebug(appLog) << "VIDAndPID is the same";
                 return true;
             }
         }
     }
+    qCDebug(appLog) << "Modalias is not the same";
     return false;
 }
 
 bool DeviceManager::findByVIDPID(DeviceType deviceType, DeviceBaseInfo *device, const QString &vid, const QString &pid)
 {
-    if (vid.isEmpty() ||  pid.isEmpty())
+    qCDebug(appLog) << "Finding by VIDPID for deviceType:" << deviceType;
+    if (vid.isEmpty() ||  pid.isEmpty()) {
+        qCDebug(appLog) << "VID or PID is empty";
         return false;
+    }
     {
-        if (!device)
+        if (!device) {
+            qCDebug(appLog) << "Device is null";
             return false;
+        }
 
         QString tmp_refvid = vid.toLower();
-        if (tmp_refvid.contains("0x"))
+        if (tmp_refvid.contains("0x")) {
+            qCDebug(appLog) << "VID contains 0x";
             tmp_refvid.remove("0x");
+        }
         QString tmp_refpid = pid.toLower();
-        if (tmp_refpid.contains("0x"))
+        if (tmp_refpid.contains("0x")) {
+            qCDebug(appLog) << "PID contains 0x";
             tmp_refpid.remove("0x");
+        }
 
         QString tmp_vid =  device->getVID().toLower();
         QString tmp_pid =  device->getPID().toLower();
-        if (tmp_vid.contains("0x"))
+        if (tmp_vid.contains("0x")) {
+            qCDebug(appLog) << "VID contains 0x";
             tmp_vid.remove("0x");
-        if (tmp_pid.contains("0x"))
+        }
+        if (tmp_pid.contains("0x")) {
+            qCDebug(appLog) << "PID contains 0x";
             tmp_pid.remove("0x");
+        }
 
         if (tmp_vid.isEmpty() || tmp_pid.isEmpty()) {
             QString tmp_VIDAndPID =  device->getVIDAndPID().toLower();  ////VID和PID相同即认为是同一设备
-            if (tmp_VIDAndPID.contains(tmp_refvid) && tmp_VIDAndPID.contains(tmp_refpid))
+            if (tmp_VIDAndPID.contains(tmp_refvid) && tmp_VIDAndPID.contains(tmp_refpid)) {
+                qCDebug(appLog) << "VIDAndPID is the same";
                 return true;
+            }
         } else {
             if ((0 == tmp_refvid.compare(tmp_vid, Qt::CaseInsensitive)) && (0 == tmp_refpid.compare(tmp_pid, Qt::CaseInsensitive))) {
+                qCDebug(appLog) << "VID and PID are the same";
                 return true;
             }
         }
     }
+    qCDebug(appLog) << "VID and PID are not the same";
     return false;
 }
 
 bool DeviceManager::findByVendorName(DeviceType deviceType, DeviceBaseInfo *device, const QString &vendor, const QString &name)
 {
-
-    if (name.isEmpty())
+    qCDebug(appLog) << "Finding by VendorName for deviceType:" << deviceType;
+    if (name.isEmpty()) {
+        qCDebug(appLog) << "Name is empty";
         return false;
-    if (vendor.isEmpty())
+    }
+    if (vendor.isEmpty()) {
+        qCDebug(appLog) << "Vendor is empty";
         if ((deviceType != DT_Bios) && (deviceType != DT_Computer))
             return false;
+    }
     if (!device)
         return false;
     QString tmp_vendor;
@@ -641,25 +711,32 @@ bool DeviceManager::findByVendorName(DeviceType deviceType, DeviceBaseInfo *devi
             return true;
         }
     }
+    qCDebug(appLog) << "VendorName is not the same";
     return false;
 }
 
 DeviceBaseInfo *DeviceManager::getBluetoothAtIndex(int index)
 {
-    if (m_ListDeviceBluetooth.size() <= index)
+    qCDebug(appLog) << "Getting Bluetooth device at index:" << index;
+    if (m_ListDeviceBluetooth.size() <= index) {
+        qCDebug(appLog) << "Index is out of range";
         return nullptr;
+    }
     return m_ListDeviceBluetooth[index];
 }
 
 void DeviceManager::addMouseDevice(DeviceInput *const device)
 {
+    // qCDebug(appLog) << "Adding mouse device";
     // 如果不是重复设备则添加到设备列表
     m_ListDeviceMouse.append(device);
 }
 
 DeviceBaseInfo *DeviceManager::getMouseDevice(const QString &unique_id)
 {
+    qCDebug(appLog) << "Getting mouse device with unique ID:" << unique_id;
     if (unique_id.isEmpty()) {
+        qCDebug(appLog) << "Unique ID is empty";
         return nullptr;
     }
     for (QList<DeviceBaseInfo *>::iterator it = m_ListDeviceMouse.begin(); it != m_ListDeviceMouse.end(); ++it) {
@@ -668,11 +745,13 @@ DeviceBaseInfo *DeviceManager::getMouseDevice(const QString &unique_id)
             return *it;
         }
     }
+    qCDebug(appLog) << "Mouse device with unique ID:" << unique_id << "not found";
     return nullptr;
 }
 
 bool DeviceManager::addMouseInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Adding mouse info from lshw";
     // 从lshw中添加鼠标信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceMouse.begin();
     for (; it != m_ListDeviceMouse.end(); ++it) {
@@ -680,25 +759,31 @@ bool DeviceManager::addMouseInfoFromLshw(const QMap<QString, QString> &mapInfo)
         if (!device)
             continue;
 
-        if (device->setInfoFromlshw(mapInfo))
+        if (device->setInfoFromlshw(mapInfo)) {
+            qCDebug(appLog) << "Mouse info added from lshw";
             return true;
+        }
     }
+    qCDebug(appLog) << "Mouse info not added from lshw";
     return false;
 }
 
 void DeviceManager::addCpuDevice(DeviceCpu *const device)
 {
+    // qCDebug(appLog) << "Adding CPU device";
     // 添加CPU设备
     m_ListDeviceCPU.append(device);
 }
 
 void DeviceManager::addStorageDeivce(DeviceStorage *const device)
 {
+    // qCDebug(appLog) << "Adding storage device";
     m_ListDeviceStorage.append(device);
 }
 
 void DeviceManager::addLshwinfoIntoStorageDevice(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Adding lshw info into storage device";
     // 从lshw中添加存储设备信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceStorage.begin();
     for (; it != m_ListDeviceStorage.end(); ++it) {
@@ -713,6 +798,7 @@ void DeviceManager::addLshwinfoIntoStorageDevice(const QMap<QString, QString> &m
 
 void DeviceManager::addLshwinfoIntoNVMEStorageDevice(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Adding NVME info into storage device";
     // 从lshw中添加NVME存储设备信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceStorage.begin();
     for (; it != m_ListDeviceStorage.end(); ++it) {
@@ -727,6 +813,7 @@ void DeviceManager::addLshwinfoIntoNVMEStorageDevice(const QMap<QString, QString
 
 void DeviceManager::setStorageInfoFromSmartctl(const QString &name, const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Adding smartctl info into storage device";
     // // 从smartctl中添加存储设备信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceStorage.begin();
     for (; it != m_ListDeviceStorage.end(); ++it) {
@@ -741,6 +828,7 @@ void DeviceManager::setStorageInfoFromSmartctl(const QString &name, const QMap<Q
 
 void DeviceManager::mergeDisk()
 {
+    qCDebug(appLog) << "Merging disk";
     QList<int> m_ListStorageIndex;
     QMap<QString, QList<int> > allSerialIDs;
     for (int i = 0; i < m_ListDeviceStorage.size(); ++i) {
@@ -775,6 +863,7 @@ void DeviceManager::mergeDisk()
 
 void DeviceManager::checkDiskSize()
 {
+    qCDebug(appLog) << "Checking disk size";
     for (int i = 0; i < m_ListDeviceStorage.size(); ++i) {
         DeviceStorage *device = dynamic_cast<DeviceStorage *>(m_ListDeviceStorage[i]);
         device->checkDiskSize();
@@ -783,6 +872,7 @@ void DeviceManager::checkDiskSize()
 
 bool DeviceManager::setStorageDeviceMediaType(const QString &name, const QString &value)
 {
+    qCDebug(appLog) << "Setting storage device media type";
     // 设置存储设备介质类型
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceStorage.begin();
     for (; it != m_ListDeviceStorage.end(); ++it) {
@@ -800,6 +890,7 @@ bool DeviceManager::setStorageDeviceMediaType(const QString &name, const QString
 
 bool DeviceManager::setKLUStorageDeviceMediaType(const QString &name, const QString &value)
 {
+    qCDebug(appLog) << "Setting KLU storage device media type";
     // 设置KLU机器存储设备介质类型
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceStorage.begin();
     for (; it != m_ListDeviceStorage.end(); ++it) {
@@ -817,12 +908,14 @@ bool DeviceManager::setKLUStorageDeviceMediaType(const QString &name, const QStr
 
 void DeviceManager::addGpuDevice(DeviceGpu *const device)
 {
+    // qCDebug(appLog) << "Adding GPU device";
     // 添加显示适配器
     m_ListDeviceGPU.append(device);
 }
 
 void DeviceManager::setGpuInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting GPU info from lshw";
     // 从lshw中添加显示适配器信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceGPU.begin();
     for (; it != m_ListDeviceGPU.end(); ++it) {
@@ -836,6 +929,7 @@ void DeviceManager::setGpuInfoFromLshw(const QMap<QString, QString> &mapInfo)
 
 void DeviceManager::setGpuInfoFromXrandr(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting GPU info from xrandr";
     // 从xrandr中添加显示适配器信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceGPU.begin();
     for (; it != m_ListDeviceGPU.end(); ++it) {
@@ -849,6 +943,7 @@ void DeviceManager::setGpuInfoFromXrandr(const QMap<QString, QString> &mapInfo)
 
 void DeviceManager::setGpuSizeFromDmesg(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting GPU size from dmesg";
     // 从dmesg中设置显卡大小
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceGPU.begin();
     for (; it != m_ListDeviceGPU.end(); ++it) {
@@ -862,12 +957,14 @@ void DeviceManager::setGpuSizeFromDmesg(const QMap<QString, QString> &mapInfo)
 
 void DeviceManager::addMemoryDevice(DeviceMemory *const device)
 {
+    // qCDebug(appLog) << "Adding memory device";
     // 添加内存
     m_ListDeviceMemory.append(device);
 }
 
 void DeviceManager::setMemoryInfoFromDmidecode(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting memory info from dmidecode";
     // 从dmidecode中添加内存信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceMemory.begin();
     for (; it != m_ListDeviceMemory.end(); ++it) {
@@ -882,12 +979,14 @@ void DeviceManager::setMemoryInfoFromDmidecode(const QMap<QString, QString> &map
 
 void DeviceManager::addMonitor(DeviceMonitor *const device)
 {
+    // qCDebug(appLog) << "Adding monitor device";
     // 添加显示设备
     m_ListDeviceMonitor.append(device);
 }
 
 void DeviceManager::setMonitorInfoFromXrandr(const QString &main, const QString &edid, const QString &rate)
 {
+    qCDebug(appLog) << "Setting monitor info from xrandr";
     // 从xrandr中添加显示设备信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceMonitor.begin();
     for (; it != m_ListDeviceMonitor.end(); ++it) {
@@ -902,6 +1001,7 @@ void DeviceManager::setMonitorInfoFromXrandr(const QString &main, const QString 
 
 void DeviceManager::setMonitorInfoFromDbus(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting monitor info from dbus";
     // 从 dbus 中添加显示设备信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceMonitor.begin();
     for (; it != m_ListDeviceMonitor.end(); ++it) {
@@ -916,12 +1016,14 @@ void DeviceManager::setMonitorInfoFromDbus(const QMap<QString, QString> &mapInfo
 
 void DeviceManager::addBiosDevice(DeviceBios *const device)
 {
+    // qCDebug(appLog) << "Adding bios device";
     // 添加主板信息
     m_ListDeviceBios.append(device);
 }
 
 void DeviceManager::setLanguageInfo(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting language info";
     // 设置语言信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceBios.begin();
     for (; it != m_ListDeviceBios.end(); ++it) {
@@ -936,11 +1038,13 @@ void DeviceManager::setLanguageInfo(const QMap<QString, QString> &mapInfo)
 
 void DeviceManager::addBluetoothDevice(DeviceBluetooth *const device)
 {
+    // qCDebug(appLog) << "Adding bluetooth device";
     m_ListDeviceBluetooth.append(device);
 }
 
 void DeviceManager::setBluetoothInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting bluetooth info from lshw";
     // 从lshw中获取蓝牙信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceBluetooth.begin();
     for (; it != m_ListDeviceBluetooth.end(); ++it) {
@@ -955,6 +1059,7 @@ void DeviceManager::setBluetoothInfoFromLshw(const QMap<QString, QString> &mapIn
 
 bool DeviceManager::setBluetoothInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting bluetooth info from hwinfo";
     // 从hwinfo中获取蓝牙信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceBluetooth.begin();
     for (; it != m_ListDeviceBluetooth.end(); ++it) {
@@ -970,6 +1075,7 @@ bool DeviceManager::setBluetoothInfoFromHwinfo(const QMap<QString, QString> &map
 
 bool DeviceManager::setBluetoothInfoFromWifiInfo(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting bluetooth info from wifi info";
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceBluetooth.begin();
     for (; it != m_ListDeviceBluetooth.end(); ++it) {
         DeviceBluetooth *device = dynamic_cast<DeviceBluetooth *>(*it);
@@ -982,6 +1088,7 @@ bool DeviceManager::setBluetoothInfoFromWifiInfo(const QMap<QString, QString> &m
 
 DeviceBaseInfo *DeviceManager::getBluetoothDevice(const QString &unique_id)
 {
+    qCDebug(appLog) << "Getting bluetooth device with unique ID:" << unique_id;
     for (QList<DeviceBaseInfo *>::iterator it = m_ListDeviceBluetooth.begin(); it != m_ListDeviceBluetooth.end(); ++it) {
         DeviceBluetooth *bt = dynamic_cast<DeviceBluetooth *>(*it);
         if (bt && bt->uniqueID() == unique_id) {
@@ -993,16 +1100,19 @@ DeviceBaseInfo *DeviceManager::getBluetoothDevice(const QString &unique_id)
 
 void DeviceManager::addAudioDevice(DeviceAudio *const device)
 {
+    // qCDebug(appLog) << "Adding audio device";
     m_ListDeviceAudio.append(device);
 }
 
 void DeviceManager::delAudioDevice(DeviceAudio *const device)
 {
+    // qCDebug(appLog) << "Deleting audio device";
     m_ListDeviceAudio.removeOne(device);
 }
 
 void DeviceManager::deleteDisableDuplicate_AudioDevice(void)
 {
+    qCDebug(appLog) << "Deleting disable duplicate audio device";
     if (m_ListDeviceAudio.size() > 0) {
         for (QList<DeviceBaseInfo *>::iterator it = m_ListDeviceAudio.begin(); it != m_ListDeviceAudio.end(); ++it) {
             DeviceAudio *audio_1 = dynamic_cast<DeviceAudio *>(*it);
@@ -1023,6 +1133,7 @@ void DeviceManager::deleteDisableDuplicate_AudioDevice(void)
 
 DeviceBaseInfo *DeviceManager::getAudioDevice(const QString &path)
 {
+    qCDebug(appLog) << "Getting audio device with path:" << path;
     for (QList<DeviceBaseInfo *>::iterator it = m_ListDeviceAudio.begin(); it != m_ListDeviceAudio.end(); ++it) {
         DeviceAudio *audio = dynamic_cast<DeviceAudio *>(*it);
         QString tpath = audio->uniqueID();
@@ -1048,11 +1159,13 @@ DeviceBaseInfo *DeviceManager::getAudioDevice(const QString &path)
             return *it;
         }
     }
+    qCDebug(appLog) << "Audio device with path:" << path << "not found";
     return nullptr;
 }
 
 void DeviceManager::setAudioInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting audio info from lshw";
     // 从lshw中获取音频适配器信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceAudio.begin();
     for (; it != m_ListDeviceAudio.end(); ++it) {
@@ -1067,6 +1180,7 @@ void DeviceManager::setAudioInfoFromLshw(const QMap<QString, QString> &mapInfo)
 
 void DeviceManager::setAudioChipFromDmesg(const QString &info)
 {
+    qCDebug(appLog) << "Setting audio chip from dmesg";
     // 从dmesg中获取声卡芯片型号
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceAudio.begin();
     for (; it != m_ListDeviceAudio.end(); ++it) {
@@ -1080,12 +1194,14 @@ void DeviceManager::setAudioChipFromDmesg(const QString &info)
 
 void DeviceManager::addNetworkDevice(DeviceNetwork *const device)
 {
+    // qCDebug(appLog) << "Adding network device";
     // 添加网络适配器
     m_ListDeviceNetwork.append(device);
 }
 
 bool DeviceManager::setNetworkInfoFromWifiInfo(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting network info from wifi info";
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceNetwork.begin();
     for (; it != m_ListDeviceNetwork.end(); ++it) {
 
@@ -1097,24 +1213,30 @@ bool DeviceManager::setNetworkInfoFromWifiInfo(const QMap<QString, QString> &map
             return true;
         }
     }
+    qCDebug(appLog) << "Network info from wifi info not found";
     return false;
 }
 
 DeviceBaseInfo *DeviceManager::getNetworkDevice(const QString &unique_id)
 {
+    qCDebug(appLog) << "Getting network device with unique ID:" << unique_id;
     for (QList<DeviceBaseInfo *>::iterator it = m_ListDeviceNetwork.begin(); it != m_ListDeviceNetwork.end(); ++it) {
         DeviceNetwork *net = dynamic_cast<DeviceNetwork *>(*it);
         if (!unique_id.isEmpty() && net && net->uniqueID() == unique_id) {
             return *it;
         }
     }
+    qCDebug(appLog) << "Network device with unique ID:" << unique_id << "not found";
     return nullptr;
 }
 
 void DeviceManager::correctNetworkLinkStatus(QString linkStatus, QString networkDriver)
 {
-    if (m_ListDeviceNetwork.size() == 0)
+    qCDebug(appLog) << "Correcting network link status";
+    if (m_ListDeviceNetwork.size() == 0) {
+        qCDebug(appLog) << "Network device list is empty";
         return;
+    }
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceNetwork.begin();
     for (; it != m_ListDeviceNetwork.end(); ++it) {
         DeviceNetwork *device = dynamic_cast<DeviceNetwork *>(*it);
@@ -1127,6 +1249,7 @@ void DeviceManager::correctNetworkLinkStatus(QString linkStatus, QString network
 
 QStringList DeviceManager::networkDriver()
 {
+    qCDebug(appLog) << "Getting network driver";
     m_networkDriver.clear();
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceNetwork.begin();
     for (; it != m_ListDeviceNetwork.end(); ++it) {
@@ -1136,13 +1259,17 @@ QStringList DeviceManager::networkDriver()
         //保存各个网卡的逻辑名称，用于判断具体网卡
         m_networkDriver.append(device->logicalName());
     }
+    qCDebug(appLog) << "Network driver:" << m_networkDriver;
     return m_networkDriver;
 }
 
 void DeviceManager::correctPowerInfo(const QMap<QString, QMap<QString, QString>> &mapInfo)
 {
-    if (m_ListDevicePower.size() == 0)
+    qCDebug(appLog) << "Correcting power info";
+    if (m_ListDevicePower.size() == 0) {
+        qCDebug(appLog) << "Power device list is empty";
         return;
+    }
     QList<DeviceBaseInfo *>::iterator it = m_ListDevicePower.begin();
     for (; it != m_ListDevicePower.end(); ++it) {
         DevicePower *device = dynamic_cast<DevicePower *>(*it);
@@ -1157,23 +1284,27 @@ void DeviceManager::correctPowerInfo(const QMap<QString, QMap<QString, QString>>
 
 void DeviceManager::addImageDevice(DeviceImage *const device)
 {
+    // qCDebug(appLog) << "Adding image device";
     // 添加图像设备
     m_ListDeviceImage.append(device);
 }
 
 DeviceBaseInfo *DeviceManager::getImageDevice(const QString &unique_id)
 {
+    qCDebug(appLog) << "Getting image device with unique ID:" << unique_id;
     for (QList<DeviceBaseInfo *>::iterator it = m_ListDeviceImage.begin(); it != m_ListDeviceImage.end(); ++it) {
         DeviceImage *image = dynamic_cast<DeviceImage *>(*it);
         if (image && image->uniqueID() == unique_id) {
             return *it;
         }
     }
+    qCDebug(appLog) << "Image device with unique ID:" << unique_id << "not found";
     return nullptr;
 }
 
 void DeviceManager::setCameraInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting camera info from lshw";
     // 从lshw获取图像设备信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceImage.begin();
     for (; it != m_ListDeviceImage.end(); ++it) {
@@ -1187,12 +1318,14 @@ void DeviceManager::setCameraInfoFromLshw(const QMap<QString, QString> &mapInfo)
 
 void DeviceManager::addKeyboardDevice(DeviceInput *const device)
 {
+    // qCDebug(appLog) << "Adding keyboard device";
     // 添加键盘
     m_ListDeviceKeyboard.append(device);
 }
 
 void DeviceManager::setKeyboardInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting keyboard info from lshw";
     // 从lshw获取键盘信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceKeyboard.begin();
     for (; it != m_ListDeviceKeyboard.end(); ++it) {
@@ -1207,6 +1340,7 @@ void DeviceManager::setKeyboardInfoFromLshw(const QMap<QString, QString> &mapInf
 
 void DeviceManager::addOthersDevice(DeviceOthers *const device)
 {
+    qCDebug(appLog) << "Adding others device";
     // 添加其他设备
     bool isOtherDevice = true;
     foreach (auto disk, m_ListDeviceStorage) {
@@ -1228,6 +1362,7 @@ void DeviceManager::addOthersDevice(DeviceOthers *const device)
 
 DeviceBaseInfo *DeviceManager::getOthersDevice(const QString &unique_id)
 {
+    qCDebug(appLog) << "Getting others device with unique ID:" << unique_id;
     if (unique_id.isEmpty()) {
         return nullptr;
     }
@@ -1237,11 +1372,13 @@ DeviceBaseInfo *DeviceManager::getOthersDevice(const QString &unique_id)
             return *it;
         }
     }
+    qCDebug(appLog) << "Others device with unique ID:" << unique_id << "not found";
     return nullptr;
 }
 
 void DeviceManager::addOthersDeviceFromHwinfo(DeviceOthers *const device)
 {
+    qCDebug(appLog) << "Adding others device from hwinfo";
     // 从hwinfo中获取其他设备信息
     foreach (auto cur, m_ListDeviceOthers) {
         DeviceOthers *deviceOthers = dynamic_cast<DeviceOthers *>(cur);
@@ -1251,11 +1388,13 @@ void DeviceManager::addOthersDeviceFromHwinfo(DeviceOthers *const device)
         if (deviceOthers->busInfo() == device->busInfo() && deviceOthers->busInfo() != "")
             return;
     }
+    qCDebug(appLog) << "Adding others device from hwinfo";
     m_ListDeviceOthers.append(device);
 }
 
 void DeviceManager::setOthersDeviceInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting others device info from lshw";
     //从lshw中获取其他设备信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceOthers.begin();
     for (; it != m_ListDeviceOthers.end(); ++it) {
@@ -1269,6 +1408,7 @@ void DeviceManager::setOthersDeviceInfoFromLshw(const QMap<QString, QString> &ma
 
 void DeviceManager::setCpuRefreshInfoFromlscpu(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting CPU refresh info from lscpu";
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceCPU.begin();
     for (; it != m_ListDeviceCPU.end(); ++it) {
         DeviceCpu *device = dynamic_cast<DeviceCpu *>(*it);
@@ -1281,36 +1421,42 @@ void DeviceManager::setCpuRefreshInfoFromlscpu(const QMap<QString, QString> &map
 
 void DeviceManager::addPowerDevice(DevicePower *const device)
 {
+    // qCDebug(appLog) << "Adding power device";
     // 添加电池设备
     m_ListDevicePower.append(device);
 }
 
 void DeviceManager::addPrintDevice(DevicePrint *const device)
 {
+    // qCDebug(appLog) << "Adding print device";
     // 添加打印机信息
     m_ListDevicePrint.append(device);
 }
 
 void DeviceManager::addOtherPCIDevice(DeviceOtherPCI *const device)
 {
+    // qCDebug(appLog) << "Adding other PCI device";
     // 添加其他PCI设备
     m_ListDeviceOtherPCI.append(device);
 }
 
 void DeviceManager::addComputerDevice(DeviceComputer *const device)
 {
+    // qCDebug(appLog) << "Adding computer device";
     // 添加计算机设备
     m_ListDeviceComputer.append(device);
 }
 
 void DeviceManager::addCdromDevice(DeviceCdrom *const device)
 {
+    // qCDebug(appLog) << "Adding CDROM device";
     // 添加CDROM
     m_ListDeviceCdrom.append(device);
 }
 
 void DeviceManager::addLshwinfoIntoCdromDevice(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Adding CDROM info from lshw";
     // 从lshw中添加CDROM信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceCdrom.begin();
     for (; it != m_ListDeviceCdrom.end(); ++it) {
@@ -1324,17 +1470,20 @@ void DeviceManager::addLshwinfoIntoCdromDevice(const QMap<QString, QString> &map
 
 void DeviceManager::addBusId(const QStringList &busId)
 {
+    // qCDebug(appLog) << "Adding bus ID";
     // 添加设备总线信息
     m_BusIdList.append(busId);
 }
 
 const QStringList &DeviceManager::getBusId()
 {
+    // qCDebug(appLog) << "Getting bus ID";
     return m_BusIdList;
 }
 
 void DeviceManager::addCmdInfo(const QMap<QString, QList<QMap<QString, QString> > > &cmdInfo)
 {
+    // qCDebug(appLog) << "Adding command info";
     QMutexLocker locker(&addCmdMutex);
     // 添加命令信息
     foreach (const QString &key, cmdInfo.keys()) {
@@ -1347,12 +1496,14 @@ void DeviceManager::addCmdInfo(const QMap<QString, QList<QMap<QString, QString> 
 
 const QList<QMap<QString, QString>> &DeviceManager::cmdInfo(const QString &key)
 {
+    // qCDebug(appLog) << "Getting command info";
     QMutexLocker locker(&addCmdMutex);
     return m_cmdInfo[key];
 }
 
 bool DeviceManager::exportToTxt(const QString &filePath)
 {
+    qCDebug(appLog) << "Exporting to txt file";
     // 导出设备信息到txt文件
     QFile txtFile(filePath);
     if (false == txtFile.open(QIODevice::WriteOnly))
@@ -1384,6 +1535,7 @@ bool DeviceManager::exportToTxt(const QString &filePath)
 
 bool DeviceManager::exportToXlsx(const QString &filePath)
 {
+    qCDebug(appLog) << "Exporting to xlsx file";
     // 导出设备信息到xlsx表格
     QXlsx::Document xlsx;
     QXlsx::Format boldFont;
@@ -1413,6 +1565,7 @@ bool DeviceManager::exportToXlsx(const QString &filePath)
 
 bool DeviceManager::exportToDoc(const QString &filePath)
 {
+    qCDebug(appLog) << "Exporting to doc file";
     // 导出设备信息到doc文件
     Docx::Document doc(":/template.docx");
     overviewToDoc(doc);
@@ -1441,6 +1594,7 @@ bool DeviceManager::exportToDoc(const QString &filePath)
 
 bool DeviceManager::exportToHtml(const QString &filePath)
 {
+    qCDebug(appLog) << "Exporting to html file";
     // 导出设备信息到html文件
     QFile html(filePath);
     if (false == html.open(QIODevice::WriteOnly))
@@ -1480,11 +1634,13 @@ bool DeviceManager::exportToHtml(const QString &filePath)
 
 int DeviceManager::currentXlsRow()
 {
+    // qCDebug(appLog) << "Getting current XLS row";
     return m_CurrentXlsRow++;
 }
 
 void DeviceManager::overviewToTxt(QTextStream &out)
 {
+    qCDebug(appLog) << "Exporting overview to txt";
     // 概况信息导出到txt
     out << "[" << tr("Overview") << "]\n-------------------------------------------------";
     out << "\n";
@@ -1526,6 +1682,7 @@ void DeviceManager::overviewToTxt(QTextStream &out)
 
 void DeviceManager::overviewToHtml(QFile &html)
 {
+    qCDebug(appLog) << "Exporting overview to html";
     // 导出概况信息到html
     html.write((QString("<h2>") + "[" + tr("Overview") + "]" + "</h2>").toUtf8());
     QDomDocument doc;
@@ -1551,6 +1708,7 @@ void DeviceManager::overviewToHtml(QFile &html)
 
 void DeviceManager::overviewToDoc(Docx::Document &doc)
 {
+    qCDebug(appLog) << "Exporting overview to doc";
     // 导出概况信息到doc文件
     doc.addHeading("[" + tr("Overview") + "]");
     doc.addParagraph("-------------------------------------------------");
@@ -1578,6 +1736,7 @@ void DeviceManager::overviewToDoc(Docx::Document &doc)
 
 void DeviceManager::overviewToXlsx(QXlsx::Document &xlsx, QXlsx::Format &boldFont)
 {
+    qCDebug(appLog) << "Exporting overview to xlsx";
     // 导出概况信息到xlsx文件
     boldFont.setFontBold(true);
     xlsx.write(m_CurrentXlsRow++, 1, "[" + tr("Overview") + "]", boldFont);
@@ -1610,6 +1769,7 @@ void DeviceManager::overviewToXlsx(QXlsx::Document &xlsx, QXlsx::Format &boldFon
 
 void DeviceManager::infoToHtml(QDomDocument &doc, const QString &key, const QString &value)
 {
+    qCDebug(appLog) << "Exporting info to html";
     // 导出设备信息到html
     // 创建表格,设置表格属性
     QDomElement table = doc.createElement("table");
@@ -1648,6 +1808,7 @@ void DeviceManager::infoToHtml(QDomDocument &doc, const QString &key, const QStr
 
 const QMap<QString, QString>  &DeviceManager::getDeviceOverview()
 {
+    qCDebug(appLog) << "Getting device overview";
     // 获取所有设备的概况信息
     m_OveriewMap.clear();
 
@@ -1692,6 +1853,7 @@ const QMap<QString, QString>  &DeviceManager::getDeviceOverview()
 
 const QMap<QString, QMap<QString, QStringList> > &DeviceManager::getDeviceDriverPool()
 {
+    qCDebug(appLog) << "Getting device driver pool";
     // 获取所有设备驱动与设备名称设备类别的对应关系
     auto iter = m_DeviceClassMap.begin();
 
@@ -1714,17 +1876,20 @@ const QMap<QString, QMap<QString, QStringList> > &DeviceManager::getDeviceDriver
 
 void DeviceManager::addInputInfo(const QString &key, const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Adding input info";
     // 添加输入设备信息
     if (m_InputDeviceInfo.find(key) == m_InputDeviceInfo.end())
         m_InputDeviceInfo.insert(key, mapInfo);
 }
 const QMap<QString, QString> &DeviceManager::inputInfo(const QString &key)
 {
+    // qCDebug(appLog) << "Getting input info";
     return m_InputDeviceInfo[key];
 }
 
 bool DeviceManager::isDeviceExistInPairedDevice(const QString &mac)
 {
+    qCDebug(appLog) << "Checking if device exists in paired device";
     // 获取蓝牙设备配对信息
     const QList<QMap<QString, QString> >  &cmdInfo = DeviceManager::instance()->cmdInfo("bt_device");
 
@@ -1740,11 +1905,13 @@ bool DeviceManager::isDeviceExistInPairedDevice(const QString &mac)
 
 void DeviceManager::setCpuNum(int num)
 {
+    // qCDebug(appLog) << "Setting CPU number to:" << num;
     m_CpuNum = num;
 }
 
 void DeviceManager::setCpuFrequencyIsCur(const bool &flag)
 {
+    qCDebug(appLog) << "Setting CPU frequency is current";
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceCPU.begin();
     for (; it != m_ListDeviceCPU.end(); ++it) {
         DeviceCpu *device = dynamic_cast<DeviceCpu *>(*it);

--- a/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
@@ -58,10 +58,12 @@ void DeviceMemory::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "serial", m_SerialNumber);
 
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "Finished setting memory info from lshw";
 }
 
 TomlFixMethod DeviceMemory::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "Setting memory info from TOML one by one";
     TomlFixMethod ret = TOML_None;
         // 添加基本信息
     ret = setTomlAttribute(mapInfo, "Size", m_Size);
@@ -78,6 +80,7 @@ TomlFixMethod DeviceMemory::setInfoFromTomlOneByOne(const QMap<QString, QString>
     ret = setTomlAttribute(mapInfo, "Data Width", m_DataBandwidth);
 //3. 获取设备的其它信息
     getOtherMapInfo(mapInfo);
+    qCDebug(appLog) << "Finished setting memory info from TOML";
     return ret;
 }
 
@@ -85,8 +88,10 @@ bool DeviceMemory::setInfoFromDmidecode(const QMap<QString, QString> &mapInfo)
 {
     qCDebug(appLog) << "Setting memory info from dmidecode data";
     // 由 locator属性判断是否为同一内存条
-    if (mapInfo["Locator"] != m_Locator || m_MatchedFromDmi == true)
+    if (mapInfo["Locator"] != m_Locator || m_MatchedFromDmi == true) {
+        qCDebug(appLog) << "Memory locator does not match or already matched from DMI, skipping";
         return false;
+    }
 
     // 由dmidecode设置基本属性
     setAttribute(mapInfo, "Part Number", m_Name);
@@ -106,17 +111,21 @@ bool DeviceMemory::setInfoFromDmidecode(const QMap<QString, QString> &mapInfo)
 
     // 设置类型
     setAttribute(mapInfo, "Type", m_Type);
-    if (m_Type == "<OUT OF SPEC>")
+    if (m_Type == "<OUT OF SPEC>") {
+        qCDebug(appLog) << "Memory type is '<OUT OF SPEC>', clearing it";
         m_Type = "";
+    }
 
     // 获取其他属性
     getOtherMapInfo(mapInfo);
     m_MatchedFromDmi = true;
+    qCDebug(appLog) << "Successfully set memory info from dmidecode";
     return true;
 }
 
 void DeviceMemory::initFilterKey()
 {
+    qCDebug(appLog) << "Initializing filter keys for memory device";
     // 初始化可显示属性
     addFilterKey(QObject::tr("Array Handle"));  // 数组程序
     addFilterKey(QObject::tr("Error Information Handle")); //错误信息程序
@@ -138,10 +147,12 @@ void DeviceMemory::initFilterKey()
     addFilterKey(QObject::tr("Volatile Size"));       // 易丢失大小
     addFilterKey(QObject::tr("Cache Size"));   // 缓存大小
     addFilterKey(QObject::tr("Logical Size"));  // 逻辑大小
+    qCDebug(appLog) << "Filter keys initialized";
 }
 
 void DeviceMemory::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "Loading base device info for memory";
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name);
     addBaseDeviceInfo(tr("Vendor"), m_Vendor);
@@ -151,68 +162,82 @@ void DeviceMemory::loadBaseDeviceInfo()
     addBaseDeviceInfo(tr("Total Width"), m_TotalBandwidth);
     addBaseDeviceInfo(tr("Locator"), m_Locator);
     addBaseDeviceInfo(tr("Serial Number"), m_SerialNumber);
+    qCDebug(appLog) << "Base device info loaded";
 }
 
 void DeviceMemory::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "Loading other device info for memory";
     // 倒序，头插，保证原来的顺序
     // 添加其他信息,成员变量
     if (Common::boardVendorType().isEmpty()) {
+        qCDebug(appLog) << "Board vendor type is empty, loading full voltage info";
         addOtherDeviceInfo(tr("Configured Voltage"), m_ConfiguredVoltage);
         addOtherDeviceInfo(tr("Maximum Voltage"), m_MaximumVoltage);
         addOtherDeviceInfo(tr("Minimum Voltage"), m_MinimumVoltage);
         addOtherDeviceInfo(tr("Configured Speed"), m_ConfiguredSpeed);
     } else {
+        qCDebug(appLog) << "Board vendor type is not empty, loading configured speed only";
         addOtherDeviceInfo(tr("Configured Speed"), m_ConfiguredSpeed);
     }
     addOtherDeviceInfo(tr("Data Width"), m_DataBandwidth);
 
     // 将QMap<QString, QString>内容转存为QList<QPair<QString, QString>>
     mapInfoToList();
+    qCDebug(appLog) << "Other device info loaded";
 }
 
 void DeviceMemory::loadTableHeader()
 {
+    qCDebug(appLog) << "Loading table header for memory";
     // 加载表头
     m_TableHeader.append(tr("Name"));
     m_TableHeader.append(tr("Vendor"));
     m_TableHeader.append(tr("Type"));
     m_TableHeader.append(tr("Speed"));
     m_TableHeader.append(tr("Size"));
+    qCDebug(appLog) << "Table header loaded";
 }
 
 void DeviceMemory::loadTableData()
 {
+    qCDebug(appLog) << "Loading table data for memory";
     // 加载表格内容
     m_TableData.append(m_Name);
     m_TableData.append(m_Vendor);
     m_TableData.append(m_Type);
     m_TableData.append(m_Speed);
     m_TableData.append(m_Size);
+    qCDebug(appLog) << "Table data loaded";
 }
 
 const QString &DeviceMemory::name()const
 {
+    // qCDebug(appLog) << "Getting memory name:" << m_Name;
     return m_Name;
 }
 
 const QString &DeviceMemory::vendor() const
 {
+    // qCDebug(appLog) << "Getting memory vendor:" << m_Vendor;
     return m_Vendor;
 }
 
 const QString &DeviceMemory::driver() const
 {
+    // qCDebug(appLog) << "Getting memory driver:" << m_Driver;
     return m_Driver;
 }
 
 bool DeviceMemory::available()
 {
+    // qCDebug(appLog) << "Checking memory availability, returning true";
     return true;
 }
 
 QString DeviceMemory::subTitle()
 {
+    // qCDebug(appLog) << "Getting memory subtitle";
     // 获取子标题
     return m_Vendor + " " + m_Name;
 }
@@ -223,8 +248,10 @@ const QString DeviceMemory::getOverviewInfo()
     // 获取概况信息
     QString ov;
     QString nameStr = m_Name != "" ? m_Name : m_Vendor;
-    if (nameStr == "--")
+    if (nameStr == "--") {
+        qCDebug(appLog) << "Name string is '--', clearing it";
         nameStr.clear();
+    }
     ov += QString("%1(%2 %3 %4)") \
           .arg(m_Size) \
           .arg(nameStr) \

--- a/deepin-devicemanager/src/DeviceManager/DeviceOtherPCI.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceOtherPCI.cpp
@@ -4,6 +4,9 @@
 
 // 项目自身文件
 #include "DeviceOtherPCI.h"
+#include "DDLog.h"
+
+using namespace DDLog;
 
 DeviceOtherPCI::DeviceOtherPCI()
     : DeviceBaseInfo()
@@ -17,11 +20,12 @@ DeviceOtherPCI::DeviceOtherPCI()
     , m_Latency("")
     , m_InputOutput("")
 {
-
+    qCDebug(appLog) << "DeviceOtherPCI::DeviceOtherPCI()";
 }
 
 TomlFixMethod DeviceOtherPCI::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceOtherPCI::setInfoFromTomlOneByOne";
     TomlFixMethod ret = TOML_None;
    // 添加基本信息
     ret = setTomlAttribute(mapInfo, "Model", m_Model);
@@ -40,36 +44,42 @@ TomlFixMethod DeviceOtherPCI::setInfoFromTomlOneByOne(const QMap<QString, QStrin
 
 const QString &DeviceOtherPCI::name()const
 {
+    // qCDebug(appLog) << "DeviceOtherPCI::name";
     return m_Name;
 }
 
 const QString &DeviceOtherPCI::vendor() const
 {
+    // qCDebug(appLog) << "DeviceOtherPCI::vendor";
     return m_Vendor;
 }
 
 const QString &DeviceOtherPCI::driver()const
 {
+    // qCDebug(appLog) << "DeviceOtherPCI::driver";
     return m_Driver;
 }
 
 QString DeviceOtherPCI::subTitle()
 {
+    // qCDebug(appLog) << "DeviceOtherPCI::subTitle";
     return m_Model;
 }
 
 const QString DeviceOtherPCI::getOverviewInfo()
 {
+    // qCDebug(appLog) << "DeviceOtherPCI::getOverviewInfo";
     return m_Name.isEmpty() ? m_Model : m_Name;
 }
 
 void DeviceOtherPCI::initFilterKey()
 {
-
+    // qCDebug(appLog) << "DeviceOtherPCI::initFilterKey";
 }
 
 void DeviceOtherPCI::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceOtherPCI::loadBaseDeviceInfo";
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name.isEmpty() ? m_Vendor + m_Model : m_Name);
     addBaseDeviceInfo(tr("Vendor"), m_Vendor);
@@ -80,6 +90,7 @@ void DeviceOtherPCI::loadBaseDeviceInfo()
 
 void DeviceOtherPCI::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceOtherPCI::loadOtherDeviceInfo";
     // 添加其他信息,成员变量
     addOtherDeviceInfo(tr("Input/Output"), m_InputOutput);
     addOtherDeviceInfo(tr("Memory"), m_Memory);
@@ -96,6 +107,7 @@ void DeviceOtherPCI::loadOtherDeviceInfo()
 
 void DeviceOtherPCI::loadTableData()
 {
+    qCDebug(appLog) << "DeviceOtherPCI::loadTableData";
     // 加载表格数据
     m_TableData.append(m_Name);
     m_TableData.append(m_Vendor);

--- a/deepin-devicemanager/src/DeviceManager/DevicePower.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DevicePower.cpp
@@ -4,6 +4,7 @@
 
 // 项目自身文件
 #include "DevicePower.h"
+#include "DDLog.h"
 
 // Qt库文件
 #include<QFileInfo>
@@ -12,6 +13,7 @@
 #include <DApplication>
 
 DWIDGET_USE_NAMESPACE
+using namespace DDLog;
 
 DevicePower::DevicePower()
     : DeviceBaseInfo()
@@ -35,12 +37,14 @@ DevicePower::DevicePower()
     , m_Temp("")
 
 {
+    qCDebug(appLog) << "DevicePower::DevicePower()";
     // 初始化可显示属性
     initFilterKey();
 }
 
 TomlFixMethod DevicePower::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DevicePower::setInfoFromTomlOneByOne";
     TomlFixMethod ret = TOML_None;
     // 添加基本信息    
     ret = setTomlAttribute(mapInfo, "Model", m_Model);    
@@ -64,8 +68,10 @@ TomlFixMethod DevicePower::setInfoFromTomlOneByOne(const QMap<QString, QString> 
 
 bool DevicePower::setInfoFromUpower(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DevicePower::setInfoFromUpower";
     // 设置upower中获取的信息
     if (mapInfo["Device"].contains("line_power", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "DevicePower::setInfoFromUpower, device contains line_power";
         return false;
     }
     // m_Name = QObject::tr("battery");  
@@ -107,6 +113,7 @@ bool DevicePower::setInfoFromUpower(const QMap<QString, QString> &mapInfo)
 
 void DevicePower::setDaemonInfo(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DevicePower::setDaemonInfo";
     // 设置守护进程信息
     if (m_Name == QObject::tr("battery"))
         getOtherMapInfo(mapInfo);
@@ -114,37 +121,44 @@ void DevicePower::setDaemonInfo(const QMap<QString, QString> &mapInfo)
 
 const QString &DevicePower::name()const
 {
+    // qCDebug(appLog) << "DevicePower::name";
     return m_Name;
 }
 
 const QString &DevicePower::vendor() const
 {
+    // qCDebug(appLog) << "DevicePower::vendor";
     return m_Vendor;
 }
 
 const QString &DevicePower::driver() const
 {
+    // qCDebug(appLog) << "DevicePower::driver";
     return m_Driver;
 }
 
 bool DevicePower::available()
 {
+    // qCDebug(appLog) << "DevicePower::available";
     return true;
 }
 
 QString DevicePower::subTitle()
 {
+    // qCDebug(appLog) << "DevicePower::subTitle";
     return m_Name;
 }
 
 const QString DevicePower::getOverviewInfo()
 {
+    // qCDebug(appLog) << "DevicePower::getOverviewInfo";
     // 获取概况信息
     return DApplication::translate("ManulTrack", m_Name.trimmed().toStdString().data(), "");
 }
 
 void DevicePower::initFilterKey()
 {
+    qCDebug(appLog) << "DevicePower::initFilterKey";
     // 初始化可显示属性
     addFilterKey(QObject::tr("native-path"));
     addFilterKey(QObject::tr("power supply"));
@@ -174,6 +188,7 @@ void DevicePower::initFilterKey()
 
 void DevicePower::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "DevicePower::loadBaseDeviceInfo";
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name);
     addBaseDeviceInfo(tr("Model"), m_Model);
@@ -195,12 +210,14 @@ void DevicePower::loadBaseDeviceInfo()
 
 void DevicePower::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "DevicePower::loadOtherDeviceInfo";
     // 将QMap<QString, QString>内容转存为QList<QPair<QString, QString>>
     mapInfoToList();
 }
 
 void DevicePower::loadTableData()
 {
+    qCDebug(appLog) << "DevicePower::loadTableData";
     // 加载表格信息
     m_TableData.append(m_Name);
     m_TableData.append(m_Vendor);

--- a/deepin-devicemanager/src/DeviceManager/DevicePrint.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DevicePrint.cpp
@@ -5,9 +5,12 @@
 // 项目自身文件
 #include "DevicePrint.h"
 #include "DBusEnableInterface.h"
+#include "DDLog.h"
 
 // Qt库文件
 #include <QLoggingCategory>
+
+using namespace DDLog;
 
 DevicePrint::DevicePrint()
     : DeviceBaseInfo()
@@ -19,6 +22,7 @@ DevicePrint::DevicePrint()
     , m_Shared("")
     , m_MakeAndModel("")
 {
+    qCDebug(appLog) << "DevicePrint::DevicePrint()";
     // 初始化可显示属性
     initFilterKey();
 
@@ -29,6 +33,7 @@ DevicePrint::DevicePrint()
 
 TomlFixMethod DevicePrint::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DevicePrint::setInfoFromTomlOneByOne";
     TomlFixMethod ret = TOML_None;
     // 添加基本信息
     ret = setTomlAttribute(mapInfo, "Model", m_Model);
@@ -46,11 +51,13 @@ TomlFixMethod DevicePrint::setInfoFromTomlOneByOne(const QMap<QString, QString> 
 
 void DevicePrint::setInfo(const QMap<QString, QString> &info)
 {
+    qCDebug(appLog) << "DevicePrint::setInfo";
     // 获取打印机类型和型号
     QString vt;
     setAttribute(info, "printer-info", vt);
     QStringList lstInfo = vt.split(" ");
     if (lstInfo.size() > 1) {
+        qCDebug(appLog) << "DevicePrint::setInfo, lstInfo size > 1";
         m_Vendor = lstInfo[0];
         m_Model = vt.replace(m_Vendor, "").trimmed();
     }
@@ -65,52 +72,63 @@ void DevicePrint::setInfo(const QMap<QString, QString> &info)
 
     // 获取打印机接口
     QStringList lstUri = m_URI.split(":");
-    if (lstUri.size() > 1)
+    if (lstUri.size() > 1) {
+        qCDebug(appLog) << "DevicePrint::setInfo, lstUri size > 1";
         m_InterfaceType = lstUri[0];
+    }
 
     getOtherMapInfo(info);
 }
 
 const QString &DevicePrint::name()const
 {
+    // qCDebug(appLog) << "DevicePrint::name";
     return m_Name;
 }
 
 const QString &DevicePrint::vendor() const
 {
+    // qCDebug(appLog) << "DevicePrint::vendor";
     return m_Vendor;
 }
 
 const QString DevicePrint::makeAndeModel() const
 {
+    // qCDebug(appLog) << "DevicePrint::makeAndeModel";
     return m_MakeAndModel;
 }
 
 const QString &DevicePrint::driver() const
 {
+    // qCDebug(appLog) << "DevicePrint::driver";
     return m_Driver;
 }
 
 bool DevicePrint::available()
 {
+    // qCDebug(appLog) << "DevicePrint::available";
     return true;
 }
 
 QString DevicePrint::subTitle()
 {
+    // qCDebug(appLog) << "DevicePrint::subTitle";
     return m_Name;
 }
 
 const QString DevicePrint::getOverviewInfo()
 {
+    // qCDebug(appLog) << "DevicePrint::getOverviewInfo";
     // 获取概况信息
     return m_Name.isEmpty() ? m_Model : m_Name;
 }
 
 EnableDeviceStatus DevicePrint::setEnable(bool e)
 {
+    qCDebug(appLog) << "DevicePrint::setEnable, enable:" << e;
     bool res  = DBusEnableInterface::getInstance()->enablePrinter("printer", m_Name, m_URI, e);
     if (res) {
+        qCDebug(appLog) << "DevicePrint::setEnable, enable success";
         m_Enable = e;
     }
     // 设置设备状态
@@ -119,11 +137,13 @@ EnableDeviceStatus DevicePrint::setEnable(bool e)
 
 bool DevicePrint::enable()
 {
+    qCDebug(appLog) << "DevicePrint::enable";
     return m_Status == "5" ? false : true;
 }
 
 void DevicePrint::initFilterKey()
 {
+    qCDebug(appLog) << "DevicePrint::initFilterKey";
     // 初始化可显示属性
     addFilterKey(QObject::tr("copies"));
     addFilterKey(QObject::tr("job-cancel-after"));
@@ -146,6 +166,7 @@ void DevicePrint::initFilterKey()
 
 void DevicePrint::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "DevicePrint::loadBaseDeviceInfo";
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name);
     addBaseDeviceInfo(tr("Model"), m_Model);
@@ -155,6 +176,7 @@ void DevicePrint::loadBaseDeviceInfo()
 
 void DevicePrint::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "DevicePrint::loadOtherDeviceInfo";
     // 添加其他信息,成员变量
     addOtherDeviceInfo(tr("Shared"), m_Shared);
     addOtherDeviceInfo(tr("URI"), m_URI);
@@ -167,9 +189,11 @@ void DevicePrint::loadOtherDeviceInfo()
 
 void DevicePrint::loadTableData()
 {
+    qCDebug(appLog) << "DevicePrint::loadTableData";
     // 加载表格数据
     QString tName = m_Name;
     if (!enable()) {
+        qCDebug(appLog) << "DevicePrint::loadTableData, not enable";
         tName = "(" + tr("Disable") + ") " + m_Name;
     }
 

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -39,6 +39,7 @@ DeviceStorage::DeviceStorage()
 
 TomlFixMethod DeviceStorage::setInfoFromTomlOneByOne(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceStorage::setInfoFromTomlOneByOne";
     TomlFixMethod ret = TOML_None;
     // 添加基本信息
     ret = setTomlAttribute(mapInfo, "Media Type", m_MediaType);
@@ -57,6 +58,7 @@ TomlFixMethod DeviceStorage::setInfoFromTomlOneByOne(const QMap<QString, QString
 
 static QString decimalkilos(quint64 value)
 {
+    qCDebug(appLog) << "decimalkilos";
     const QString prefixes("KMGTPEZY");
     int i = 0;
     quint64 curValue = value;
@@ -69,6 +71,7 @@ static QString decimalkilos(quint64 value)
     }
 
     if (i < 4) {
+        qCDebug(appLog) << "decimalkilos, i < 4";
         quint64 diffValue = value - curValue * 1000;
         double calValue = diffValue / 1000.0 + 0.1;
         curValue += static_cast<quint64>(calValue);
@@ -76,6 +79,7 @@ static QString decimalkilos(quint64 value)
         if (i > 0)
             valueStr += prefixes[i - 1];
     } else if (i <= prefixes.size()) { // 单位T以上处理
+        qCDebug(appLog) << "decimalkilos, i <= prefixes.size()";
         if (value % 1000 >= 1)
             valueStr = QString::number(value) + " " + prefixes[i - 2]; //保留小数部分 如1920GB 10001GB
         else
@@ -87,6 +91,7 @@ static QString decimalkilos(quint64 value)
 
 static quint64 convertToBytes(const QString& size, double scale)
 {
+    qCDebug(appLog) << "convertToBytes";
     /*convert "KB MB GB TB PB EB ZB YB " to bytes */
     const QString prefixes("KMGTPEZY");
     quint64 diskBytesSize = 0;
@@ -95,24 +100,32 @@ static quint64 convertToBytes(const QString& size, double scale)
 
     QRegularExpression reg("([0-9]*\\.?[0-9]*)([A-Za-z]*)");
     QRegularExpressionMatch match = reg.match(size);
-    if(!match.hasMatch())
+    if(!match.hasMatch()) {
+        qCDebug(appLog) << "convertToBytes, no match";
         return diskBytesSize;
+    }
     QString sizeValue1 = match.captured(1);
-    if(sizeValue1.isEmpty())
+    if(sizeValue1.isEmpty()) {
+        qCDebug(appLog) << "convertToBytes, sizeValue1 is empty";
         return diskBytesSize;
+    }
     QString diskUnits = size.right(size.length() - sizeValue1.size()).trimmed().toUpper();
-    if(diskUnits.isEmpty())
+    if(diskUnits.isEmpty()) {
+        qCDebug(appLog) << "convertToBytes, diskUnits is empty";
         return diskBytesSize;
+    }
     diskUnits.replace("B","").replace("I","");
     QChar lastChar = diskUnits.at(diskUnits.length() - 1);
 
     if (prefixes.contains(diskUnits)) {
+        qCDebug(appLog) << "convertToBytes, prefixes contains diskUnits";
         diskSizeFloat = sizeValue1.toDouble();
 
         int i = 0;
         while (i < prefixes.size()) {
             QChar iChar = prefixes.at(i++);
             if(iChar == lastChar) {
+                qCDebug(appLog) << "convertToBytes, iChar == lastChar";
                 multiplier = std::pow(scale,i);
                 break;
             }
@@ -124,11 +137,13 @@ static quint64 convertToBytes(const QString& size, double scale)
 
 void DeviceStorage::unitConvertByDecimal()
 {
+    qCDebug(appLog) << "DeviceStorage::unitConvertByDecimal";
     if(m_SizeBytes > 0)
         m_Size = decimalkilos(m_SizeBytes);
 
     quint64 gbyte =  1000000000;
     if (m_Interface.contains("UFS", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "DeviceStorage::unitConvertByDecimal, interface contains UFS";
         if(m_SizeBytes > 255*gbyte && m_SizeBytes < 257*gbyte) {
             m_Size = "256 GB";
         } else if(m_SizeBytes > 511*gbyte && m_SizeBytes < 513*gbyte) {
@@ -153,22 +168,29 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Vendor", m_Vendor);
 
     // 希捷硬盘为ATA硬盘，无法直接获取厂商信息,只能特殊处理
-    if (m_Name.startsWith("ST") && m_Vendor.isEmpty())
+    if (m_Name.startsWith("ST") && m_Vendor.isEmpty()) {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, vendor is Seagate";
         m_Vendor = "ST";
+    }
     //根据产品PN中的固定前两位 RS来匹配厂商 为Longsys 如产品PN ：RSYE3836N-480G    RSYE3836N-960G    RSYE3836N-1920     RSYE3836N-3840
-    if (m_Name.startsWith("RS") && m_Vendor.isEmpty())
+    if (m_Name.startsWith("RS") && m_Vendor.isEmpty()) {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, vendor is Longsys";
         m_Vendor = "Longsys";
+    }
 
     setAttribute(mapInfo, "Driver", m_Driver); // 驱动
     QRegularExpression exp("pci 0x[0-9a-zA-Z]*");
     QRegularExpressionMatch match = exp.match(m_Vendor);
-    if (match.hasMatch())
+    if (match.hasMatch()) {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, vendor is pci";
         m_Vendor = "";
+    }
 
     setAttribute(mapInfo, "Attached to", m_Interface);
     QRegularExpression re(".*\\((.*)\\).*");
     match = re.match(m_Interface);
     if (match.hasMatch()) {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, interface has match";
         m_Interface = match.captured(1);
         m_Interface.replace("Controller", "");
         m_Interface.replace("controller", "");
@@ -182,16 +204,20 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     QRegularExpression reSize(".*\\((.*)bytes\\).*");
     match = reSize.match(m_Size);
     if (match.hasMatch()) {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, size has match";
         bool ok = false;
         quint64 bytesSize = match.captured(1).trimmed().toULongLong(&ok);
         if (ok) {
+            qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, size convert to ullong success";
             m_Size = decimalkilos(bytesSize);
             m_SizeBytes = bytesSize;
         } else {
+            qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, size convert to ullong failed";
             m_Size.replace(QRegularExpression("\\(.*\\)"), "").replace(" ", "");
             m_SizeBytes = convertToBytes(m_Size,DISK_SCALE_1024);
         }
     } else {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, size has no match";
         m_Size.replace(QRegularExpression("\\(.*\\)"), "").replace(" ", "");
         m_SizeBytes = convertToBytes(m_Size,DISK_SCALE_1024);
     }
@@ -207,10 +233,13 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     QString strLink = mapInfo["SysFS Device Link"];
     m_SerialNumber = getSerialID(strLink);
     if (m_SerialNumber.isEmpty()) {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, serial number is empty";
         setAttribute(mapInfo, "Serial ID", m_SerialNumber);
     }
-    if (m_SerialNumber.compare("0",Qt::CaseInsensitive) == 0)
+    if (m_SerialNumber.compare("0",Qt::CaseInsensitive) == 0) {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, serial number is 0";
         m_SerialNumber = "";
+    }
 
     setAttribute(mapInfo, "SysFS BusID", m_KeyToLshw);
     setAttribute(mapInfo, "Device File", m_DeviceFile);
@@ -222,6 +251,7 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     QStringList blockfs = blockDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::Readable);
     foreach (QString fsname, blockfs) {
         if (m_DeviceFile.contains(fsname, Qt::CaseInsensitive)) {
+            qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, device file contains fsname";
             logicalName = fsname;
             break;
         }
@@ -230,6 +260,7 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     QString Path = "/sys/block/" + logicalName + "/device/spec_version";
     QFile file(Path);
     if (file.open(QIODevice::ReadOnly)) {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, open spec_version success";
         QString output2 = file.readAll();
         if (output2.contains("310", Qt::CaseInsensitive)) {
             m_Interface = "UFS 3.1";
@@ -239,8 +270,10 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
         file.close();
     }
 
-    if (m_KeyToLshw.contains("nvme", Qt::CaseInsensitive))
+    if (m_KeyToLshw.contains("nvme", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "DeviceStorage::setHwinfoInfo, key contains nvme";
         setAttribute(mapInfo, "SysFS Device Link", m_NvmeKey);
+    }
 
     setAttribute(mapInfo, "Module Alias", m_Modalias);
     setAttribute(mapInfo, "VID_PID", m_VID_PID);
@@ -252,9 +285,11 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
 
 QString DeviceStorage::getSerialID(QString &strDeviceLink)
 {
+    qCDebug(appLog) << "DeviceStorage::getSerialID";
     //取SerialID优先级：1.取cid 2.取unique_number 3.取hwinfo中的SerialID
     QString strSerialNumber = "";
     if (!strDeviceLink.isEmpty() && strDeviceLink.contains("platform/")) {
+        qCDebug(appLog) << "DeviceStorage::getSerialID, device link contains platform";
         // /devices/platform/f8300000.ufs/host0/target0:0:0/0:0:0:3
         // /proc/bootdevice/name:f8300000.ufs
         QRegularExpression reg(".*platform/([^/]+)/.*");
@@ -268,16 +303,20 @@ QString DeviceStorage::getSerialID(QString &strDeviceLink)
 #endif
         }
         if (!strName.isEmpty()) { //取到设备名称再去读文件，因为读文件开销大。
+            qCDebug(appLog) << "DeviceStorage::getSerialID, strName is not empty";
             QString Path = "/proc/bootdevice/name";
             QFile file(Path);
             if (file.open(QIODevice::ReadOnly)) {
+                qCDebug(appLog) << "DeviceStorage::getSerialID, open /proc/bootdevice/name success";
                 strBootdeviceName = file.readAll();
                 file.close();
             }
             if (strName == strBootdeviceName) {
+                qCDebug(appLog) << "DeviceStorage::getSerialID, strName == strBootdeviceName";
                 Path = "/proc/bootdevice/cid";
                 QFile filecid(Path);
                 if (filecid.open(QIODevice::ReadOnly)) {
+                    qCDebug(appLog) << "DeviceStorage::getSerialID, open /proc/bootdevice/cid success";
                     strSerialNumber = filecid.readAll().trimmed();
                     filecid.close();
                 }
@@ -286,9 +325,11 @@ QString DeviceStorage::getSerialID(QString &strDeviceLink)
     }
 
     if (strSerialNumber.isEmpty()) {
+        qCDebug(appLog) << "DeviceStorage::getSerialID, serial number is empty";
         QString Path = "/sys" + strDeviceLink + "/unique_number";
         QFile file(Path);
         if (file.open(QIODevice::ReadOnly)) {
+            qCDebug(appLog) << "DeviceStorage::getSerialID, open unique_number success";
             QString value = file.readAll();
             strSerialNumber = value;
             file.close();
@@ -299,6 +340,7 @@ QString DeviceStorage::getSerialID(QString &strDeviceLink)
 
 bool DeviceStorage::setKLUHwinfoInfo(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceStorage::setKLUHwinfoInfo";
     // 龙芯机器中 hwinfo --disk会列出所有的分区信息
     // 存储设备不应包含分区，根据SysFS BusID 来确定是否是分区信息
     if (mapInfo.find("SysFS BusID") == mapInfo.end())
@@ -312,6 +354,7 @@ bool DeviceStorage::setKLUHwinfoInfo(const QMap<QString, QString> &mapInfo)
     QRegularExpression re(".*\\((.*)\\).*");
     QRegularExpressionMatch match = re.match(m_Interface);
     if (match.hasMatch()) {
+        qCDebug(appLog) << "DeviceStorage::setKLUHwinfoInfo, interface has match";
         m_Interface = match.captured(1);
         m_Interface.replace("Controller", "");
         m_Interface.replace("controller", "");
@@ -325,14 +368,18 @@ bool DeviceStorage::setKLUHwinfoInfo(const QMap<QString, QString> &mapInfo)
     QRegularExpression reSize(".*\\((.*)bytes\\).*");
     match = reSize.match(m_Size);
     if (match.hasMatch()) {
+        qCDebug(appLog) << "DeviceStorage::setKLUHwinfoInfo, size has match";
         bool ok = false;
         quint64 bytesSize = match.captured(1).trimmed().toULongLong(&ok);
         if (ok) {
+            qCDebug(appLog) << "DeviceStorage::setKLUHwinfoInfo, size convert to ullong success";
             m_Size = decimalkilos(bytesSize);
         } else {
+            qCDebug(appLog) << "DeviceStorage::setKLUHwinfoInfo, size convert to ullong failed";
             m_Size.replace(QRegularExpression("\\(.*\\)"), "").replace(" ", "");
         }
     } else {
+        qCDebug(appLog) << "DeviceStorage::setKLUHwinfoInfo, size has no match";
         m_Size.replace(QRegularExpression("\\(.*\\)"), "").replace(" ", "");
     }
     if (m_Size.startsWith("0") || m_Size == "")
@@ -344,8 +391,10 @@ bool DeviceStorage::setKLUHwinfoInfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Device File", m_DeviceFile);
 
     // KLU里面的介质类型的处理方式比较特殊
-    if (mapInfo["Driver"].contains("usb-storage"))
+    if (mapInfo["Driver"].contains("usb-storage")) {
+        qCDebug(appLog) << "DeviceStorage::setKLUHwinfoInfo, driver contains usb-storage";
         m_MediaType = "USB";
+    }
 
     getOtherMapInfo(mapInfo);
     return true;
@@ -372,6 +421,7 @@ bool DeviceStorage::addInfoFromlshw(const QMap<QString, QString> &mapInfo)
     // 获取唯一key
     QStringList words = mapInfo["bus info"].split(":");
     if (words.size() == 2) {
+        qCDebug(appLog) << "DeviceStorage::addInfoFromlshw, words size is 2";
         m_KeyFromStorage = words[0];
         m_KeyFromStorage.replace("@", "");
     }
@@ -390,6 +440,7 @@ bool DeviceStorage::addInfoFromlshw(const QMap<QString, QString> &mapInfo)
 
 bool DeviceStorage::addNVMEInfoFromlshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceStorage::addNVMEInfoFromlshw";
     QStringList keys = mapInfo["bus info"].split("@");
     if (keys.size() != 2)
         return false;
@@ -400,8 +451,10 @@ bool DeviceStorage::addNVMEInfoFromlshw(const QMap<QString, QString> &mapInfo)
     //bus info: pci@0000:0d:00.0
     // 确认为同一设备
     if (m_NvmeKey.contains(key, Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "DeviceStorage::addNVMEInfoFromlshw, key contains nvme";
         setAttribute(mapInfo, "vendor", m_Vendor);
     } else {
+        qCDebug(appLog) << "DeviceStorage::addNVMEInfoFromlshw, key not contains nvme";
         return false;
     }
 
@@ -410,6 +463,7 @@ bool DeviceStorage::addNVMEInfoFromlshw(const QMap<QString, QString> &mapInfo)
 
 bool DeviceStorage::addInfoFromSmartctl(const QString &name, const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceStorage::addInfoFromSmartctl";
     // 查看传入的设备信息与当前的设备信息是不是同一个设备信息
     if (!m_DeviceFile.contains(name, Qt::CaseInsensitive))
         return false;
@@ -421,39 +475,56 @@ bool DeviceStorage::addInfoFromSmartctl(const QString &name, const QMap<QString,
 
 bool DeviceStorage::setMediaType(const QString &name, const QString &value)
 {
-    if (!m_DeviceFile.contains(name))
+    qCDebug(appLog) << "DeviceStorage::setMediaType";
+    if (!m_DeviceFile.contains(name)) {
+        qCDebug(appLog) << "DeviceStorage::setMediaType, device file does not contain name";
         return false;
+    }
 
-    if (QString("0") == value)
+    if (QString("0") == value) {
+        qCDebug(appLog) << "DeviceStorage::setMediaType, media type is SSD";
         m_MediaType = QObject::tr("SSD");
-    else if (QString("1") == value)
+    } else if (QString("1") == value) {
+        qCDebug(appLog) << "DeviceStorage::setMediaType, media type is HDD";
         m_MediaType = QObject::tr("HDD");
-    else
+    } else {
+        qCDebug(appLog) << "DeviceStorage::setMediaType, media type is Unknown";
         m_MediaType = QObject::tr("Unknown");
+    }
 
     return true;
 }
 
 bool DeviceStorage::setKLUMediaType(const QString &name, const QString &value)
 {
-    if (!m_DeviceFile.contains(name))
+    qCDebug(appLog) << "DeviceStorage::setKLUMediaType";
+    if (!m_DeviceFile.contains(name)) {
+        qCDebug(appLog) << "DeviceStorage::setKLUMediaType, device file does not contain name";
         return false;
+    }
 
-    if (m_MediaType == "USB")
+    if (m_MediaType == "USB") {
+        qCDebug(appLog) << "DeviceStorage::setKLUMediaType, media type is USB";
         return true;
+    }
 
-    if (QString("0") == value)
+    if (QString("0") == value) {
+        qCDebug(appLog) << "DeviceStorage::setKLUMediaType, media type is SSD";
         m_MediaType = QObject::tr("SSD");
-    else if (QString("1") == value)
+    } else if (QString("1") == value) {
+        qCDebug(appLog) << "DeviceStorage::setKLUMediaType, media type is HDD";
         m_MediaType = QObject::tr("HDD");
-    else
+    } else {
+        qCDebug(appLog) << "DeviceStorage::setKLUMediaType, media type is Unknown";
         m_MediaType = QObject::tr("Unknown");
+    }
 
     return true;
 }
 
 bool DeviceStorage::isValid()
 {
+    qCDebug(appLog) << "DeviceStorage::isValid";
     // 若是m_Size为空则 该设备无效
     if (m_Size.isEmpty() && m_SizeBytes == 0) {
         qCDebug(appLog) << "Storage device invalid - empty size";
@@ -465,6 +536,7 @@ bool DeviceStorage::isValid()
 
 void DeviceStorage::setDiskSerialID(const QString &deviceFiles)
 {
+    qCDebug(appLog) << "DeviceStorage::setDiskSerialID";
     // Serial ID 与 device Files 中信息一致
     if (!m_SerialNumber.isEmpty() && deviceFiles.contains(m_SerialNumber))
         return;
@@ -477,6 +549,7 @@ void DeviceStorage::setDiskSerialID(const QString &deviceFiles)
     foreach (auto item, itemList) {
         if (item.contains("by-id", Qt::CaseInsensitive) &&
                 item.contains(modelName, Qt::CaseInsensitive)) {
+            qCDebug(appLog) << "DeviceStorage::setDiskSerialID, item contains by-id and modelName";
 
             int index;
             index = item.lastIndexOf("_");
@@ -490,7 +563,9 @@ void DeviceStorage::setDiskSerialID(const QString &deviceFiles)
 
 QString DeviceStorage::getDiskSerialID()
 {
+    qCDebug(appLog) << "DeviceStorage::getDiskSerialID";
     if (m_Interface.contains("USB", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "DeviceStorage::getDiskSerialID, interface contains USB";
         return m_SerialNumber + m_KeyToLshw;
     }
     return m_SerialNumber;
@@ -498,6 +573,7 @@ QString DeviceStorage::getDiskSerialID()
 
 void DeviceStorage::appendDisk(DeviceStorage *device)
 {
+    qCDebug(appLog) << "DeviceStorage::appendDisk";
     QList<QPair<QString, QString> > allAttribs = device->getBaseAttribs();
     QMap<QString, QString> allAttribMaps;
     for (int i = 0; i < allAttribs.size(); ++i) {
@@ -505,9 +581,11 @@ void DeviceStorage::appendDisk(DeviceStorage *device)
     }
 
     quint64 size2 = device->getDiskSizeByte();
-    if(m_SizeBytes == 0)
+    if(m_SizeBytes == 0) {
+        qCDebug(appLog) << "DeviceStorage::appendDisk, m_SizeBytes is 0";
         m_SizeBytes = size2;
-    else if (size2 > 0) {
+    } else if (size2 > 0) {
+        qCDebug(appLog) << "DeviceStorage::appendDisk, size2 > 0";
         m_SizeBytes += size2;
 
         QList<QPair<QString, QString> > allOtherAttribs = device->getOtherAttribs();
@@ -533,6 +611,7 @@ void DeviceStorage::appendDisk(DeviceStorage *device)
             QString curBusInfo = curAllOtherAttribMaps[keyStr];
             QString busInfo = allAttribMaps[keyStr];
             if (!curBusInfo.isEmpty() && !busInfo.isEmpty() && curBusInfo != busInfo) {
+                // qCDebug(appLog) << "DeviceStorage::appendDisk, bus info not empty and not equal";
                 setOtherDeviceInfo(keyStr, curBusInfo + "," + busInfo);
             }
         }
@@ -542,11 +621,13 @@ void DeviceStorage::appendDisk(DeviceStorage *device)
 
 void DeviceStorage::checkDiskSize()
 {
+    qCDebug(appLog) << "DeviceStorage::checkDiskSize";
     QRegularExpression reg("[0-9]*.?[0-9]*");
     int index = reg.match(m_Size).capturedStart();
     // index>0时，对于"32GB"（数字开头的字符串,index=0）无法获取正确的数据32
     // 所以要改为index >= 0
     if (index >= 0) {
+        qCDebug(appLog) << "DeviceStorage::checkDiskSize, index >= 0";
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         double num = reg.cap(0).toDouble(); // Qt 5 使用 cap
 #else
@@ -555,6 +636,7 @@ void DeviceStorage::checkDiskSize()
         double num1 = num - int(num);
         QString type = m_Size.right(m_Size.length() - reg.match(m_Size).captured(0).size()).trimmed();
         if (!qFuzzyCompare(num1, 0.0) && type == "GB") {
+            qCDebug(appLog) << "DeviceStorage::checkDiskSize, num1 is not 0 and type is GB";
             m_Size = QString::number(int(num) + 1) + " " + type;
         }
     }
@@ -562,6 +644,7 @@ void DeviceStorage::checkDiskSize()
 
 QString DeviceStorage::compareSize(const QString &size1, const QString &size2)
 {
+    qCDebug(appLog) << "DeviceStorage::compareSize";
     // 比较smartctl中可能提供的两个大小，取大值作为存储设备的大小
     if (size1.isEmpty() || size2.isEmpty())
         return size1 + size2;
@@ -584,44 +667,54 @@ QString DeviceStorage::compareSize(const QString &size1, const QString &size2)
 #endif
 
     // 返回较大值
-    if (num1 > num2)
+    if (num1 > num2) {
+        qCDebug(appLog) << "DeviceStorage::compareSize, num1 > num2";
         return size1;
-    else
+    } else {
+        qCDebug(appLog) << "DeviceStorage::compareSize, num1 <= num2";
         return size2;
+    }
 }
 
 const QString &DeviceStorage::name() const
 {
+    // qCDebug(appLog) << "DeviceStorage::name";
     return m_Name;
 }
 
 const QString &DeviceStorage::vendor() const
 {
+    // qCDebug(appLog) << "DeviceStorage::vendor";
     return m_Vendor;
 }
 
 const QString &DeviceStorage::driver() const
 {
+    // qCDebug(appLog) << "DeviceStorage::driver";
     return m_Driver;
 }
 
 const QString &DeviceStorage::keyFromStorage()const
 {
+    // qCDebug(appLog) << "DeviceStorage::keyFromStorage";
     return m_KeyFromStorage;
 }
 
 QString DeviceStorage::subTitle()
 {
+    // qCDebug(appLog) << "DeviceStorage::subTitle";
     return m_Name;
 }
 
 const QString DeviceStorage::getOverviewInfo()
 {
+    // qCDebug(appLog) << "DeviceStorage::getOverviewInfo";
     return QString("%1 (%2)").arg(m_Name).arg(m_Size);;
 }
 
 void DeviceStorage::initFilterKey()
 {
+    qCDebug(appLog) << "DeviceStorage::initFilterKey";
     // hwinfo --disk
     addFilterKey(QObject::tr("Hardware Class"));
     addFilterKey(QObject::tr("Device File"));
@@ -640,6 +733,7 @@ void DeviceStorage::initFilterKey()
 
 void DeviceStorage::loadBaseDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceStorage::loadBaseDeviceInfo";
     // 添加基本信息
     addBaseDeviceInfo(tr("Name"), m_Name);
     addBaseDeviceInfo(tr("Vendor"), m_Vendor);
@@ -651,6 +745,7 @@ void DeviceStorage::loadBaseDeviceInfo()
 
 void DeviceStorage::loadOtherDeviceInfo()
 {
+    qCDebug(appLog) << "DeviceStorage::loadOtherDeviceInfo";
     // 添加其他信息,成员变量
     addOtherDeviceInfo(tr("Firmware Version"), m_FirmwareVersion);
     addOtherDeviceInfo(tr("Speed"), m_Speed);
@@ -673,6 +768,7 @@ void DeviceStorage::loadOtherDeviceInfo()
     addOtherDeviceInfo(tr("Physical ID"), m_PhysID);
 
     if (m_RotationRate == QString("Solid State Device")) {
+        qCDebug(appLog) << "DeviceStorage::loadOtherDeviceInfo, rotation rate is Solid State Device";
         m_MediaType = QObject::tr("SSD");
     }
 
@@ -682,6 +778,7 @@ void DeviceStorage::loadOtherDeviceInfo()
 
 void DeviceStorage::loadTableHeader()
 {
+    qCDebug(appLog) << "DeviceStorage::loadTableHeader";
     // 加载表头信息
     m_TableHeader.append(tr("Name"));
     m_TableHeader.append(tr("Vendor"));
@@ -691,9 +788,11 @@ void DeviceStorage::loadTableHeader()
 
 void DeviceStorage::loadTableData()
 {
+    qCDebug(appLog) << "DeviceStorage::loadTableData";
     // 加载表格数据
     QString model = m_Name;
     if (!available()) {
+        qCDebug(appLog) << "DeviceStorage::loadTableData, not available";
         model = "(" + tr("Unavailable") + ") " + m_Name;
     }
     m_TableData.append(model);
@@ -704,6 +803,7 @@ void DeviceStorage::loadTableData()
 
 void DeviceStorage::getInfoFromLshw(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceStorage::getInfoFromLshw";
     // lshw信息获取
     setAttribute(mapInfo, "capabilities", m_Capabilities);
     setAttribute(mapInfo, "version", m_Version);
@@ -717,6 +817,7 @@ void DeviceStorage::getInfoFromLshw(const QMap<QString, QString> &mapInfo)
     QRegularExpression re(".*\\((.*)\\)$");
     QRegularExpressionMatch match = re.match(sizeFromlshw);
     if (match.hasMatch()) {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromLshw, size has match";
         sizeFromlshw = match.captured(1);
         sizeByte = convertToBytes(sizeFromlshw, DISK_SCALE_1000);
     }
@@ -732,8 +833,10 @@ void DeviceStorage::getInfoFromLshw(const QMap<QString, QString> &mapInfo)
 
 void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
 {
+    qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl";
     if (mapInfo.size() < 5) {
         if (!mapInfo.isEmpty() && m_Interface.contains("USB", Qt::CaseInsensitive)) {
+            qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, mapInfo is not empty and interface contains USB";
             m_MediaType = QObject::tr("SSD");
         }
         return;
@@ -744,16 +847,21 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
     // 速度
     QString sataVersion = mapInfo["SATA Version is"];
     QStringList strList = sataVersion.split(",");
-    if (strList.size() == 2)
+    if (strList.size() == 2) {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, strList size is 2";
         m_Speed = strList[1];
+    }
 
     setAttribute(mapInfo, "Rotation Rate", m_RotationRate);
     // 解决Bug45428,INTEL SSDSA2BW160G3L 这个型号的硬盘通过lsblk获取的rota是１，所以这里需要特殊处理
-    if (m_RotationRate == QString("Solid State Device"))
+    if (m_RotationRate == QString("Solid State Device")) {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, rotation rate is Solid State Device";
         m_MediaType = QObject::tr("SSD");
+    }
 
     // 按照HW的需求，如果是固态硬盘就不显示转速
     if (m_RotationRate == QString("HW_SSD")) {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, rotation rate is HW_SSD";
         m_MediaType = QObject::tr("SSD");
         m_RotationRate = "";
     }
@@ -764,6 +872,7 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
         capacity = compareSize(mapInfo["Total NVM Capacity"], mapInfo["Namespace 1 Size/Capacity"]);
 
     if (capacity != "") {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, capacity is not empty";
         QRegularExpression reg(".*\\[(.*)\\]$");
         if (reg.match(capacity).hasMatch())
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -776,6 +885,7 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
         QRegularExpression re("(\\d+)bytes*");     //取值格式如： User Capacity:    1,000,204,886,016 bytes [1.00 TB]     Total NVM Capacity:   256,060,514,304 [256 GB]
         int pos = re.match(capacity).capturedStart();
         if (pos != -1) {
+            qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, capacity has match";
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             QString byteSize = re.cap(1); // Qt 5 使用 cap
 #else
@@ -791,15 +901,21 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
     // 通过不断适配，当厂商有在固件中提供时，硬盘型号从smartctl中获取更加合理
     // 因为hwinfo获取的是主控的型号，而硬盘厂商由于还不能自己生产主控，只能采购别人的主控
     //SATA
-    if (mapInfo.find("Device Model") != mapInfo.end())
+    if (mapInfo.find("Device Model") != mapInfo.end()) {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, mapInfo contains Device Model";
         m_Name = mapInfo["Device Model"];
+    }
     //NVME
-    if (mapInfo.find("Model Number") != mapInfo.end())
+    if (mapInfo.find("Model Number") != mapInfo.end()) {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, mapInfo contains Model Number";
         m_Name = mapInfo["Model Number"];
+    }
 
-    if (mapInfo.find("Serial Number") != mapInfo.end())
+    if (mapInfo.find("Serial Number") != mapInfo.end()) {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, mapInfo contains Serial Number";
         setAttribute(mapInfo, "Serial Number", m_SerialNumber, true);
-    else if (mapInfo.find("Serial number") != mapInfo.end()) {
+    } else if (mapInfo.find("Serial number") != mapInfo.end()) {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, mapInfo contains Serial number";
         setAttribute(mapInfo, "Serial number", m_SerialNumber, true);
     }
 
@@ -808,6 +924,8 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
         && Common::boardVendorType() != "PGUW" && Common::boardVendorType() != "PGUV")
             m_Size.replace(QRegularExpression("\\.0[1-9]"), ".00");
     //根据产品PN中的固定前两位 RS来匹配厂商 为Longsys 如产品PN ：RSYE3836N-480G    RSYE3836N-960G    RSYE3836N-1920     RSYE3836N-3840
-    if (m_Name.startsWith("RS") && m_Vendor.isEmpty())
+    if (m_Name.startsWith("RS") && m_Vendor.isEmpty()) {
+        qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, name starts with RS and vendor is empty";
         m_Vendor = "Longsys";
+    }
 }

--- a/deepin-devicemanager/src/SingleDeviceManager.cpp
+++ b/deepin-devicemanager/src/SingleDeviceManager.cpp
@@ -26,6 +26,7 @@ void SingleDeviceManager::activateWindow()
         m_qspMainWnd.reset(new MainWindow());
         Dtk::Widget::moveToCenter(m_qspMainWnd.get());
         m_qspMainWnd->show();
+        qCDebug(appLog) << "Main window created and shown.";
         QJsonObject obj{
             {"tid", EventLogUtils::Start},
             {"version", QCoreApplication::applicationVersion()},
@@ -36,9 +37,11 @@ void SingleDeviceManager::activateWindow()
         m_qspMainWnd->setWindowState(Qt::WindowActive);
         m_qspMainWnd->activateWindow(); // Reactive main window
         m_qspMainWnd->showNormal();     //非特效模式下激活窗口
+        qCDebug(appLog) << "Main window already exists, activated and shown.";
     }
     if (!m_PageDescription.isEmpty()) {
         QMetaObject::invokeMethod(m_qspMainWnd.get(), "slotSetPage", Qt::QueuedConnection, Q_ARG(QString, m_PageDescription));
+        qCDebug(appLog) << "Setting page to:" << m_PageDescription;
     }
 }
 
@@ -54,13 +57,16 @@ bool SingleDeviceManager::parseCmdLine()
 
     if (!m_PageDescription.isEmpty()) {
         m_PageDescription.clear();
+        qCDebug(appLog) << "Cleared existing page description.";
     }
     QStringList paraList = parser.positionalArguments();
     if (!paraList.isEmpty()) {
         m_PageDescription = paraList[0];
+        qCDebug(appLog) << "Parsed page description:" << m_PageDescription;
     }
 
     if (paraList.size() > 0 && m_PageDescription.isEmpty()) {
+        qCWarning(appLog) << "Positional arguments exist but page description is empty, returning false.";
         return false;
     }
     qCDebug(appLog) << "SingleDeviceManager::parseCmdLine() result:" << true;
@@ -76,6 +82,7 @@ void SingleDeviceManager::startDeviceManager(QString pageDescription)
     } else {
         qCDebug(appLog) << "SingleDeviceManager::startDeviceManager with empty page";
         if (m_qspMainWnd.get()) {                   //先判断当前是否已经存在一个进程。
+            qCDebug(appLog) << "Main window exists, activating it.";
             m_qspMainWnd.get()->setWindowState((m_qspMainWnd.get()->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
 //            m_qspMainWnd.get()->activateWindow();   //特效模式下激活窗口            m_qspMainWnd.get()->showNormal();       //无特效激活窗口
         }

--- a/deepin-devicemanager/src/main.cpp
+++ b/deepin-devicemanager/src/main.cpp
@@ -61,6 +61,7 @@ int main(int argc, char *argv[])
 
     // /usr/bin/devicemanager notify
     if (argc > 2 && QString(argv[1]).contains("notify")) {
+        qCDebug(appLog) << "Starting notification process";
         notify(argc, argv);
         return -1;
     }
@@ -74,6 +75,7 @@ int main(int argc, char *argv[])
     #endif
 
     if (!QString(qgetenv("XDG_CURRENT_DESKTOP")).toLower().startsWith("deepin")) {
+        qCDebug(appLog) << "XDG_CURRENT_DESKTOP is not deepin, setting it to Deepin";
         setenv("XDG_CURRENT_DESKTOP", "Deepin", 1);
     }
 
@@ -118,6 +120,7 @@ int main(int argc, char *argv[])
         QIcon appIcon = QIcon::fromTheme("deepin-devicemanager");
 
         if (false == appIcon.isNull()) {
+            qCDebug(appLog) << "Setting application icon";
             app.setProductIcon(appIcon);
             app.setWindowIcon(appIcon);
         }
@@ -149,6 +152,7 @@ int main(int argc, char *argv[])
 
 void notify(int argc, char *argv[])
 {
+    qCDebug(appLog) << "Starting notification process";
     // 1. 连接到dbus
     qCDebug(appLog) << "Starting notification process";
     if (!QDBusConnection::sessionBus().isConnected()) {
@@ -163,12 +167,15 @@ void notify(int argc, char *argv[])
     QString view = QObject::tr("View");
     QString l = QString(argv[2]);
     if ("zh_CN" == l) {
+        qCDebug(appLog) << "Setting notification language to zh_CN";
         body = QString("您有驱动可进行安装/更新");
         view = QString("查 看");
     } else if ("zh_HK" == l) {
+        qCDebug(appLog) << "Setting notification language to zh_HK";
         body = QString("您有驅動可進行安裝/更新");
         view = QString("查 看");
     } else if ("zh_TW" == l) {
+        qCDebug(appLog) << "Setting notification language to zh_TW";
         body = QString("您有驅動可進行安裝/更新");
         view = QString("查 看");
     }
@@ -189,6 +196,7 @@ void notify(int argc, char *argv[])
     int timeout = 3000;
 
     int count = 0;
+    qCDebug(appLog) << "Attempting to send notification...";
     while (count < 10) {
         QDBusReply<uint32_t> reply  = mp_Iface->call("Notify", appname, replaces_id, appicon, title, body, actionlist, hints, timeout);
         if (reply.isValid()) {


### PR DESCRIPTION
Add more logs for device manager.

Log: More logs for device manager.

## Summary by Sourcery

Add comprehensive qCDebug logging across the device manager and all device types to trace construction, method calls, attribute loading, and state changes without altering existing functionality.

Enhancements:
- Instrument DeviceBaseInfo, DeviceManager, and all Device* classes with debug log statements in constructors, destructors, getters, setters, and export routines.
- Log entry, exit, and key internal state changes (counts, flags, paths, return values) in critical methods for improved traceability.