### PR TITLE
fix: [GPU] The max resolution and min resolution show error.

### DIFF
--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -337,8 +337,8 @@ void ThreadExecXrandr::getResolutionFromDBus(QMap<QString, QString> &lstMap)
     }
 
     if (maxResolutionWidth != -1) {
-        lstMap.insert("maxResolution", QString("%1×%2").arg(maxResolutionWidth).arg(maxResolutionHeight));
-        lstMap.insert("minResolution", QString("%1×%2").arg(minResolutionWidth).arg(minResolutionHeight));
+        lstMap.insert("maxResolution", QString("%1 x %2").arg(maxResolutionWidth).arg(maxResolutionHeight));
+        lstMap.insert("minResolution", QString("%1 x %2").arg(minResolutionWidth).arg(minResolutionHeight));
     }
 }
 


### PR DESCRIPTION
-- Show 'x' not show 'X'.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-323421.html

## Summary by Sourcery

Bug Fixes:
- Change maxResolution and minResolution strings to use "%1 x %2" instead of "%1×%2"