### PR TITLE
feat: Update display size for specific device models

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -258,7 +258,7 @@ const QString DeviceMonitor::getOverviewInfo()
     QString ov;
 
     ov = QString("%1(%2)").arg(m_Name).arg(m_ScreenSize);
-    if (Common::specialComType == 6) {
+    if (Common::specialComType == 6 || Common::specialComType == 7) {
         ov = QString("(%1)").arg(m_ScreenSize);
     } else {
         ov = QString("%1(%2)").arg(m_Name).arg(m_ScreenSize);
@@ -275,7 +275,7 @@ void DeviceMonitor::initFilterKey()
 void DeviceMonitor::loadBaseDeviceInfo()
 {
     // 添加基本信息
-    if (Common::specialComType != 6 && Common::specialComType != 5) {
+    if (Common::specialComType != 6 && Common::specialComType != 5 && Common::specialComType != 7) {
         addBaseDeviceInfo(("Name"), m_Name);
         addBaseDeviceInfo(("Vendor"), m_Vendor);
         addBaseDeviceInfo(("Type"), m_Model);
@@ -349,10 +349,10 @@ bool DeviceMonitor::setMainInfoFromXrandr(const QString &info, const QString &ra
                     curRate = QString::number(ceil(curRate.left(pos).toDouble())) + curRate.right(curRate.size() - pos);
                 }
             }
-            if (Common::specialComType == 1 || Common::specialComType == 5 || Common::specialComType == 6) {
+            if (Common::specialComType == 1 || Common::specialComType == 5 || Common::specialComType == 6  || Common::specialComType == 7) {
                 m_RefreshRate = QString("%1").arg(curRate);
             }
-            if (Common::specialComType == 5 || Common::specialComType == 6) {
+            if (Common::specialComType == 5 || Common::specialComType == 6 || Common::specialComType == 7) {
                 m_CurrentResolution = QString("%1").arg(reScreenSize.cap(1)).replace("x", "×", Qt::CaseInsensitive);
             } else {
                 m_CurrentResolution = QString("%1 @%2").arg(reScreenSize.cap(1)).arg(curRate).replace("x", "×", Qt::CaseInsensitive);

--- a/deepin-devicemanager/src/Tool/EDIDParser.cpp
+++ b/deepin-devicemanager/src/Tool/EDIDParser.cpp
@@ -205,8 +205,12 @@ void EDIDParser::parseScreenSize()
         }
     }
 
+    if (Common::specialComType == 7){ // sepcial task:378963
+        m_Width = 296;
+        m_Height = 197;
+    }
     double inch = sqrt((m_Width / 2.54) * (m_Width / 2.54) + (m_Height / 2.54) * (m_Height / 2.54))/10;
-    m_ScreenSize = QString("%1 %2(%3mm×%4mm)").arg(QString::number(inch, '0', 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
+    m_ScreenSize = QString("%1 %2(%3mm×%4mm)").arg(QString::number(inch, '0', Common::specialComType == 7 ? 0 : 1)).arg(QObject::tr("inch")).arg(m_Width).arg(m_Height);
 }
 
 QString EDIDParser::binToDec(QString strBin)   //二进制转十进制

--- a/deepin-devicemanager/src/Tool/EDIDParser.h
+++ b/deepin-devicemanager/src/Tool/EDIDParser.h
@@ -8,7 +8,7 @@
 #include<QString>
 #include<QStringList>
 #include<QMap>
-
+#include <commonfunction.h>
 /**
  * @brief The EDIDParser class
  * 用于解析edid的类

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -78,7 +78,7 @@ void ThreadExecXrandr::loadXrandrInfo(QList<QMap<QString, QString>> &lstMap, con
             QRegExp re(".*([0-9]{1,5}\\sx\\s[0-9]{1,5}).*([0-9]{1,5}\\sx\\s[0-9]{1,5}).*([0-9]{1,5}\\sx\\s[0-9]{1,5}).*");
             if (re.exactMatch(line)) {
                 lstMap[lstMap.count() - 1].insert("minResolution", re.cap(1));
-                lstMap[lstMap.count() - 1].insert("curResolution", re.cap(2));
+                lstMap[lstMap.count() - 1].insert("curResolution", re.cap(2).replace("x", "×", Qt::CaseInsensitive));
                 lstMap[lstMap.count() - 1].insert("maxResolution", re.cap(3));
             }
             continue;
@@ -337,8 +337,8 @@ void ThreadExecXrandr::getResolutionFromDBus(QMap<QString, QString> &lstMap)
     }
 
     if (maxResolutionWidth != -1) {
-        lstMap.insert("maxResolution", QString("%1 x %2").arg(maxResolutionWidth).arg(maxResolutionHeight));
-        lstMap.insert("minResolution", QString("%1 x %2").arg(minResolutionWidth).arg(minResolutionHeight));
+        lstMap.insert("maxResolution", QString("%1×%2").arg(maxResolutionWidth).arg(maxResolutionHeight));
+        lstMap.insert("minResolution", QString("%1×%2").arg(minResolutionWidth).arg(minResolutionHeight));
     }
 }
 


### PR DESCRIPTION
Corrected firmware errors in EDID files by customizing all screen sizes to the actual 14-inch measurements.

Log: Update display size specifications in EDID
Task: https://pms.uniontech.com/task-view-378963.html
Change-Id: Icccb3d31514c17f5f550bd2262e0e7a429c3dc85

## Summary by Sourcery

Add support for a new special device type (7) with corrected 14-inch display measurements and propagate this throughout the display info logic

New Features:
- Introduce specialComType 7 handling with explicit 296×197 mm screen dimensions

Enhancements:
- Include type 7 in overview, base info, refresh rate, and resolution parsing logic
- Use '×' as the resolution separator consistently when parsing Xrandr and DBus outputs
- Adjust inch rounding precision for type 7 displays