### PR TITLE
chore: More logs for device manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ ui_*.h
 *.jsc
 Makefile*
 *build-*
+build/
 
 # Qt unit tests
 target_wrapper.*
@@ -45,3 +46,4 @@ CMakeLists.txt.user*
 # AI
 .cursor
 .specstory
+.cursorindexingignore

--- a/deepin-devicemanager/src/DriverControl/DBusDriverInterface.cpp
+++ b/deepin-devicemanager/src/DriverControl/DBusDriverInterface.cpp
@@ -78,22 +78,27 @@ bool DBusDriverInterface::isDriverPackage(const QString &path)
 
 bool DBusDriverInterface::isArchMatched(const QString &path)
 {
+    qCDebug(appLog) << "DBusDriverInterface::isArchMatched";
     QDBusReply<bool> reply = mp_Iface->call("isArchMatched", path);
     if (reply.isValid())
         return reply.value();
+    qCDebug(appLog) << "DBusDriverInterface::isArchMatched, reply is invalid";
     return false;
 }
 
 bool DBusDriverInterface::isDebValid(const QString &path)
 {
+    qCDebug(appLog) << "DBusDriverInterface::isDebValid";
     QDBusReply<bool> reply = mp_Iface->call("isDebValid", path);
     if (reply.isValid())
         return reply.value();
+    qCDebug(appLog) << "DBusDriverInterface::isDebValid, reply is invalid";
     return false;
 }
 
 bool DBusDriverInterface::backupDeb(const QString &debpath)
 {
+    qCDebug(appLog) << "DBusDriverInterface::backupDeb";
     QDBusReply<bool> reply = mp_Iface->call("backupDeb", debpath);
 
     return reply.value();
@@ -101,6 +106,7 @@ bool DBusDriverInterface::backupDeb(const QString &debpath)
 
 bool DBusDriverInterface::delDeb(const QString &debname)
 {
+    qCDebug(appLog) << "DBusDriverInterface::delDeb";
     QDBusReply<bool> reply = mp_Iface->call("delDeb",debname);
 
     return reply.value();
@@ -108,6 +114,7 @@ bool DBusDriverInterface::delDeb(const QString &debname)
 
 bool DBusDriverInterface::aptUpdate()
 {
+    qCDebug(appLog) << "DBusDriverInterface::aptUpdate";
     QDBusReply<bool> reply = mp_Iface->call("aptUpdate");
 
     return reply.value();
@@ -128,12 +135,15 @@ DBusDriverInterface::~DBusDriverInterface()
 
 void DBusDriverInterface::slotProcessChange(qint32 value, QString detail)
 {
+    qCDebug(appLog) << "DBusDriverInterface::slotProcessChange";
     emit processChange(value, detail);
 }
 
 void DBusDriverInterface::slotProcessEnd(bool success, QString msg)
 {
+    qCDebug(appLog) << "DBusDriverInterface::slotProcessEnd";
     if (success) {
+        qCDebug(appLog) << "DBusDriverInterface::slotProcessEnd, success";
         emit processChange(100, "");
         usleep(300000);
     }
@@ -142,27 +152,32 @@ void DBusDriverInterface::slotProcessEnd(bool success, QString msg)
 
 void DBusDriverInterface::slotCallFinished(QDBusPendingCallWatcher *watcher)
 {
+    qCDebug(appLog) << "DBusDriverInterface::slotCallFinished";
     QDBusPendingReply<bool> reply = *watcher;
     watcher->deleteLater();
 }
 
 void DBusDriverInterface::slotDownloadProgressChanged(QStringList msg)
 {
+    qCDebug(appLog) << "DBusDriverInterface::slotDownloadProgressChanged";
     emit downloadProgressChanged(msg);
 }
 
 void DBusDriverInterface::slotDownloadFinished()
 {
+    qCDebug(appLog) << "DBusDriverInterface::slotDownloadFinished";
     emit downloadFinished();
 }
 
 void DBusDriverInterface::slotInstallProgressFinished(bool bsuccess, int err)
 {
+    qCDebug(appLog) << "DBusDriverInterface::slotInstallProgressFinished";
     emit installProgressFinished(bsuccess, err);
 }
 
 void DBusDriverInterface::slotInstallProgressChanged(qint32 progress)
 {
+    qCDebug(appLog) << "DBusDriverInterface::slotInstallProgressChanged";
     emit installProgressChanged(progress);
 }
 
@@ -182,6 +197,7 @@ void DBusDriverInterface::init()
     qCDebug(appLog) << "DBus interface created for service:" << SERVICE_NAME;
 
     if (mp_Iface->isValid()) {
+        qCDebug(appLog) << "DBusDriverInterface::init, iface is valid";
         connect(mp_Iface, SIGNAL(sigProgressDetail(qint32, QString)), this, SLOT(slotProcessChange(qint32, QString)));
         connect(mp_Iface, SIGNAL(sigFinished(bool, QString)), this, SLOT(slotProcessEnd(bool, QString)));
 

--- a/deepin-devicemanager/src/DriverControl/DriverScanner.cpp
+++ b/deepin-devicemanager/src/DriverControl/DriverScanner.cpp
@@ -39,14 +39,17 @@ void DriverScanner::run()
 
             // 检测本地安装版本
             if (!info->packages().isEmpty()) {
+                // qCDebug(appLog) << "Checking local version for package:" << info->packages();
                 QString outInfo = Common::executeClientCmd("apt", QStringList() << "policy" << info->packages(), QString(), -1, false);
                 if (!outInfo.isEmpty()) {
+                    // qCDebug(appLog) << "apt policy output:" << outInfo;
                     QStringList infoList = outInfo.split("\n");
                     int index = 0;
                     for (int i = 0; i < infoList.size(); i++)
                     {
                         if (infoList[i].startsWith(info->packages())) {
                             index = i;
+                            // qCDebug(appLog) << "Found package info at index:" << index;
                             break;
                         }
                     }
@@ -56,13 +59,14 @@ void DriverScanner::run()
                         QString curVersion;
                         if (match.hasMatch()) {
                             curVersion = match.captured(1);
+                            // qCDebug(appLog) << "Found current version:" << curVersion;
                         }
                         info->m_Version = curVersion.trimmed();
                     }
                 }
             }
 
-            qCDebug(appLog) << "Driver scan progress:" << info->name() << "progress:" << 100 / m_ListDriverInfo.size();
+            // qCDebug(appLog) << "Driver scan progress:" << info->name() << "progress:" << 100 / m_ListDriverInfo.size();
             emit scanInfo(info->name(), 100 / m_ListDriverInfo.size());
             sleep(1);
         } else {

--- a/deepin-devicemanager/src/EnableControl/DBusTouchPad.cpp
+++ b/deepin-devicemanager/src/EnableControl/DBusTouchPad.cpp
@@ -49,7 +49,9 @@ bool DBusTouchPad::isExists()
 {
     qCDebug(appLog) << "Check touchpad existence";
     if (m_dbusTouchPad->isValid()) {
-        return m_dbusTouchPad->property("Exist").toBool();
+        bool exists = m_dbusTouchPad->property("Exist").toBool();
+        qCDebug(appLog) << "Touchpad exists:" << exists;
+        return exists;
     }
     qCWarning(appLog) << "Invalid DBus interface when checking touchpad existence";
     return false;
@@ -78,7 +80,9 @@ bool DBusTouchPad::getEnable()
 {
     qCDebug(appLog) << "Get touchpad enable state";
     if (m_dbusTouchPad->isValid()) {
-        return m_dbusTouchPad->property("TPadEnable").toBool();
+        bool enabled = m_dbusTouchPad->property("TPadEnable").toBool();
+        qCDebug(appLog) << "Touchpad enabled state:" << enabled;
+        return enabled;
     }
     qCWarning(appLog) << "Invalid DBus interface when getting touchpad state";
     return false;

--- a/deepin-devicemanager/src/GenerateDevice/DBusInterface.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DBusInterface.cpp
@@ -63,6 +63,7 @@ void DBusInterface::init()
     qCDebug(appLog) << "DBusInterface::init start";
     // 1. 连接到dbus
     if (!QDBusConnection::systemBus().isConnected()) {
+        qCWarning(appLog) << "Cannot connect to the D-Bus session bus.";
         fprintf(stderr, "Cannot connect to the D-Bus session bus./n"
                 "To start it, run:/n"
                 "/teval `dbus-launch --auto-syntax`/n");

--- a/deepin-devicemanager/src/GenerateDevice/DeviceFactory.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceFactory.cpp
@@ -35,27 +35,40 @@ DeviceGenerator *DeviceFactory::getDeviceGenerator()
 
     // 根据架构创建设备信息生成器
     DeviceGenerator *generator = nullptr;
-    if (arch == "x86_64")
+    if (arch == "x86_64") {
+        qCDebug(appLog) << "DeviceFactory::getDeviceGenerator create X86Generator";
         generator = new X86Generator();
-    else if (arch == "mips64")
+    } else if (arch == "mips64") {
+        qCDebug(appLog) << "DeviceFactory::getDeviceGenerator create MipsGenerator";
         generator = new MipsGenerator();
-    else if (arch == "aarch64") {
+    } else if (arch == "aarch64") {
         QString type = Common::boardVendorType();
+        qCDebug(appLog) << "DeviceFactory::getDeviceGenerator arch is aarch64, type is" << type;
         if (!type.isEmpty()) {
-            if (type == "KLVV")
+            if (type == "KLVV") {
+                qCDebug(appLog) << "DeviceFactory::getDeviceGenerator create KLVGenerator";
                 generator = new KLVGenerator();
-            else if (type == "PGUV" || type == "PGUW")
+            } else if (type == "PGUV" || type == "PGUW") {
+                qCDebug(appLog) << "DeviceFactory::getDeviceGenerator create PanguVGenerator";
                 generator = new PanguVGenerator();
-            else if (type == "KLVU")
+            } else if (type == "KLVU") {
+                qCDebug(appLog) << "DeviceFactory::getDeviceGenerator create KLUGenerator";
                 generator = new KLUGenerator();
-            else if (type == "PGUX")
+            } else if (type == "PGUX") {
+                qCDebug(appLog) << "DeviceFactory::getDeviceGenerator create PanguXGenerator";
                 generator = new PanguXGenerator();
-            else
+            } else {
+                qCDebug(appLog) << "DeviceFactory::getDeviceGenerator create HWGenerator";
                 generator = new HWGenerator();
-        } else
+            }
+        } else {
+            qCDebug(appLog) << "DeviceFactory::getDeviceGenerator create ArmGenerator";
             generator = new ArmGenerator();
-    } else
+        }
+    } else {
+        qCDebug(appLog) << "DeviceFactory::getDeviceGenerator create X86Generator by default";
         generator = new X86Generator();
+    }
 
     qCDebug(appLog) << "DeviceFactory::getDeviceGenerator end, arch:" << Common::getArch() << "type:" << Common::boardVendorType() << "generator:" << generator;
     return generator;

--- a/deepin-devicemanager/src/GenerateDevice/GenerateDevicePool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/GenerateDevicePool.cpp
@@ -17,7 +17,7 @@ using namespace DDLog;
 GenerateTask::GenerateTask(DeviceType deviceType)
     : m_Type(deviceType)
 {
-    qCDebug(appLog) << "GenerateTask destructor, type:" << m_Type;
+    qCDebug(appLog) << "GenerateTask constructor, type:" << m_Type;
 }
 
 GenerateTask::~GenerateTask()
@@ -27,83 +27,103 @@ GenerateTask::~GenerateTask()
 
 void GenerateTask::run()
 {
-    qCDebug(appLog) << "GenerateTask::run start";
+    qCDebug(appLog) << "GenerateTask::run start, type:" << m_Type;
 
     DeviceGenerator *generator = DeviceFactory::getDeviceGenerator();
 
-    if (!generator)
+    if (!generator) {
+        qCWarning(appLog) << "GenerateTask::run get generator failed";
         return;
+    }
 
     switch (m_Type) {
     case DT_Computer:
+        qCDebug(appLog) << "GenerateTask::run generate computer device";
         generator->generatorComputerDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Cpu:
+        qCDebug(appLog) << "GenerateTask::run generate cpu device";
         generator->generatorCpuDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Bios:
+        qCDebug(appLog) << "GenerateTask::run generate bios device";
         generator->generatorBiosDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Memory:
+        qCDebug(appLog) << "GenerateTask::run generate memory device";
         generator->generatorMemoryDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Storage:
+        qCDebug(appLog) << "GenerateTask::run generate storage device";
         generator->generatorDiskDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Gpu:
+        qCDebug(appLog) << "GenerateTask::run generate gpu device";
         generator->generatorGpuDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Monitor:
+        qCDebug(appLog) << "GenerateTask::run generate monitor device";
         generator->generatorMonitorDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Network:
+        qCDebug(appLog) << "GenerateTask::run generate network device";
         generator->generatorNetworkDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Audio:
+        qCDebug(appLog) << "GenerateTask::run generate audio device";
         generator->generatorAudioDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Bluetoorh:
+        qCDebug(appLog) << "GenerateTask::run generate bluetooth device";
         generator->generatorBluetoothDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Keyboard:
+        qCDebug(appLog) << "GenerateTask::run generate keyboard device";
         generator->generatorKeyboardDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Mouse:
+        qCDebug(appLog) << "GenerateTask::run generate mouse device";
         generator->generatorMouseDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Print:
+        qCDebug(appLog) << "GenerateTask::run generate print device";
         generator->generatorPrinterDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Image:
+        qCDebug(appLog) << "GenerateTask::run generate image device";
         generator->generatorCameraDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Cdrom:
+        qCDebug(appLog) << "GenerateTask::run generate cdrom device";
         generator->generatorCdromDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Others:
+        qCDebug(appLog) << "GenerateTask::run generate others device";
         generator->generatorOthersDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     case DT_Power:
+        qCDebug(appLog) << "GenerateTask::run generate power device";
         generator->generatorPowerDevice();
         generator->generatorInfoFromToml(m_Type);
         break;
     default:
+        qCDebug(appLog) << "GenerateTask::run generate unknown device";
         break;
     }
 
@@ -127,6 +147,7 @@ void GenerateDevicePool::generateDevice()
 
     QList<DeviceType>::iterator it = m_TypeList.begin();
     for (; it != m_TypeList.end(); ++it) {
+        // qCDebug(appLog) << "GenerateDevicePool::generateDevice start task for type:" << (*it);
         GenerateTask *task = new GenerateTask((*it));
         connect(task, &GenerateTask::finished, this, &GenerateDevicePool::slotFinished);
         QThreadPool::globalInstance()->start(task);
@@ -137,8 +158,10 @@ void GenerateDevicePool::generateDevice()
     // 这里是为了确保其它设备在最后一个生成
     qint64 beginMSecond = QDateTime::currentMSecsSinceEpoch();
     while (true) {
+        // qCDebug(appLog) << "GenerateDevicePool::generateDevice wait for tasks finished, finished count:" << m_FinishedGenerator;
         qint64 curMSecond = QDateTime::currentMSecsSinceEpoch();
         if (m_FinishedGenerator == m_TypeList.size()  || curMSecond - beginMSecond > 4000) {
+            // qCDebug(appLog) << "GenerateDevicePool::generateDevice all tasks finished or timeout, generate others device";
             DeviceGenerator *generator = DeviceFactory::getDeviceGenerator();
             generator->generatorOthersDevice();
             generator->generatorInfoFromToml(DT_Others);

--- a/deepin-devicemanager/src/GenerateDevice/GetInfoPool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/GetInfoPool.cpp
@@ -21,7 +21,7 @@ CmdTask::CmdTask(QString key, QString file, QString info, GetInfoPool *parent)
     , m_Info(info)
     , mp_Parent(parent)
 {
-
+    qCDebug(appLog) << "CmdTask constructor, key:" << key;
 }
 
 CmdTask::~CmdTask()
@@ -55,6 +55,7 @@ void GetInfoPool::getAllInfo()
 
     QList<QStringList>::iterator it = m_CmdList.begin();
     for (; it != m_CmdList.end(); ++it) {
+        qCDebug(appLog) << "GetInfoPool::getAllInfo start task for key:" << (*it)[0];
         CmdTask *task = new CmdTask((*it)[0], (*it)[1], (*it)[2], this);
         start(task);
         task->deleteLater();
@@ -68,6 +69,7 @@ void GetInfoPool::finishedCmd(const QString &info, const QMap<QString, QList<QMa
     QMutexLocker m_lock(&mutex);
     m_FinishedNum++;
     if (m_FinishedNum == m_CmdList.size()) {
+        qCDebug(appLog) << "GetInfoPool::finishedCmd all tasks finished";
         emit finishedAll(info);
         m_FinishedNum = 0;
     }

--- a/deepin-devicemanager/src/GenerateDevice/MipsGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/MipsGenerator.cpp
@@ -44,6 +44,7 @@ void MipsGenerator::generatorComputerDevice()
 
     // home url
     if (cmdInfo.size() > 0) {
+        qCDebug(appLog) << "MipsGenerator::generatorComputerDevice get home url";
         QString value = cmdInfo[0]["HOME_URL"];
         device->setHomeUrl(value.replace("\"", ""));
     }
@@ -51,6 +52,7 @@ void MipsGenerator::generatorComputerDevice()
     // name type
     const QList<QMap<QString, QString> >  &sysInfo = DeviceManager::instance()->cmdInfo("lshw_system");
     if (sysInfo.size() > 0) {
+        qCDebug(appLog) << "MipsGenerator::generatorComputerDevice get system info";
         device->setType(sysInfo[0]["description"]);
         device->setVendor(sysInfo[0]["vendor"]);
         device->setName(sysInfo[0]["product"]);
@@ -58,21 +60,26 @@ void MipsGenerator::generatorComputerDevice()
 
     // 龙心机器从sudo dmidecode -t 1中获取机器信息
     const QList<QMap<QString, QString> >  &dmiInfo = DeviceManager::instance()->cmdInfo("dmidecode1");
-    if (dmiInfo.size() > 1)
+    if (dmiInfo.size() > 1) {
+        qCDebug(appLog) << "MipsGenerator::generatorComputerDevice get product name from dmidecode";
         device->setName(dmiInfo[1]["Product Name"]);
+    }
 
     // set Os Description from /etc/os-version
     QString productName = DeviceGenerator::getProductName();
     device->setOsDescription(productName);
+    qCDebug(appLog) << "MipsGenerator::generatorComputerDevice get product name" << productName;
 
     // os
     const QList<QMap<QString, QString> >  &verInfo = DeviceManager::instance()->cmdInfo("cat_version");
     if (verInfo.size() > 0) {
+        qCDebug(appLog) << "MipsGenerator::generatorComputerDevice get os version";
         QString info = verInfo[0]["OS"].trimmed();
         info = info.trimmed();
         QRegularExpression reg("\\(gcc [\\s\\S]*(\\([\\s\\S]*\\))\\)");
         QRegularExpressionMatch match = reg.match(info);
         if (match.hasMatch()) {
+            qCDebug(appLog) << "MipsGenerator::generatorComputerDevice match os version";
             QString tmp = match.captured(0);
             info.remove(tmp);
             info.insert(match.capturedStart(), match.captured(1));

--- a/deepin-devicemanager/src/GenerateDevice/PanguGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/PanguGenerator.cpp
@@ -26,6 +26,7 @@ void PanguGenerator::generatorComputerDevice()
 
     // home url
     if (cmdInfo.size() > 0) {
+        qCDebug(appLog) << "PanguGenerator::generatorComputerDevice get home url";
         QString value = cmdInfo[0]["HOME_URL"];
         device->setHomeUrl(value.replace("\"", ""));
     }
@@ -36,29 +37,37 @@ void PanguGenerator::generatorComputerDevice()
     const QList<QMap<QString, QString> >  &dmidecode3List = DeviceManager::instance()->cmdInfo("dmidecode3");
 
     if (dmidecode1List.size() > 1) {
+        qCDebug(appLog) << "PanguGenerator::generatorComputerDevice get device info from dmidecode";
         device->setVendor(dmidecode1List[1]["Manufacturer"], dmidecode2List[0]["Manufacturer"]);
         device->setName(dmidecode1List[1]["Product Name"], dmidecode2List[0]["Product Name"], dmidecode1List[1]["Family"], dmidecode1List[1]["Version"]);
     }
 
     if (dmidecode3List.size() > 1) {
+        qCDebug(appLog) << "PanguGenerator::generatorComputerDevice get device type from dmidecode";
         device->setType(dmidecode3List[1]["Type"]);
     }
 
     // setOsDescription
     QString os = "UOS";
     DSysInfo::DeepinType type = DSysInfo::deepinType();
-    if (DSysInfo::DeepinProfessional == type)
+    qCDebug(appLog) << "PanguGenerator::generatorComputerDevice get deepin type:" << type;
+    if (DSysInfo::DeepinProfessional == type) {
+        qCDebug(appLog) << "PanguGenerator::generatorComputerDevice deepin type is professional";
         os =  "UOS 20";
-    else if (DSysInfo::DeepinPersonal == type)
+    } else if (DSysInfo::DeepinPersonal == type) {
+        qCDebug(appLog) << "PanguGenerator::generatorComputerDevice deepin type is personal";
         os =  "UOS 20 Home";
-    else if (DSysInfo::DeepinDesktop == type)
+    } else if (DSysInfo::DeepinDesktop == type) {
+        qCDebug(appLog) << "PanguGenerator::generatorComputerDevice deepin type is desktop";
         os =  "Deepin 20 Beta";
+    }
 
     device->setOsDescription(os);
 
     // os
     const QList<QMap<QString, QString> >  &verInfo = DeviceManager::instance()->cmdInfo("cat_version");
     if (verInfo.size() > 0) {
+        qCDebug(appLog) << "PanguGenerator::generatorComputerDevice get os version";
         QString info = verInfo[0]["OS"].trimmed();
         info = info.trimmed();
         
@@ -66,6 +75,7 @@ void PanguGenerator::generatorComputerDevice()
         QRegularExpression reg("\\(gcc [\\s\\S]*(\\([\\s\\S]*\\))\\)");
         QRegularExpressionMatch match = reg.match(info);
         if (match.hasMatch()) {
+            qCDebug(appLog) << "PanguGenerator::generatorComputerDevice match os version 1";
             QString tmp = match.captured(0);
             info.remove(tmp);
             info.insert(match.capturedStart(), match.captured(1));
@@ -75,6 +85,7 @@ void PanguGenerator::generatorComputerDevice()
         reg.setPattern("(\\(root.*\\)) (\\(.*\\))");
         match = reg.match(info);
         if (match.hasMatch()) {
+            qCDebug(appLog) << "PanguGenerator::generatorComputerDevice match os version 2";
             QString tmp = match.captured(1);
             info.remove(tmp);
         }

--- a/deepin-devicemanager/src/GenerateDevice/PanguVGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/PanguVGenerator.cpp
@@ -25,20 +25,26 @@ void parseEDID(QStringList allEDIDS,QString input)
 {
     qCDebug(appLog) << "parseEDID start, input:" << input;
     for (auto edid:allEDIDS) {
+        // qCDebug(appLog) << "parseEDID process edid:" << edid;
         QProcess process;
         process.start(QString("hexdump %1").arg(edid));
         process.waitForFinished(-1);
 
         QString deviceInfo = process.readAllStandardOutput();
-        if(deviceInfo.isEmpty())
+        if(deviceInfo.isEmpty()) {
+            qCWarning(appLog) << "parseEDID device info is empty, skip";
             continue;
+        }
 
         QString edidStr;
         QStringList lines = deviceInfo.split("\n");
         for (auto line:lines) {
+            // qCDebug(appLog) << "parseEDID process line:" << line;
             QStringList words = line.trimmed().split(" ");
-            if(words.size() != 9)
+            if(words.size() != 9) {
+                // qCWarning(appLog) << "parseEDID words size is not 9, skip";
                 continue;
+            }
 
             words.removeAt(0);
             QString l = words.join("");
@@ -48,6 +54,7 @@ void parseEDID(QStringList allEDIDS,QString input)
 
         lines = edidStr.split("\n");
         if(lines.size() > 3){
+            // qCDebug(appLog) << "parseEDID lines size > 3, parse edid";
             EDIDParser edidParser;
             QString errorMsg;
             edidParser.setEdid(edidStr,errorMsg,"\n", false);
@@ -61,8 +68,10 @@ void parseEDID(QStringList allEDIDS,QString input)
             DeviceMonitor *device = new DeviceMonitor();
             device->setInfoFromEdid(mapInfo);
             DeviceManager::instance()->addMonitor(device);
+            // qCDebug(appLog) << "parseEDID add monitor device";
         }
     }
+    qCDebug(appLog) << "parseEDID end";
 }
 
 void PanguVGenerator::generatorMonitorDevice()
@@ -77,6 +86,7 @@ void PanguVGenerator::generatorMonitorDevice()
     allEDIDS2.append("/sys/devices/platform/hisi-drm/drm/card0/card0-VGA-1/edid");
     allEDIDS2.append("/sys/devices/platform/hldrm/drm/card0/card0-VGA-1/edid");
     parseEDID(allEDIDS2,"VGA-1");
+    qCDebug(appLog) << "PanguVGenerator::generatorMonitorDevice end";
 }
 
 void PanguVGenerator::generatorNetworkDevice()
@@ -86,7 +96,9 @@ void PanguVGenerator::generatorNetworkDevice()
     const QList<QMap<QString, QString>> lstInfo = DeviceManager::instance()->cmdInfo("lshw_network");
     QList<QMap<QString, QString> >::const_iterator it = lstInfo.begin();
     for (; it != lstInfo.end(); ++it) {
+        // qCDebug(appLog) << "PanguVGenerator::generatorNetworkDevice process lshw network info";
         if ((*it).size() < 2) {
+            // qCDebug(appLog) << "PanguVGenerator::generatorNetworkDevice network info not enough";
             continue;
         }
         QMap<QString, QString> tempMap = *it;
@@ -100,8 +112,10 @@ void PanguVGenerator::generatorNetworkDevice()
 //        }
 
         QString logicalName = tempMap["logical name"].trimmed();
-        if(! ifconfigCardName.contains(logicalName))
+        if(! ifconfigCardName.contains(logicalName)) {
+            // qCDebug(appLog) << "PanguVGenerator::generatorNetworkDevice logical name not in ifconfig list, skip";
             continue;
+        }
 
         DeviceNetwork *device = new DeviceNetwork();
         device->setInfoFromLshw(*it);
@@ -124,25 +138,34 @@ QStringList PanguVGenerator::getNetworkInfoFromifconfig()
     process.start(cmd);
     QString ifconfigInfo;
     bool re = process.waitForFinished(-1);
-    if (!re)
+    if (!re) {
+        qCWarning(appLog) << "PanguVGenerator::getNetworkInfoFromifconfig ifconfig command failed";
         return  ret;
+    }
     ifconfigInfo = process.readAllStandardOutput();
     //截取查询到的各个网卡连接信息
     QStringList list = ifconfigInfo.split("\n");
     for (int i = 1; i < list.size(); i++) {  //skip Iface
+        // qCDebug(appLog) << "PanguVGenerator::getNetworkInfoFromifconfig process ifconfig line:" << list.at(i);
         //filter "lo" 网卡
-        if (list.at(i).contains("lo"))
+        if (list.at(i).contains("lo")) {
+            // qCDebug(appLog) << "PanguVGenerator::getNetworkInfoFromifconfig is lo interface, skip";
             continue;
+        }
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         QStringList line = list.at(i).split(" ", QString::SkipEmptyParts);
 #else
         QStringList line = list.at(i).split(" ", Qt::SkipEmptyParts);
 #endif
         {
-            if(line.size() < 2)
+            if(line.size() < 2) {
+                // qCWarning(appLog) << "PanguVGenerator::getNetworkInfoFromifconfig line size < 2, skip";
                 continue;
-            if(line.at(0).isEmpty())
+            }
+            if(line.at(0).isEmpty()) {
+                // qCWarning(appLog) << "PanguVGenerator::getNetworkInfoFromifconfig line is empty, skip";
                 continue;
+            }
             else
                 ret.append(line.at(0));
         }

--- a/deepin-devicemanager/src/LogConfigRead/LogConfigread.cpp
+++ b/deepin-devicemanager/src/LogConfigRead/LogConfigread.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "LogConfigread.h"
+#include "DDLog.h"
 #include "dtkcore_global.h"
 #include "qglobal.h"
 #include <QLoggingCategory>
@@ -9,6 +10,7 @@
 #include <DConfig>
 
 DCORE_USE_NAMESPACE
+using namespace DDLog;
 
 MLogger::MLogger(QObject *parent)
     : QObject(parent), m_rules(""), m_config(nullptr) {
@@ -24,32 +26,43 @@ MLogger::MLogger(QObject *parent)
   setRules(m_rules);
   // watch dconfig
   connect(m_config, &DConfig::valueChanged, this, [this](const QString &key) {
+    qCDebug(appLog) << "MLogger dconfig value changed, key:" << key;
     if (key == "rules") {
+      qCDebug(appLog) << "MLogger dconfig value changed, set rules";
       setRules(m_config->value(key).toByteArray());
     }
   });
 }
 
-MLogger::~MLogger() { m_config->deleteLater(); }
+MLogger::~MLogger() {
+    qCDebug(appLog) << "MLogger destructor";
+    m_config->deleteLater();
+}
 
 void MLogger::setRules(const QString &rules) {
+  qCDebug(appLog) << "MLogger::setRules, rules:" << rules;
   auto tmpRules = rules;
   m_rules = tmpRules.replace(";", "\n");
   QLoggingCategory::setFilterRules(m_rules);
 }
 
 void MLogger::appendRules(const QString &rules) {
+  qCDebug(appLog) << "MLogger::appendRules, rules:" << rules;
   QString tmpRules = rules;
   tmpRules = tmpRules.replace(";", "\n");
   auto tmplist = tmpRules.split('\n');
   for (int i = 0; i < tmplist.count(); i++)
     if (m_rules.contains(tmplist.at(i))) {
+      qCDebug(appLog) << "MLogger::appendRules, rules already contains:" << tmplist.at(i);
       tmplist.removeAt(i);
       i--;
     }
-  if (tmplist.isEmpty())
+  if (tmplist.isEmpty()) {
+    qCDebug(appLog) << "MLogger::appendRules, no new rules";
     return;
+  }
   m_rules.isEmpty() ? m_rules = tmplist.join("\n")
                     : m_rules += "\n" + tmplist.join("\n");
+  qCDebug(appLog) << "MLogger::appendRules, new rules:" << m_rules;
 }
 

--- a/deepin-devicemanager/src/Page/DeviceWidget.cpp
+++ b/deepin-devicemanager/src/Page/DeviceWidget.cpp
@@ -45,14 +45,17 @@ DeviceWidget::~DeviceWidget()
 {
     qCDebug(appLog) << "DeviceWidget destructor start";
     if (mp_ListView) {
+        qCDebug(appLog) << "DeviceWidget destructor delete list view";
         delete mp_ListView;
         mp_ListView = nullptr;
     }
     if (mp_PageInfo) {
+        qCDebug(appLog) << "DeviceWidget destructor delete page info";
         delete mp_PageInfo;
         mp_PageInfo = nullptr;
     }
     if (m_Layout) {
+        qCDebug(appLog) << "DeviceWidget destructor delete layout";
         delete m_Layout;
         m_Layout = nullptr;
     }
@@ -63,8 +66,10 @@ void DeviceWidget::updateListView(const QList<QPair<QString, QString> > &lst)
 {
     qCDebug(appLog) << "DeviceWidget::updateListView start";
     // 更新左边的列表
-    if (mp_ListView)
+    if (mp_ListView) {
+        qCDebug(appLog) << "DeviceWidget::updateListView update list items";
         mp_ListView->updateListItems(lst);
+    }
     qCDebug(appLog) << "DeviceWidget::updateListView end";
 }
 
@@ -77,8 +82,10 @@ void DeviceWidget::updateDevice(const QString &itemStr, const QList<DeviceBaseIn
     }
 
     // 更新右边的详细内容
-    if (mp_PageInfo)
+    if (mp_PageInfo) {
+        qCDebug(appLog) << "DeviceWidget::updateDevice update table";
         mp_PageInfo->updateTable(itemStr, lst);
+    }
     qCDebug(appLog) << "DeviceWidget::updateDevice end";
 }
 
@@ -91,8 +98,10 @@ void DeviceWidget::updateOverview(const QMap<QString, QString> &map)
     }
 
     // 更新概况
-    if (mp_PageInfo)
+    if (mp_PageInfo) {
+        qCDebug(appLog) << "DeviceWidget::updateOverview update table";
         mp_PageInfo->updateTable(map);
+    }
     qCDebug(appLog) << "DeviceWidget::updateOverview end";
 }
 
@@ -110,12 +119,15 @@ void DeviceWidget::setFontChangeFlag()
 
 void DeviceWidget::clear()
 {
+    qCDebug(appLog) << "DeviceWidget::clear start";
     mp_ListView->clear();
     mp_PageInfo->clear();
+    qCDebug(appLog) << "DeviceWidget::clear end";
 }
 
 void DeviceWidget::slotListViewWidgetItemClicked(const QString &itemStr)
 {
+    qCDebug(appLog) << "DeviceWidget::slotListViewWidgetItemClicked item:" << itemStr;
     // ListView Item 点击
     m_CurItemStr = itemStr;
     emit itemClicked(itemStr);
@@ -123,23 +135,28 @@ void DeviceWidget::slotListViewWidgetItemClicked(const QString &itemStr)
 
 void DeviceWidget::slotUpdateUI()
 {
+    qCDebug(appLog) << "DeviceWidget::slotUpdateUI start";
     // 更新当前UI界面
     emit itemClicked(m_CurItemStr);
 }
 
 void DeviceWidget::resizeEvent(QResizeEvent *event)
 {
+    // qCDebug(appLog) << "DeviceWidget::resizeEvent start";
     DWidget::resizeEvent(event);
     // 获取所有设备类别
     const QList<QPair<QString, QString>> &types = DeviceManager::instance()->getDeviceTypes();
 
     // 根据右侧Listview当前Index获取当前设备类别的
     QString userStr = mp_ListView->currentIndex();
+    // qCDebug(appLog) << "DeviceWidget::resizeEvent current index:" << userStr;
 
     QString deviceType = "";
     foreach (auto iter, types) {
+        // qCDebug(appLog) << "DeviceWidget::resizeEvent check type:" << iter.second;
         if (iter.second.contains(userStr)) {
             deviceType = iter.first;
+            // qCDebug(appLog) << "DeviceWidget::resizeEvent found device type:" << deviceType;
             break;
         }
     }
@@ -152,21 +169,28 @@ void DeviceWidget::resizeEvent(QResizeEvent *event)
         // 更新Overview界面
         QMap<QString, QString> overviewMap = DeviceManager::instance()->getDeviceOverview();
         mp_PageInfo->updateTable(overviewMap);
+        qCDebug(appLog) << "DeviceWidget::resizeEvent update overview table";
     }
 
     // 更新设备信息界面
     if (lst.size() == 1) {
+        qCDebug(appLog) << "DeviceWidget::resizeEvent update single device table";
         mp_PageInfo->updateTable(deviceType, lst);
     } else if (lst.size() > 1) {
+        qCDebug(appLog) << "DeviceWidget::resizeEvent update multi device table";
         // 判断是否是BIOS界面
         DeviceBios *bios = dynamic_cast<DeviceBios *>(lst[0]);
-        if (bios)
+        if (bios) {
+            qCDebug(appLog) << "DeviceWidget::resizeEvent is bios device, update table";
             mp_PageInfo->updateTable(deviceType, lst);
+        }
     }
+    qCDebug(appLog) << "DeviceWidget::resizeEvent end";
 }
 
 void DeviceWidget::initWidgets()
 {
+    qCDebug(appLog) << "DeviceWidget::initWidgets start";
     // 初始化页面布局
     m_Layout = new QHBoxLayout();
     m_Layout->setContentsMargins(0, 0, 0, 0);

--- a/deepin-devicemanager/src/Page/PageDetail.cpp
+++ b/deepin-devicemanager/src/Page/PageDetail.cpp
@@ -39,19 +39,25 @@ using namespace DDLog;
 DetailButton::DetailButton(const QString &txt)
     : DCommandLinkButton(txt)
 {
+    qCDebug(appLog) << "DetailButton constructor";
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
 }
 
 void DetailButton::updateText()
 {
-    if (this->text() == tr("More"))
+    qCDebug(appLog) << "DetailButton::updateText start";
+    if (this->text() == tr("More")) {
+        qCDebug(appLog) << "DetailButton::updateText set text to Collapse";
         this->setText(tr("Collapse"));
-    else
+    } else {
+        qCDebug(appLog) << "DetailButton::updateText set text to More";
         this->setText(tr("More"));
+    }
 }
 
 void DetailButton::paintEvent(QPaintEvent *e)
 {
+    qCDebug(appLog) << "DetailButton::paintEvent";
     QPainter painter(this);
     painter.save();
     painter.setRenderHints(QPainter::Antialiasing, true);
@@ -66,10 +72,12 @@ void DetailButton::paintEvent(QPaintEvent *e)
     // 获取窗口当前的状态,激活，禁用，未激活
     DPalette::ColorGroup cg;
     DWidget *wid = DApplication::activeWindow();
-    if (wid /* && wid == this*/)
+    if (wid /* && wid == this*/) {
         cg = DPalette::Active;
-    else
+    } else {
+        qCDebug(appLog) << "DetailButton::paintEvent, inactive window";
         cg = DPalette::Inactive;
+    }
 
     // 开始绘制边框 *********************************************************
     // 计算绘制区域
@@ -83,12 +91,14 @@ void DetailButton::paintEvent(QPaintEvent *e)
 DetailSeperator::DetailSeperator(DWidget *parent)
     : DWidget(parent)
 {
+    qCDebug(appLog) << "DetailSeperator constructor";
     // 设置分隔符高度一个像素
     setFixedHeight(LINE_WIDTH);
 }
 
 void DetailSeperator::paintEvent(QPaintEvent *e)
 {
+    // qCDebug(appLog) << "DetailSeperator::paintEvent";
     QPainter painter(this);
     painter.save();
     painter.setRenderHints(QPainter::Antialiasing, true);
@@ -106,10 +116,13 @@ void DetailSeperator::paintEvent(QPaintEvent *e)
     // 获取窗口当前的状态,激活，禁用，未激活
     DPalette::ColorGroup cg;
     DWidget *wid = DApplication::activeWindow();
-    if (wid /* && wid == this*/)
+    if (wid /* && wid == this*/) {
+        // qCDebug(appLog) << "DetailSeperator::paintEvent, active window";
         cg = DPalette::Active;
-    else
+    } else {
+        // qCDebug(appLog) << "DetailSeperator::paintEvent, inactive window";
         cg = DPalette::Inactive;
+    }
 
     // 清除背景色颜色
     QBrush clearBrush(palette.color(cg, DPalette::Base));
@@ -131,11 +144,12 @@ void DetailSeperator::paintEvent(QPaintEvent *e)
 ScrollAreaWidget::ScrollAreaWidget(DWidget *parent)
     : DWidget(parent)
 {
-
+    // qCDebug(appLog) << "ScrollAreaWidget constructor";
 }
 
 void ScrollAreaWidget::paintEvent(QPaintEvent *e)
 {
+    // qCDebug(appLog) << "ScrollAreaWidget::paintEvent";
     QPainter painter(this);
     painter.save();
     painter.setRenderHints(QPainter::Antialiasing, true);
@@ -150,10 +164,13 @@ void ScrollAreaWidget::paintEvent(QPaintEvent *e)
     // 获取窗口当前的状态,激活，禁用，未激活
     DPalette::ColorGroup cg;
     DWidget *wid = DApplication::activeWindow();
-    if (wid /* && wid == this*/)
+    if (wid /* && wid == this*/) {
+        // qCDebug(appLog) << "ScrollAreaWidget::paintEvent, active window";
         cg = DPalette::Active;
-    else
+    } else {
+        // qCDebug(appLog) << "ScrollAreaWidget::paintEvent, inactive window";
         cg = DPalette::Inactive;
+    }
 
     // 清除背景色颜色
     QBrush clearBrush(palette.color(cg, DPalette::Base));
@@ -198,7 +215,11 @@ void PageDetail::showDeviceInfo(const QList<DeviceBaseInfo *> &lstInfo)
 
     // Create widgets for showing device info
     foreach (auto device, lstInfo) {
-        if (!device) {continue;}
+        // qCDebug(appLog) << "PageDetail::showDeviceInfo process device:" << device->name();
+        if (!device) {
+            // qCDebug(appLog) << "PageDetail::showDeviceInfo device is null, continue";
+            continue;
+        }
         TextBrowser *txtBrowser = new TextBrowser(this);
         txtBrowser->showDeviceInfo(device);
         connect(txtBrowser, &TextBrowser::refreshInfo, this, &PageDetail::refreshInfo);
@@ -206,8 +227,10 @@ void PageDetail::showDeviceInfo(const QList<DeviceBaseInfo *> &lstInfo)
         connect(txtBrowser, &TextBrowser::copyAllInfo, this, &PageDetail::slotCopyAllInfo);
         addWidgets(txtBrowser, device->enable() && device->available() && !device->getOtherAttribs().isEmpty());
         // 当添加到最后一个设备详细信息时，隐藏分隔符
-        if (device == lstInfo.last())
+        if (device == lstInfo.last()) {
+            // qCDebug(appLog) << "PageDetail::showDeviceInfo is last device, hide seperator";
             m_ListDetailSeperator[lstInfo.size() - 1]->setVisible(false);
+        }
     }
     // 刷新展示页面时,滚动条还原
     mp_ScrollArea->verticalScrollBar()->setValue(0);
@@ -218,20 +241,24 @@ void PageDetail::showDeviceInfo(const QList<DeviceBaseInfo *> &lstInfo)
 
 void PageDetail::showInfoOfNum(int index)
 {
+    qCDebug(appLog) << "PageDetail::showInfoOfNum start, index:" << index;
     if (index >= m_ListHlayout.size()
             || index >= m_ListTextBrowser.size()
             || index >= m_ListDetailButton.size()
             || index >= m_ListDetailSeperator.size()) {
+        qCWarning(appLog) << "PageDetail::showInfoOfNum index out of range";
         return;
     }
     int value = 0;
     for (int i = 0; i <= index - 1; i++) {
+        // qCDebug(appLog) << "PageDetail::showInfoOfNum calculate scroll value, i:" << i;
         value += m_ListTextBrowser[i]->height();
         value += m_ListDetailButton[i]->height();
         value += m_ListDetailSeperator[i]->height();
         value += SPACE_HEIGHT;
     }
     mp_ScrollArea->verticalScrollBar()->setValue(value);
+    qCDebug(appLog) << "PageDetail::showInfoOfNum end, value:" << value;
 }
 
 EnableDeviceStatus PageDetail::enableDevice(int row, bool enable)
@@ -244,8 +271,10 @@ EnableDeviceStatus PageDetail::enableDevice(int row, bool enable)
 
     // 设置 TextBrowser 可用
     TextBrowser *browser = m_ListTextBrowser.at(row);
-    if (!browser)
+    if (!browser) {
+        qCWarning(appLog) << "PageDetail::enableDevice browser is null";
         return EDS_Cancle;
+    }
 
     return browser->setDeviceEnabled(enable);
 }
@@ -267,6 +296,7 @@ void PageDetail::setWakeupMachine(int row, bool wakeup)
 
 void PageDetail::paintEvent(QPaintEvent *e)
 {
+    // qCDebug(appLog) << "PageDetail::paintEvent";
     QPainter painter(this);
     painter.save();
     painter.setRenderHints(QPainter::Antialiasing, true);
@@ -284,10 +314,13 @@ void PageDetail::paintEvent(QPaintEvent *e)
     // 获取窗口当前的状态,激活，禁用，未激活
     DPalette::ColorGroup cg;
     DWidget *wid = DApplication::activeWindow();
-    if (wid /* && wid == this*/)
+    if (wid /* && wid == this*/) {
+        qCDebug(appLog) << "PageDetail::paintEvent, active window";
         cg = DPalette::Active;
-    else
+    } else {
+        qCDebug(appLog) << "PageDetail::paintEvent, inactive window";
         cg = DPalette::Inactive;
+    }
 
     // 开始绘制边框 *********************************************************
     // 计算绘制区域
@@ -302,11 +335,13 @@ void PageDetail::paintEvent(QPaintEvent *e)
 
 void PageDetail::resizeEvent(QResizeEvent *event)
 {
+    // qCDebug(appLog) << "PageDetail::resizeEvent";
     DWidget::resizeEvent(event);
 }
 
 void PageDetail::addWidgets(TextBrowser *widget, bool enable)
 {
+    qCDebug(appLog) << "PageDetail::addWidgets start, enable:" << enable;
     // 添加 textBrowser
     if (widget != nullptr && m_ListTextBrowser.size() != 0)
         mp_ScrollAreaLayout->addSpacing(SEPERATOR_HEIGHT);
@@ -336,10 +371,12 @@ void PageDetail::addWidgets(TextBrowser *widget, bool enable)
     m_ListHlayout.append(hLayout);
     m_ListDetailButton.append(button);
     m_ListDetailSeperator.append(seperator);
+    qCDebug(appLog) << "PageDetail::addWidgets end";
 }
 
 void PageDetail::clearWidget()
 {
+    qCDebug(appLog) << "PageDetail::clearWidget start";
     QList<TextBrowser *> listTextBrowser = m_ListTextBrowser;
     m_ListTextBrowser.clear();
     //  清空TextBrowser
@@ -386,13 +423,17 @@ void PageDetail::clearWidget()
     mp_ScrollAreaLayout->setContentsMargins(0, 0, 0, 0);
     mp_ScrollAreaLayout->setSpacing(0);
     mp_ScrollWidget->setLayout(mp_ScrollAreaLayout);
+    qCDebug(appLog) << "PageDetail::clearWidget end";
 }
 
 void PageDetail::slotBtnClicked()
 {
+    qCDebug(appLog) << "PageDetail::slotBtnClicked start";
     DetailButton *button = qobject_cast<DetailButton *>(sender());
-    if (!button)
+    if (!button) {
+        qCWarning(appLog) << "PageDetail::slotBtnClicked, invalid button";
         return;
+    }
     int index = 0;
     foreach (DetailButton *b, m_ListDetailButton) {
         if (button == b)

--- a/deepin-devicemanager/src/Page/PageDriverBackupInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverBackupInfo.cpp
@@ -31,6 +31,7 @@ PageDriverBackupInfo::PageDriverBackupInfo(QWidget *parent)
     connect(mp_ViewBackable, &PageDriverTableView::itemChecked, this, &PageDriverBackupInfo::itemChecked);
     connect(mp_HeadWidget, &DetectedStatusWidget::backupAll, this, &PageDriverBackupInfo::backupAll);
     connect(mp_HeadWidget, &DetectedStatusWidget::backupAll, this, [=](){
+        qCDebug(appLog) << "PageDriverBackupInfo backupAll triggered, set checked cb disnable";
         mp_ViewBackable->setCheckedCBDisnable();
     });
     connect(mp_HeadWidget, &DetectedStatusWidget::cancelClicked, this, &PageDriverBackupInfo::undoBackup);
@@ -39,6 +40,7 @@ PageDriverBackupInfo::PageDriverBackupInfo(QWidget *parent)
 
 void PageDriverBackupInfo::initUI()
 {
+    qCDebug(appLog) << "PageDriverBackupInfo::initUI start";
     this->setLineWidth(0);
     initTable();
 
@@ -89,10 +91,12 @@ void PageDriverBackupInfo::initUI()
     mainLayout->addSpacing(16);
     mainLayout->addWidget(area);
     this->setLayout(mainLayout);
+    qCDebug(appLog) << "PageDriverBackupInfo::initUI end";
 }
 
 void PageDriverBackupInfo::initTable()
 {
+    qCDebug(appLog) << "PageDriverBackupInfo::initTable start";
     mp_ViewBackable->initHeaderView(QStringList() << "" << tr("Name")
                                     << tr("Current Version") << tr("Driver Platform Version")
                                     << tr("Status") << tr("Action"), true);
@@ -108,6 +112,7 @@ void PageDriverBackupInfo::initTable()
     mp_ViewBackedUp->initHeaderView(QStringList() << tr("Name") << tr("Current Version") << tr("Driver Platform Version"));
     mp_ViewBackedUp->setColumnWidth(0, 418);
     mp_ViewBackedUp->setColumnWidth(1, 185);
+    qCDebug(appLog) << "PageDriverBackupInfo::initTable end";
 }
 
 void PageDriverBackupInfo::addDriverInfoToTableView(DriverInfo *info, int index)
@@ -124,6 +129,7 @@ void PageDriverBackupInfo::addDriverInfoToTableView(DriverInfo *info, int index)
         // 设置CheckBtn
         DriverCheckItem *cbItem = new DriverCheckItem(this);
         connect(cbItem, &DriverCheckItem::sigChecked, view, [index, view](bool checked) {
+            qCDebug(appLog) << "PageDriverBackupInfo check item " << index << " checked:" << checked;
             Q_UNUSED(index)
             view->setHeaderCbStatus(checked);
         });
@@ -158,6 +164,7 @@ void PageDriverBackupInfo::addDriverInfoToTableView(DriverInfo *info, int index)
     }
 
     if (!info->debBackupVersion().isEmpty()) {
+        qCDebug(appLog) << "Driver is backed up, version:" << info->debBackupVersion();
         view = mp_ViewBackedUp;
         view->appendRowItems(3);
 
@@ -194,23 +201,29 @@ void PageDriverBackupInfo::showTables(int backableLength, int backedupLength)
 
     // 显示表头显示的内容
     if (backableLength == 0) {
+        qCDebug(appLog) << "PageDriverBackupInfo::showTables no backable driver";
         mp_HeadWidget->setNoBackupDriverUI(backableLength, backedupLength);
     } else {
+        qCDebug(appLog) << "PageDriverBackupInfo::showTables has backable driver";
         mp_HeadWidget->setBackableDriverUI(backableLength, backedupLength);
     }
 }
 
 void PageDriverBackupInfo::getCheckedDriverIndex(QList<int> &lstIndex)
 {
+    qCDebug(appLog) << "PageDriverBackupInfo::getCheckedDriverIndex start";
     mp_ViewBackable->getCheckedDriverIndex(lstIndex);
+    qCDebug(appLog) << "PageDriverBackupInfo::getCheckedDriverIndex end, count:" << lstIndex.size();
 }
 
 void PageDriverBackupInfo::clearAllData()
 {
+    qCDebug(appLog) << "PageDriverBackupInfo::clearAllData start";
     mp_ViewBackable->clear();
     mp_ViewBackedUp->clear();
 
     initTable();
+    qCDebug(appLog) << "PageDriverBackupInfo::clearAllData end";
 }
 
 void PageDriverBackupInfo::updateItemStatus(int index, Status status)
@@ -225,10 +238,12 @@ void PageDriverBackupInfo::updateItemStatus(int index, Status status)
 
 void PageDriverBackupInfo::setCheckedCBDisnable()
 {
+    qCDebug(appLog) << "PageDriverBackupInfo::setCheckedCBDisnable";
     mp_ViewBackable->setCheckedCBDisnable();
 }
 
 void PageDriverBackupInfo::setHeaderCbEnable(bool enable)
 {
+    qCDebug(appLog) << "PageDriverBackupInfo::setHeaderCbEnable, enable:" << enable;
     mp_ViewBackable->setHeaderCbEnable(enable);
 }

--- a/deepin-devicemanager/src/Page/PageDriverInstallInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverInstallInfo.cpp
@@ -35,6 +35,7 @@ PageDriverInstallInfo::PageDriverInstallInfo(QWidget *parent)
     connect(mp_ViewCanUpdate, &PageDriverTableView::itemChecked, this, &PageDriverInstallInfo::itemChecked);
     connect(mp_HeadWidget, &DetectedStatusWidget::installAll, this, &PageDriverInstallInfo::installAll);
     connect(mp_HeadWidget, &DetectedStatusWidget::installAll, this, [=](){
+        qCDebug(appLog) << "PageDriverInstallInfo installAll triggered, set checked cb disnable";
         // 安装过程中，所有已经选中的勾选框置灰
         mp_ViewNotInstall->setCheckedCBDisnable();
         mp_ViewCanUpdate->setCheckedCBDisnable();
@@ -45,6 +46,7 @@ PageDriverInstallInfo::PageDriverInstallInfo(QWidget *parent)
 
 void PageDriverInstallInfo::initUI()
 {
+    qCDebug(appLog) << "PageDriverInstallInfo::initUI start";
     this->setLineWidth(0);
     initTable();
 
@@ -97,10 +99,12 @@ void PageDriverInstallInfo::initUI()
     vLaout->addSpacing(16);
     vLaout->addWidget(area);
     this->setLayout(vLaout);
+    qCDebug(appLog) << "PageDriverInstallInfo::initUI end";
 }
 
 void PageDriverInstallInfo::initTable()
 {
+    qCDebug(appLog) << "PageDriverInstallInfo::initTable start";
     // 设置列宽
     mp_ViewNotInstall->initHeaderView(QStringList() << ""
                                       << tr("Device Name")
@@ -131,6 +135,7 @@ void PageDriverInstallInfo::initTable()
 
     mp_AllDriverIsNew->initHeaderView(QStringList() << tr("Device Name") << tr("Current Version"));
     mp_AllDriverIsNew->setColumnWidth(0, 418);
+    qCDebug(appLog) << "PageDriverInstallInfo::initTable end";
 }
 
 void PageDriverInstallInfo::addDriverInfoToTableView(DriverInfo *info, int index)
@@ -138,12 +143,15 @@ void PageDriverInstallInfo::addDriverInfoToTableView(DriverInfo *info, int index
     qCDebug(appLog) << "Adding driver info to table view, name:" << info->name() << "index:" << index << "status:" << info->status();
     PageDriverTableView *view = nullptr;
     if (ST_NOT_INSTALL == info->status()) {
+        qCDebug(appLog) << "Driver not installed";
         view = mp_ViewNotInstall;
         view->appendRowItems(6);
     } else if (ST_CAN_UPDATE == info->status()) {
+        qCDebug(appLog) << "Driver can be updated";
         view = mp_ViewCanUpdate;
         view->appendRowItems(6);
     } else if (ST_DRIVER_IS_NEW == info->status()) {
+        qCDebug(appLog) << "Driver is new";
         view = mp_AllDriverIsNew;
         view->appendRowItems(2);
     } else {
@@ -154,10 +162,11 @@ void PageDriverInstallInfo::addDriverInfoToTableView(DriverInfo *info, int index
     int row = view->model()->rowCount() - 1;
 
     if (view != mp_AllDriverIsNew) {
-
+        qCDebug(appLog) << "Driver is not new, add check box and buttons";
         // 设置CheckBtn
         DriverCheckItem *cbItem = new DriverCheckItem(this);
         connect(cbItem, &DriverCheckItem::sigChecked, view, [index, view](bool checked) {
+            qCDebug(appLog) << "PageDriverInstallInfo check item " << index << " checked:" << checked;
             Q_UNUSED(index)
             view->setHeaderCbStatus(checked);
         });
@@ -186,6 +195,7 @@ void PageDriverInstallInfo::addDriverInfoToTableView(DriverInfo *info, int index
         DriverOperationItem *operateItem = new DriverOperationItem(this, ST_NOT_INSTALL == info->status() ? DriverOperationItem::INSTALL : DriverOperationItem::UPDATE);
         view->setWidget(row, 5, operateItem);
     } else {
+        qCDebug(appLog) << "Driver is new, just show info";
         // 设置设备信息
         DriverNameItem *nameItem = new DriverNameItem(this, info->type());
         nameItem->setName(info->name());
@@ -200,6 +210,7 @@ void PageDriverInstallInfo::addDriverInfoToTableView(DriverInfo *info, int index
 
 void PageDriverInstallInfo::addCurDriverInfo(DriverInfo *info)
 {
+    qCDebug(appLog) << "PageDriverInstallInfo::addCurDriverInfo, name:" << info->name();
     mp_AllDriverIsNew->appendRowItems(2);
 
     DriverNameItem *nameItem = new DriverNameItem(this, info->type());
@@ -231,25 +242,31 @@ void PageDriverInstallInfo::showTables(int installLength, int updateLength, int 
     // 显示表头显示的内容
     const QMap<QString, QString> &overviewMap = DeviceManager::instance()->getDeviceOverview();
     if (installLength == 0 && updateLength == 0) {
+        qCDebug(appLog) << "No driver to install or update";
         mp_HeadWidget->setNoUpdateDriverUI(overviewMap["Overview"]);
     } else {
+        qCDebug(appLog) << "Driver to install or update";
         mp_HeadWidget->setDetectFinishUI(QString::number(installLength + updateLength), overviewMap["Overview"], installLength != 0);
     }
 }
 
 void PageDriverInstallInfo::getCheckedDriverIndex(QList<int> &lstIndex)
 {
+    qCDebug(appLog) << "PageDriverInstallInfo::getCheckedDriverIndex start";
     mp_ViewNotInstall->getCheckedDriverIndex(lstIndex);
     mp_ViewCanUpdate->getCheckedDriverIndex(lstIndex);
+    qCDebug(appLog) << "PageDriverInstallInfo::getCheckedDriverIndex end, count:" << lstIndex.size();
 }
 
 void PageDriverInstallInfo::clearAllData()
 {
+    qCDebug(appLog) << "PageDriverInstallInfo::clearAllData start";
     mp_ViewCanUpdate->clear();
     mp_ViewNotInstall->clear();
     mp_AllDriverIsNew->clear();
 
     initTable();
+    qCDebug(appLog) << "PageDriverInstallInfo::clearAllData end";
 }
 
 void PageDriverInstallInfo::updateItemStatus(int index, Status status, QString errS)
@@ -270,17 +287,20 @@ void PageDriverInstallInfo::setCheckedCBDisnable()
 
 void PageDriverInstallInfo::setHeaderCbEnable(bool enable)
 {
+    qCDebug(appLog) << "PageDriverInstallInfo::setHeaderCbEnable, enable:" << enable;
     mp_ViewNotInstall->setHeaderCbEnable(enable);
     mp_ViewCanUpdate->setHeaderCbEnable(enable);
 }
 void PageDriverInstallInfo::slotDownloadProgressChanged(DriverType type, QString size, QStringList msg)
 {
+    qCDebug(appLog) << "PageDriverInstallInfo::slotDownloadProgressChanged, type:" << type << "size:" << size;
     // 将下载过程时时更新到表格上方的状态里面 qCInfo(appLog) << "Download ********** " << msg[0] << " , " << msg[1] << " , " << msg[2];
     mp_HeadWidget->setDownloadUI(type, msg[2], msg[1], size, msg[0].toInt());
 }
 
 void PageDriverInstallInfo::slotDownloadFinished(int index, Status status)
 {
+    // qCDebug(appLog) << "Download finished, index:" << index << "status:" << status;
     mp_ViewCanUpdate->setItemStatus(index, status);
     mp_ViewNotInstall->setItemStatus(index, status);
 }

--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -74,6 +74,7 @@ PageDriverManager::PageDriverManager(DWidget *parent)
     connect(DBusDriverInterface::getInstance(), &DBusDriverInterface::installProgressDetail, this, &PageDriverManager::slotRestoreProgress);//还原
     connect(DBusDriverInterface::getInstance(), &DBusDriverInterface::installFinished, this, &PageDriverManager::slotRestoreFinished);
     connect(DBusDriverInterface::getInstance(), &DBusDriverInterface::backupProgressFinished, this, [=](bool success){
+        qCDebug(appLog) << "PageDriverManager backup progress finished, success:" << success;
         if (success) {
             mp_BackupThread->setStatus(DriverBackupThread::Success);
         } else {
@@ -97,6 +98,7 @@ PageDriverManager::PageDriverManager(DWidget *parent)
     connect(mp_DriverBackupInfoPage, &PageDriverBackupInfo::redetected, this, &PageDriverManager::startScanning);
 
     connect(mp_DriverRestoreInfoPage, &PageDriverRestoreInfo::gotoBackup, this, [=](){
+        qCDebug(appLog) << "PageDriverManager gotoBackup triggered";
         mp_ListView->setCurType(tr("Driver Backup"));
         mp_ListView->itemClicked(tr("Driver Backup"));
     });
@@ -145,11 +147,13 @@ PageDriverManager::~PageDriverManager()
 
 void PageDriverManager::addDriverInfo(DriverInfo *info)
 {
+    qCDebug(appLog) << "PageDriverManager::addDriverInfo, name:" << info->name();
     m_ListDriverInfo.append(info);
 }
 
 bool PageDriverManager::isFirstScan()
 {
+    qCDebug(appLog) << "PageDriverManager::isFirstScan, isFirstScan:" << m_IsFirstScan << "isScanning:" << m_Scanning;
     if (m_IsFirstScan)
         return true;
     if (m_Scanning || networkIsOnline())
@@ -159,27 +163,32 @@ bool PageDriverManager::isFirstScan()
 
 bool PageDriverManager::isInstalling()
 {
+    qCDebug(appLog) << "PageDriverManager::isInstalling, isInstalling:" << (mp_CurDriverInfo != nullptr);
     return mp_CurDriverInfo != nullptr;
 }
 
 bool PageDriverManager::isBackingup()
 {
+    qCDebug(appLog) << "PageDriverManager::isBackingup, isBackingup:" << (mp_CurBackupDriverInfo != nullptr);
     return mp_CurBackupDriverInfo != nullptr;
 
 }
 
 bool PageDriverManager::isRestoring()
 {
+    qCDebug(appLog) << "PageDriverManager::isRestoring, isRestoring:" << (mp_CurRestoreDriverInfo != nullptr);
     return mp_CurRestoreDriverInfo != nullptr;
 }
 
 bool PageDriverManager::isScanning()
 {
+    qCDebug(appLog) << "PageDriverManager::isScanning, isScanning:" << m_Scanning;
     return m_Scanning;
 }
 
 void PageDriverManager::updateListView(const QList<QPair<QString, QString> > &lst)
 {
+    qCDebug(appLog) << "PageDriverManager::updateListView, count:" << lst.size();
     // 更新左边的列表
     if (mp_ListView)
         mp_ListView->updateListItems(lst);
@@ -196,6 +205,7 @@ void PageDriverManager::scanDriverInfo()
     m_Scanning = true;
     // 如果在安装、备份、还原过程中则不扫描
     if (mp_CurDriverInfo || mp_CurBackupDriverInfo || mp_CurRestoreDriverInfo) {
+        qCDebug(appLog) << "Scan skipped - operation already in progress";
         return;
     }
 
@@ -213,6 +223,7 @@ void PageDriverManager::scanDriverInfo()
 
 void PageDriverManager::slotDriverOperationClicked(int index, int itemIndex, DriverOperationItem::Mode mode)
 {
+    qCDebug(appLog) << "PageDriverManager::slotDriverOperationClicked, index:" << index << "itemIndex:" << itemIndex << "mode:" << mode;
     mp_DriverInstallInfoPage->headWidget()->setReDetectEnable(false);
     mp_DriverBackupInfoPage->headWidget()->setReDetectEnable(false);
     mp_DriverRestoreInfoPage->headWidget()->setReDetectEnable(false);
@@ -220,28 +231,35 @@ void PageDriverManager::slotDriverOperationClicked(int index, int itemIndex, Dri
     switch (mode) {
     case DriverOperationItem::INSTALL:
     case DriverOperationItem::UPDATE:
+        qCDebug(appLog) << "PageDriverManager::slotDriverOperationClicked install/update driver";
         // 如果已经在安装过程中，则直接添加到list
         // 如果不在安装过程中则需要安装
         addToDriverIndex(index);
         if (! mp_CurDriverInfo) {
+            qCDebug(appLog) << "Not in installation process, start installing next driver.";
             installNextDriver();
         }
         break;
 
     case DriverOperationItem::BACKUP:
         ///驱动备份
+        qCDebug(appLog) << "PageDriverManager::slotDriverOperationClicked backup driver";
         addToBackupIndex(index);
         if (!mp_CurBackupDriverInfo) {
+            qCDebug(appLog) << "Not in backup process, start backing up next driver.";
             backupNextDriver();
         }
         break;
 
     case DriverOperationItem::RESTORE:
         ///驱动还原
+        qCDebug(appLog) << "PageDriverManager::slotDriverOperationClicked restore driver";
         mp_CurRestoreDriverInfo = m_ListDriverInfo[index];
+        qCDebug(appLog) << "Restoring driver:" << mp_CurRestoreDriverInfo->name() << "from" << mp_CurRestoreDriverInfo->backupFileName();
         DBusDriverInterface::getInstance()->installDriver(mp_CurRestoreDriverInfo->backupFileName());
         //将其它项置灰
         for (int restorableIndex : m_ListRestorableIndex) {
+            qCDebug(appLog) << "Disabling item at index:" << restorableIndex;
             mp_DriverRestoreInfoPage->setItemOperationEnable(restorableIndex, false);
         }
 
@@ -252,6 +270,7 @@ void PageDriverManager::slotDriverOperationClicked(int index, int itemIndex, Dri
 
 void PageDriverManager::slotItemCheckedClicked(int index, bool checked)
 {
+    qCDebug(appLog) << "PageDriverManager::slotItemCheckedClicked, index:" << index << "checked:" << checked;
     if (!checked) {
         // 取消选中则从list中删除
         removeFromDriverIndex(index);
@@ -260,6 +279,7 @@ void PageDriverManager::slotItemCheckedClicked(int index, bool checked)
         // 如果在安装过程中：1. 添加到list  2. 将item置灰
         addToDriverIndex(index);
         if (mp_CurDriverInfo) {
+            qCDebug(appLog) << "Installation in progress, disabling checkbox.";
             mp_DriverInstallInfoPage->setCheckedCBDisnable();
         }
     }
@@ -267,6 +287,7 @@ void PageDriverManager::slotItemCheckedClicked(int index, bool checked)
 
 void PageDriverManager::slotBackupItemCheckedClicked(int index, bool checked)
 {
+    qCDebug(appLog) << "PageDriverManager::slotBackupItemCheckedClicked, index:" << index << "checked:" << checked;
     if (!checked) {
         // 取消选中则从list中删除
         removeFromBackupIndex(index);
@@ -275,6 +296,7 @@ void PageDriverManager::slotBackupItemCheckedClicked(int index, bool checked)
         // 如果在备份过程中：1. 添加到list  2. 将item置灰
         addToBackupIndex(index);
         if (mp_CurBackupDriverInfo) {
+            qCDebug(appLog) << "Backup in progress, disabling checkbox.";
             mp_DriverBackupInfoPage->setCheckedCBDisnable();
         }
     }
@@ -282,8 +304,11 @@ void PageDriverManager::slotBackupItemCheckedClicked(int index, bool checked)
 
 void PageDriverManager::slotDownloadProgressChanged(QStringList msg)
 {
-    if (! mp_CurDriverInfo)
+    qCDebug(appLog) << "PageDriverManager::slotDownloadProgressChanged, msg:" << msg;
+    if (! mp_CurDriverInfo) {
+        qCDebug(appLog) << "No driver info, return.";
         return;
+    }
     // 将下载过程时时更新到表格上方的状态里面 qCInfo(appLog) << "Download ********** " << msg[0] << " , " << msg[1] << " , " << msg[2];
     mp_DriverInstallInfoPage->headWidget()->setDownloadUI(mp_CurDriverInfo->type(), msg[2], msg[1], mp_CurDriverInfo->size(), msg[0].toInt());
     // 设置表格下载中的状态
@@ -291,25 +316,35 @@ void PageDriverManager::slotDownloadProgressChanged(QStringList msg)
 
 void PageDriverManager::slotDownloadFinished()
 {
-    if (! mp_CurDriverInfo)
+    qCDebug(appLog) << "PageDriverManager::slotDownloadFinished";
+    if (! mp_CurDriverInfo) {
+        qCDebug(appLog) << "No driver info, return.";
         return;
+    }
 
     mp_DriverInstallInfoPage->slotDownloadFinished(m_CurIndex, mp_CurDriverInfo->status());
 }
 
 void PageDriverManager::slotInstallProgressChanged(int progress)
 {
-    if (! mp_CurDriverInfo)
+    qCDebug(appLog) << "PageDriverManager::slotInstallProgressChanged, progress:" << progress;
+    if (! mp_CurDriverInfo) {
+        qCDebug(appLog) << "No driver info, return.";
         return;
+    }
     // 当进度小于50时，apt处于下载过程
     if (progress <= 50) {
-        if (progress > 45)
+        if (progress > 45) {
+            qCDebug(appLog) << "Progress > 45, setting status to ST_INSTALL";
             mp_CurDriverInfo->m_Status = ST_INSTALL;
+        }
         QString speed = "";
         QString size = "";
         getDownloadInfo(progress * 2, mp_CurDriverInfo->m_Byte, speed, size);
+        qCDebug(appLog) << "Updating download UI, speed:" << speed << "size:" << size;
         mp_DriverInstallInfoPage->headWidget()->setDownloadUI(mp_CurDriverInfo->type(), speed, size, mp_CurDriverInfo->size(), progress * 2);
     } else {
+        qCDebug(appLog) << "Progress > 50, setting status to ST_INSTALL and updating install UI";
         mp_CurDriverInfo->m_Status = ST_INSTALL;
         // 设置表头状态
         mp_DriverInstallInfoPage->headWidget()->setInstallUI(mp_CurDriverInfo->type(), mp_CurDriverInfo->name(), (progress - 50) * 2);
@@ -321,6 +356,7 @@ void PageDriverManager::slotInstallProgressChanged(int progress)
 
 void PageDriverManager::slotInstallProgressFinished(bool bsuccess, int err)
 {
+    qCDebug(appLog) << "PageDriverManager::slotInstallProgressFinished, success:" << bsuccess << "err:" << err;
     static int successNum = 0;
     static int failedNum = 0;
     if (! mp_CurDriverInfo)
@@ -329,10 +365,13 @@ void PageDriverManager::slotInstallProgressFinished(bool bsuccess, int err)
     // 成功
     if (bsuccess) {
         successNum += 1;
+        qCDebug(appLog) << "Installation successful for" << mp_CurDriverInfo->name() << ", success count:" << successNum;
         m_ListUpdateIndex.removeAt(m_ListUpdateIndex.indexOf(m_CurIndex));
     } else { // 失败
+        qCDebug(appLog) << "Installation failed for" << mp_CurDriverInfo->name() << ", error code:" << err;
         // 通知网络错误
         if (err == EC_NOTIFY_NETWORK) {
+            qCWarning(appLog) << "Network error notified, updating UI.";
             mp_DriverInstallInfoPage->headWidget()->setNetworkErrorUI("0.00MB/s", 0);
             return;
         }
@@ -345,6 +384,7 @@ void PageDriverManager::slotInstallProgressFinished(bool bsuccess, int err)
 
         // 网络错误
         if (err == EC_NETWORK) {
+            qCWarning(appLog) << "Network error, failing all pending installations.";
             failAllIndex();
             failedNum += m_ListDriverIndex.size();
             m_ListDriverIndex.clear();
@@ -364,18 +404,24 @@ void PageDriverManager::slotInstallProgressFinished(bool bsuccess, int err)
     // 如果有其它驱动，则显示安装内容
     if (m_ListDriverIndex.size() > 0) {
         sleep(1);
+        qCDebug(appLog) << "More drivers to install, proceeding to next one.";
         installNextDriver();
     } else {
+        qCDebug(appLog) << "All installations finished.";
         // 设置头部显示效果
         if (successNum > 0) {
+            qCDebug(appLog) << "Setting install success UI.";
             mp_DriverInstallInfoPage->headWidget()->setInstallSuccessUI(QString::number(successNum), QString::number(failedNum));
         } else {
+            qCDebug(appLog) << "Setting install failed UI.";
             mp_DriverInstallInfoPage->headWidget()->setInstallFailedUI();
         }
 
         if (m_ListUpdateIndex.isEmpty()) {
+            qCDebug(appLog) << "No updatable drivers, disabling header checkbox.";
             mp_DriverInstallInfoPage->setHeaderCbEnable(false);
         } else {
+            qCDebug(appLog) << "Updatable drivers remaining, enabling header checkbox.";
             mp_DriverInstallInfoPage->setHeaderCbEnable(true);
         }
         mp_DriverInstallInfoPage->headWidget()->setReDetectEnable(true);
@@ -387,6 +433,7 @@ void PageDriverManager::slotInstallProgressFinished(bool bsuccess, int err)
         m_CancelIndex = -1;
         successNum = 0;
         failedNum = 0;
+        qCDebug(appLog) << "Resetting installation state variables.";
     }
 }
 
@@ -402,6 +449,7 @@ void PageDriverManager::slotInstallAllDrivers()
 
 void PageDriverManager::slotBackupAllDrivers()
 {
+    qCDebug(appLog) << "PageDriverManager::slotBackupAllDrivers";
     mp_DriverInstallInfoPage->headWidget()->setReDetectEnable(false);
     mp_DriverRestoreInfoPage->headWidget()->setReDetectEnable(false);
 
@@ -410,6 +458,7 @@ void PageDriverManager::slotBackupAllDrivers()
 
 void PageDriverManager::slotScanFinished(ScanResult sr)
 {
+    qCDebug(appLog) << "Driver scan finished, result:" << sr;
 //     testDevices();
 
     if (SR_SUCESS == sr) {
@@ -466,6 +515,7 @@ void PageDriverManager::slotScanFinished(ScanResult sr)
 
 void PageDriverManager::slotUndoInstall()
 {
+    qCDebug(appLog) << "PageDriverManager::slotUndoInstall";
     if (m_CancelIndex != m_CurIndex) {
         m_CancelIndex = m_CurIndex;
         DBusDriverInterface::getInstance()->undoInstallDriver();
@@ -479,6 +529,7 @@ void PageDriverManager::slotUndoInstall()
 
 void PageDriverManager::slotUndoBackup()
 {
+    qCDebug(appLog) << "PageDriverManager::slotUndoBackup";
     mp_BackupThread->undoBackup();
 
     // 直接清空列表，不再备份剩余的驱动
@@ -490,6 +541,7 @@ void PageDriverManager::slotUndoBackup()
 
 void PageDriverManager::slotListViewWidgetItemClicked(const QString &itemStr)
 {
+    qCDebug(appLog) << "PageDriverManager::slotListViewWidgetItemClicked, itemStr:" << itemStr;
     m_CurItemStr = itemStr;
     if (tr("Driver Install") == itemStr) {
         mp_StackWidget->setCurrentIndex(0);
@@ -502,27 +554,34 @@ void PageDriverManager::slotListViewWidgetItemClicked(const QString &itemStr)
 
 void PageDriverManager::slotBackupProgressChanged(int progress)
 {
+    qCDebug(appLog) << "PageDriverManager::slotBackupProgressChanged, progress:" << progress;
 
 }
 
 void PageDriverManager::slotBackupFinished(bool bsuccess)
 {
-    if (! mp_CurBackupDriverInfo)
+    qCDebug(appLog) << "PageDriverManager::slotBackupFinished, success:" << bsuccess;
+    if (! mp_CurBackupDriverInfo) {
+        qCWarning(appLog) << "Current backup driver info is null, returning.";
         return;
+    }
 
     if (bsuccess) {
         m_backupSuccessNum += 1;
+        qCDebug(appLog) << "Backup successful for" << mp_CurBackupDriverInfo->name() << ", success count:" << m_backupSuccessNum;
         // 备份成功, 直接添加到可还原列表,并在可备份列表中移除该项
         m_ListBackedupeIndex.append(m_CurBackupIndex);
         getDebBackupInfo(m_ListDriverInfo[m_CurBackupIndex]);
         if (m_ListDriverInfo[m_CurBackupIndex]->debBackupVersion() != m_ListDriverInfo[m_CurBackupIndex]->version()) {
             m_ListRestorableIndex.append(m_CurBackupIndex);
             mp_DriverRestoreInfoPage->addDriverInfoToTableView(m_ListDriverInfo[m_CurBackupIndex], m_CurBackupIndex);
+            qCDebug(appLog) << "Added" << m_ListDriverInfo[m_CurBackupIndex]->name() << "to restorable list.";
         }
         mp_DriverRestoreInfoPage->showTables(m_ListRestorableIndex.size());
         m_ListBackableIndex.removeAt(m_ListBackableIndex.indexOf(m_CurBackupIndex));
     } else {
         m_backupFailedNum += 1;
+        qCWarning(appLog) << "Backup failed for" << mp_CurBackupDriverInfo->name() << ", failed count:" << m_backupFailedNum;
     }
 
     // 安装结束后，对应的表格需要设置相应的状态
@@ -531,12 +590,16 @@ void PageDriverManager::slotBackupFinished(bool bsuccess)
 
     if (!m_ListBackupIndex.isEmpty()) {
         sleep(1);
+        qCDebug(appLog) << "More drivers to back up, proceeding to next one.";
         backupNextDriver();
     } else {
+        qCDebug(appLog) << "All backups finished.";
         if (!m_ListBackableIndex.isEmpty()) {
+            qCDebug(appLog) << "Setting backable driver UI.";
             mp_DriverBackupInfoPage->headWidget()->setBackableDriverUI(m_ListBackableIndex.size(), m_ListBackedupeIndex.size());
             mp_DriverBackupInfoPage->setHeaderCbEnable(true);
         } else {
+            qCDebug(appLog) << "Setting no backup driver UI.";
             mp_DriverBackupInfoPage->headWidget()->setNoBackupDriverUI(m_ListBackableIndex.size(), m_ListBackedupeIndex.size());
             mp_DriverBackupInfoPage->setHeaderCbEnable(false);
         }
@@ -549,32 +612,43 @@ void PageDriverManager::slotBackupFinished(bool bsuccess)
         m_CurBackupIndex = -1;
         m_backupSuccessNum = 0;
         m_backupFailedNum = 0;
+        qCDebug(appLog) << "Resetting backup state variables.";
     }
 }
 
 void PageDriverManager::slotRestoreProgress(int progress, QString strDeatils)
 {
-    if(mp_CurRestoreDriverInfo == nullptr)
+    qCDebug(appLog) << "PageDriverManager::slotRestoreProgress, progress:" << progress << "details:" << strDeatils;
+    if(mp_CurRestoreDriverInfo == nullptr) {
+        qCWarning(appLog) << "Current restore driver info is null, returning.";
         return;
+    }
     if (progress >= 100) {
+        qCDebug(appLog) << "Restore progress >= 100, setting restore driver UI.";
         mp_DriverRestoreInfoPage->headWidget()->setRestoreDriverUI(m_ListRestorableIndex.size());
     } else {
+        qCDebug(appLog) << "Restore progress < 100, setting restoring UI.";
         mp_DriverRestoreInfoPage->headWidget()->setRestoringUI(progress, mp_CurRestoreDriverInfo->name());
     }
 }
 
 void PageDriverManager::slotRestoreFinished(bool success, QString msg)
 {
+    qCDebug(appLog) << "PageDriverManager::slotRestoreFinished, success:" << success << "msg:" << msg;
     int index = -1;
     if (mp_CurRestoreDriverInfo) {
         index = m_ListDriverInfo.indexOf(mp_CurRestoreDriverInfo);
+        qCDebug(appLog) << "Restore finished for driver at index:" << index;
         for (int i = 0; i < m_ListRestorableIndex.size(); i++) {
             if (index == m_ListRestorableIndex[i]) {
+                qCDebug(appLog) << "Found restored driver in restorable list at index:" << i;
                 if (success) {
+                    qCDebug(appLog) << "Restore successful, removing from restorable list.";
                     //移除已还原项
                     m_ListRestorableIndex.removeAt(i);
                     mp_DriverRestoreInfoPage->headWidget()->setRestoreDriverUI(m_ListRestorableIndex.size());
                 } else {
+                    qCWarning(appLog) << "Restore failed, showing error dialog.";
                     //还原失败，弹出提示窗口
                     int clickedButtonIndex = mp_FailedDialog->exec();
                     if (1 == clickedButtonIndex) {
@@ -585,13 +659,18 @@ void PageDriverManager::slotRestoreFinished(bool success, QString msg)
                 }
 
                 //恢复其它置灰项
+                qCDebug(appLog) << "Re-enabling other restorable items.";
                 for (int backedupeIndex : m_ListRestorableIndex) {
-                    if (backedupeIndex != i)
+                    if (backedupeIndex != i) {
+                        // qCDebug(appLog) << "Enabling item at index:" << backedupeIndex;
                         mp_DriverRestoreInfoPage->setItemOperationEnable(backedupeIndex, true);
+                    }
                 }
                 break;
             }
         }
+    } else {
+        qCWarning(appLog) << "Current restore driver info is null.";
     }
 
     mp_DriverInstallInfoPage->headWidget()->setReDetectEnable(true);
@@ -599,9 +678,11 @@ void PageDriverManager::slotRestoreFinished(bool success, QString msg)
     mp_DriverRestoreInfoPage->headWidget()->setReDetectEnable(true);
 
     mp_CurRestoreDriverInfo = nullptr;
+    qCDebug(appLog) << "Resetting restore state variables.";
 
     //刷新表格内容
     mp_DriverRestoreInfoPage->clearAllData();
+    qCDebug(appLog) << "Refreshing restore page table view.";
     for (int backedupeIndex : m_ListRestorableIndex) {
         mp_DriverRestoreInfoPage->addDriverInfoToTableView(m_ListDriverInfo[backedupeIndex], backedupeIndex);
     }
@@ -610,6 +691,7 @@ void PageDriverManager::slotRestoreFinished(bool success, QString msg)
 
 void PageDriverManager::initWidget()
 {
+    qCDebug(appLog) << "PageDriverManager::initWidget start";
     QHBoxLayout *mainLayout = new QHBoxLayout();
     mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setSpacing(0);
@@ -636,19 +718,23 @@ void PageDriverManager::initWidget()
     mp_FailedDialog->addContent(contentFrame);
     mp_FailedDialog->addButton(tr("OK"), false, DDialog::ButtonNormal);
     mp_FailedDialog->addButton(tr("Feedback"), false, DDialog::ButtonNormal);
+    qCDebug(appLog) << "PageDriverManager::initWidget end";
 }
 
 void PageDriverManager::installNextDriver()
 {
+    qCDebug(appLog) << "PageDriverManager::installNextDriver start";
     if (!m_ListDriverIndex.isEmpty()) {
         m_CurIndex = m_ListDriverIndex[0];
         m_ListDriverIndex.removeAt(0);
         DriverInfo *info = m_ListDriverInfo[m_CurIndex];
+        qCDebug(appLog) << "Installing driver at index:" << m_CurIndex << "Name:" << info->name();
         if (info) {
             mp_CurDriverInfo = info;
             mp_CurDriverInfo->m_Status = ST_DOWNLOADING;
             mp_DriverInstallInfoPage->updateItemStatus(m_CurIndex, mp_CurDriverInfo->status());
             mp_DriverInstallInfoPage->headWidget()->setDownloadUI(mp_CurDriverInfo->type(), "0MB/s", "0MB", mp_CurDriverInfo->size(), 0);
+            qCDebug(appLog) << "Calling DBus to install driver:" << info->packages() << "version:" << info->debVersion();
             DBusDriverInterface::getInstance()->installDriver(info->packages(), info->debVersion());
         }
     }
@@ -656,10 +742,12 @@ void PageDriverManager::installNextDriver()
 
 void PageDriverManager::backupNextDriver()
 {
+    qCDebug(appLog) << "PageDriverManager::backupNextDriver start";
     if (!m_ListBackupIndex.isEmpty()) {
         m_CurBackupIndex = m_ListBackupIndex[0];
         m_ListBackupIndex.removeAt(0);
         DriverInfo *info = m_ListDriverInfo[m_CurBackupIndex];
+        qCDebug(appLog) << "Backing up driver at index:" << m_CurBackupIndex << "Name:" << info->name();
         if (info) {
             mp_CurBackupDriverInfo = info;
             qCDebug(appLog) << __func__ << "backup driver: " << mp_CurBackupDriverInfo->name();
@@ -669,6 +757,7 @@ void PageDriverManager::backupNextDriver()
                                                                         m_ListBackupIndex.size() + m_backupSuccessNum + m_backupFailedNum + 1,
                                                                         m_backupSuccessNum + m_backupFailedNum + 1);
             if (!mp_BackupThread->isRunning()) {
+                qCDebug(appLog) << "Backup thread is not running, starting it.";
                 mp_BackupThread->setBackupDriverInfo(info);
                 mp_BackupThread->start();
             }
@@ -678,6 +767,7 @@ void PageDriverManager::backupNextDriver()
 
 void PageDriverManager::scanDevices()
 {
+    qCDebug(appLog) << "PageDriverManager::scanDevices start";
     // 显卡
     scanDevicesInfo(QObject::tr("Display Adapter"), DR_Gpu);
 
@@ -697,10 +787,12 @@ void PageDriverManager::scanDevices()
 //    scanDevicesInfo(QObject::tr("Printer"), DR_Printer); //由于task 353401 要求
 
 //    scanDevicesInfo(QObject::tr("Other Devices"), DR_OtherDevice); //由于task 353401 要求
+    qCDebug(appLog) << "PageDriverManager::scanDevices end";
 }
 
 void PageDriverManager::testScanDevices()
 {
+    qCDebug(appLog) << "PageDriverManager::testScanDevices";
     DriverInfo *info = new DriverInfo();
     info->m_Name = "GeFore RTX30 Series (Notebooks) 001";
     info->m_Size = "124.36";
@@ -804,11 +896,14 @@ void PageDriverManager::testScanDevices()
 
 void PageDriverManager::scanDevicesInfo(const QString &deviceType, DriverType driverType)
 {
+    qCDebug(appLog) << "PageDriverManager::scanDevicesInfo, deviceType:" << deviceType << "driverType:" << driverType;
     // 显卡
     QList<DeviceBaseInfo *> lst;
     bool ret = DeviceManager::instance()->getDeviceList(deviceType, lst);
+    qCDebug(appLog) << "Getting device list for" << deviceType << ", result:" << ret << ", count:" << lst.size();
     if (ret) {
         foreach (DeviceBaseInfo *device, lst) {
+            qCDebug(appLog) << "Processing device:" << device->name();
             DriverInfo *info = new DriverInfo();
             info->m_Name = device->name();        // 设备名称
             info->m_Type = driverType;
@@ -827,6 +922,7 @@ void PageDriverManager::scanDevicesInfo(const QString &deviceType, DriverType dr
             if ((info->m_VendorId.isEmpty() || info->m_ModelId.isEmpty()) && vidAndPid.size() == 10 && vidAndPid.startsWith("0x")) {
                 info->m_VendorId = vidAndPid.mid(0,6);
                 info->m_ModelId = "0x" + vidAndPid.mid(6,4);
+                qCDebug(appLog) << "Extracted VID and PID:" << info->m_VendorId << info->m_ModelId;
             }
 
             qCInfo(appLog) << "m_Name" << info->m_Name;
@@ -839,12 +935,14 @@ void PageDriverManager::scanDevicesInfo(const QString &deviceType, DriverType dr
             if (print != nullptr) {
                 info->m_VendorName = device->vendor();           // vendor name
                 info->m_ModelName = print->makeAndeModel();      // model name
+                qCDebug(appLog) << "Device is a printer, vendor:" << info->m_VendorName << "model:" << info->m_ModelName;
             }
 
             DeviceNetwork *network = dynamic_cast<DeviceNetwork *>(device);
             if (network != nullptr) {
                 if (network->isWireless()) {
                     info->m_Type = DR_WiFi;
+                    qCDebug(appLog) << "Device is a wireless network adapter.";
                 }
             }
 
@@ -855,6 +953,7 @@ void PageDriverManager::scanDevicesInfo(const QString &deviceType, DriverType dr
 
 void PageDriverManager::clearAllData()
 {
+    qCDebug(appLog) << "PageDriverManager::clearAllData start";
     m_ListNewIndex.clear();
     m_ListDriverIndex.clear();
     m_ListUpdateIndex.clear();
@@ -865,17 +964,21 @@ void PageDriverManager::clearAllData()
     m_ListRestorableIndex.clear();
 
     foreach (DriverInfo *info, m_ListDriverInfo) {
+        // qCDebug(appLog) << "Deleting driver info:" << info->name();
         delete info;
+        // info = nullptr;
     }
     m_ListDriverInfo.clear();
 
     mp_DriverInstallInfoPage->clearAllData();
     mp_DriverBackupInfoPage->clearAllData();
     mp_DriverRestoreInfoPage->clearAllData();
+    qCDebug(appLog) << "PageDriverManager::clearAllData end";
 }
 
 void PageDriverManager::addToDriverIndex(int index)
 {
+    qCDebug(appLog) << "PageDriverManager::addToDriverIndex, index:" << index;
     // 如果第一次添加到index，一键安装按钮置灰
     if (m_ListDriverIndex.size() <= 0) {
         mp_DriverInstallInfoPage->headWidget()->setInstallBtnEnable(true);
@@ -884,31 +987,37 @@ void PageDriverManager::addToDriverIndex(int index)
     bool add = true;
     for (int i = 0; i < m_ListDriverIndex.size(); i++) {
         if (index == m_ListDriverIndex[i]) {
+            qCDebug(appLog) << "Index" << index << "already exists in driver index list.";
             add = false;
             break;
         }
     }
 
     if (add) {
+        qCDebug(appLog) << "Adding index" << index << "to driver index list.";
         m_ListDriverIndex.append(index);
     }
 }
 
 void PageDriverManager::addToBackupIndex(int index)
 {
+    qCDebug(appLog) << "PageDriverManager::addToBackupIndex, index:" << index;
     if (m_ListBackupIndex.isEmpty()) {
         mp_DriverBackupInfoPage->headWidget()->setBackupBtnEnable(true);
     }
 
     int ret = m_ListBackupIndex.indexOf(index);
+    qCDebug(appLog) << "Checking if index" << index << "exists in backup index list, result:" << ret;
 
     if (ret < 0) {
+        qCDebug(appLog) << "Adding index" << index << "to backup index list.";
         m_ListBackupIndex.append(index);
     }
 }
 
 void PageDriverManager::removeFromDriverIndex(int index)
 {
+    qCDebug(appLog) << "PageDriverManager::removeFromDriverIndex, index:" << index;
     auto ret = m_ListDriverIndex.indexOf(index);
     if (ret >= 0) {
         m_ListDriverIndex.removeAt(ret);
@@ -922,6 +1031,7 @@ void PageDriverManager::removeFromDriverIndex(int index)
 
 void PageDriverManager::removeFromBackupIndex(int index)
 {
+    qCDebug(appLog) << "PageDriverManager::removeFromBackupIndex, index:" << index;
     auto ret = m_ListBackupIndex.indexOf(index);
     if (ret >= 0) {
         m_ListBackupIndex.removeAt(ret);
@@ -934,6 +1044,7 @@ void PageDriverManager::removeFromBackupIndex(int index)
 
 void PageDriverManager::failAllIndex()
 {
+    qCDebug(appLog) << "PageDriverManager::failAllIndex";
     foreach (int index, m_ListDriverIndex) {
         QString errS = DApplication::translate("QObject", CommonTools::getErrorString(EC_NETWORK).toStdString().data());
         mp_DriverInstallInfoPage->updateItemStatus(index, ST_FAILED, errS);
@@ -942,16 +1053,22 @@ void PageDriverManager::failAllIndex()
 
 bool PageDriverManager::networkIsOnline()
 {
+    qCDebug(appLog) << "PageDriverManager::networkIsOnline start";
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QNetworkConfigurationManager mgr;
-    return mgr.isOnline();
+    const bool isOnline = mgr.isOnline();
+    qCDebug(appLog) << "Network is" << (isOnline ? "online" : "offline");
+    return isOnline;
 #else
-    return QNetworkInformation::instance() && QNetworkInformation::instance()->reachability() == QNetworkInformation::Reachability::Disconnected;
+    auto interfaces = QNetworkInformation::instance()->reachability();
+    qCDebug(appLog) << "Network reachability:" << interfaces;
+    return interfaces == QNetworkInformation::Reachability::Disconnected;
 #endif
 }
 
 void PageDriverManager::getDownloadInfo(int progress, qint64 total, QString &speed, QString &size)
 {
+    qCDebug(appLog) << "PageDriverManager::getDownloadInfo, progress:" << progress << "total:" << total;
     static qint64 msec = QDateTime::currentMSecsSinceEpoch();
     static double pre_bytes = total * (progress / 100.0);
     double bytes = total * (progress / 100.0);
@@ -989,6 +1106,7 @@ void PageDriverManager::getDownloadInfo(int progress, qint64 total, QString &spe
 
 void PageDriverManager::testDevices()
 {
+    qCDebug(appLog) << "PageDriverManager::testDevices";
     DriverInfo *info = new DriverInfo();
     info->m_Name = "Sharp MX-C2622R PS, 1.1";
     info->m_Version = "0.0.1";
@@ -1028,16 +1146,21 @@ void PageDriverManager::testDevices()
 
 void PageDriverManager::getDebBackupInfo(DriverInfo *info)
 {
+    qCDebug(appLog) << "PageDriverManager::getDebBackupInfo, debname:" << info->packages();
     QString debname = info->packages();
     QString backupPath =  QString("%1/driver/%2").arg(CommonTools::getBackupPath()).arg(debname);
     QDir destdir(backupPath);
+    qCDebug(appLog) << "Checking for backup in path:" << backupPath;
     if (destdir.exists()) {
+        qCDebug(appLog) << "Backup path exists, searching for .deb file.";
         //获取当前路径下的所有文件名
         QFileInfoList fileInfoList = destdir.entryInfoList();
         foreach (QFileInfo fileInfo, fileInfoList) {
             if (fileInfo.fileName() == "." || fileInfo.fileName() == "..")
                 continue;
+            qCDebug(appLog) << "Checking file:" << fileInfo.fileName();
             if (fileInfo.isFile() && fileInfo.fileName().contains(".deb") && fileInfo.fileName().contains(debname)) {
+                qCDebug(appLog) << "Found backup .deb file:" << fileInfo.fileName();
                 QString tmps = fileInfo.fileName().remove(debname).remove(".deb");
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
                 QStringList  tmpsl = tmps.split('_', QString::SkipEmptyParts);

--- a/deepin-devicemanager/src/Page/PageDriverRestoreInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverRestoreInfo.cpp
@@ -35,6 +35,7 @@ PageDriverRestoreInfo::PageDriverRestoreInfo(QWidget *parent)
 }
 void PageDriverRestoreInfo::initUI()
 {
+    qCDebug(appLog) << "PageDriverRestoreInfo::initUI start";
     this->setLineWidth(0);
     initTable();
 
@@ -119,10 +120,12 @@ void PageDriverRestoreInfo::initUI()
 
     mainLayout->addWidget(mp_StackWidget);
     this->setLayout(mainLayout);
+    qCDebug(appLog) << "PageDriverRestoreInfo::initUI end";
 }
 
 void PageDriverRestoreInfo::initTable()
 {
+    qCDebug(appLog) << "PageDriverRestoreInfo::initTable start";
     mp_ViewBackable->initHeaderView(QStringList()<< tr("Name")
                                     << tr("Current Version")
                                     << tr("Backup Version")
@@ -131,6 +134,7 @@ void PageDriverRestoreInfo::initTable()
     mp_ViewBackable->setColumnWidth(0, 324);
     mp_ViewBackable->setColumnWidth(1, 158);
     mp_ViewBackable->setColumnWidth(2, 158);
+    qCDebug(appLog) << "PageDriverRestoreInfo::initTable end";
 }
 
 void PageDriverRestoreInfo::addDriverInfoToTableView(DriverInfo *info, int index)
@@ -138,6 +142,7 @@ void PageDriverRestoreInfo::addDriverInfoToTableView(DriverInfo *info, int index
     qCDebug(appLog) << "Adding driver info to table view, name:" << info->name() << "index:" << index;
     PageDriverTableView *view = nullptr;
     if (!info->debBackupVersion().isEmpty()) {
+        qCDebug(appLog) << "Driver has backup version, adding to view";
         view = mp_ViewBackable;
         view->appendRowItems(4);
     } else {
@@ -148,6 +153,7 @@ void PageDriverRestoreInfo::addDriverInfoToTableView(DriverInfo *info, int index
     int row = view->model()->rowCount() - 1;
 
     if (view == mp_ViewBackable) {
+        qCDebug(appLog) << "Setting widgets for backable driver";
         // 设置名称
         DriverNameItem *nameItem = new DriverNameItem(this, info->type());
         nameItem->setName(info->name());
@@ -185,13 +191,16 @@ void PageDriverRestoreInfo::showTables(int backedLength)
 
 void PageDriverRestoreInfo::clearAllData()
 {
+    qCDebug(appLog) << "PageDriverRestoreInfo::clearAllData start";
     mp_ViewBackable->clear();
 
     initTable();
+    qCDebug(appLog) << "PageDriverRestoreInfo::clearAllData end";
 }
 
 void PageDriverRestoreInfo::setItemOperationEnable(int index, bool enable)
 {
+    qCDebug(appLog) << "PageDriverRestoreInfo::setItemOperationEnable, index:" << index << "enable:" << enable;
     mp_ViewBackable->setItemOperationEnable(index, enable);
 }
 

--- a/deepin-devicemanager/src/Page/PageDriverTableView.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverTableView.cpp
@@ -42,37 +42,44 @@ void PageDriverTableView::appendRowItems(int column)
 
 void PageDriverTableView::setWidget(int row, int column, DWidget *widget)
 {
+    // qCDebug(appLog) << "PageDriverTableView::setWidget, row:" << row << "column:" << column;
     mp_View->setWidget(row, column, widget);
     mp_View->resizeColumn(column);
 }
 
 QAbstractItemModel *PageDriverTableView::model() const
 {
+    // qCDebug(appLog) << "PageDriverTableView::model";
     return mp_View->model();
 }
 
 void PageDriverTableView::initHeaderView(const QStringList &headerList, bool check)
 {
+    qCDebug(appLog) << "PageDriverTableView::initHeaderView, check:" << check;
     mp_View->initHeaderView(headerList, check);
 }
 
 void PageDriverTableView::setHeaderCbStatus(bool checked)
 {
+    qCDebug(appLog) << "PageDriverTableView::setHeaderCbStatus, checked:" << checked;
     mp_View->setHeaderCbStatus(checked);
 }
 
 void PageDriverTableView::setCheckedCBDisnable()
 {
+    qCDebug(appLog) << "PageDriverTableView::setCheckedCBDisnable";
     mp_View->setCheckedCBDisable();
 }
 
 void PageDriverTableView::getCheckedDriverIndex(QList<int> &lstIndex)
 {
+    qCDebug(appLog) << "PageDriverTableView::getCheckedDriverIndex";
     mp_View->getCheckedDriverIndex(lstIndex);
 }
 
 void PageDriverTableView::setItemStatus(int index, Status s)
 {
+    qCDebug(appLog) << "PageDriverTableView::setItemStatus, index:" << index << "status:" << s;
     mp_View->setItemStatus(index, s);
 }
 
@@ -84,6 +91,7 @@ void PageDriverTableView::setErrorMsg(int index, const QString &msg)
 
 bool PageDriverTableView::hasItemDisabled()
 {
+    qCDebug(appLog) << "PageDriverTableView::hasItemDisabled";
     return mp_View->hasItemDisabled();
 }
 
@@ -96,16 +104,19 @@ void PageDriverTableView::clear()
 
 void PageDriverTableView::setItemOperationEnable(int index, bool enable)
 {
+    qCDebug(appLog) << "PageDriverTableView::setItemOperationEnable, index:" << index << "enable:" << enable;
     mp_View->setItemOperationEnable(index, enable);
 }
 
 void PageDriverTableView::removeItemAndWidget(int row, int column)
 {
+    qCDebug(appLog) << "PageDriverTableView::removeItemAndWidget, row:" << row << "column:" << column;
     mp_View->removeItemAndWidget(row, column);
 }
 
 void PageDriverTableView::setHeaderCbEnable(bool enable)
 {
+    qCDebug(appLog) << "PageDriverTableView::setHeaderCbEnable, enable:" << enable;
     mp_View->setHeaderCbEnable(enable);
 }
 
@@ -129,8 +140,10 @@ void PageDriverTableView::paintEvent(QPaintEvent *e)
     DWidget *wid = DApplication::activeWindow();
     if (wid/* && wid == this*/) {
         cg = DPalette::Active;
+        // qCDebug(appLog) << "Paint event on active window";
     } else {
         cg = DPalette::Inactive;
+        // qCDebug(appLog) << "Paint event on inactive window";
     }
 
     // 设置Widget固定高度,(+1)表示包含表头高度,(*2)表示上下边距，为保证treewidget横向滚动条与item不重叠，添加滚动条高度
@@ -155,7 +168,9 @@ void PageDriverTableView::paintEvent(QPaintEvent *e)
 
 void PageDriverTableView::resizeEvent(QResizeEvent *e)
 {
+    // qCDebug(appLog) << "PageDriverTableView::resizeEvent, new size:" << e->size() << "old size:" << e->oldSize();
     if(m_PreWidth < 680){
+        // qCDebug(appLog) << "PageDriverTableView::resizeEvent, width too small, skip";
         m_PreWidth = this->width();
         return DWidget::resizeEvent(e);
     }
@@ -166,6 +181,7 @@ void PageDriverTableView::resizeEvent(QResizeEvent *e)
 
     // 宽度不变，不做处理
     if(0 == detal) {
+        // qCDebug(appLog) << "PageDriverTableView::resizeEvent, width not changed, skip";
         return DWidget::resizeEvent(e);
     }
 
@@ -176,6 +192,7 @@ void PageDriverTableView::resizeEvent(QResizeEvent *e)
 
 void PageDriverTableView::initWidgets()
 {
+    qCDebug(appLog) << "PageDriverTableView::initWidgets";
     this->setFixedHeight(DRIVER_TABLE_HEADER_HEIGHT);
     setContentsMargins(0, 0, 0, 0);
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
@@ -187,24 +204,31 @@ void PageDriverTableView::initWidgets()
 
 void PageDriverTableView::resizeColumnWidth(int detal)
 {
+    qCDebug(appLog) << "PageDriverTableView::resizeColumnWidth, detal:" << detal;
     bool newDriverTable = mp_View->columnWidth(5) == 0;
     if(newDriverTable){
+        qCDebug(appLog) << "PageDriverTableView::resizeColumnWidth, is new driver table";
         int columnZeroWidth = mp_View->columnWidth(0);
         if(detal > 0){ // 放大
+            qCDebug(appLog) << "PageDriverTableView::resizeColumnWidth, zoom in";
             mp_View->setColumnWidth(0,columnZeroWidth + detal);
         }else{ // 缩小
+            qCDebug(appLog) << "PageDriverTableView::resizeColumnWidth, zoom out";
             if(columnZeroWidth + detal > 120){
                 mp_View->setColumnWidth(0,columnZeroWidth + detal);
             }
         }
     }else{
+        qCDebug(appLog) << "PageDriverTableView::resizeColumnWidth, is not new driver table";
         int columnOneWidth = mp_View->columnWidth(1);
         int columnTwoWidth = mp_View->columnWidth(2);
         int columnFourWidth = mp_View->columnWidth(4);
         if(detal > 0){ // 放大
+            qCDebug(appLog) << "PageDriverTableView::resizeColumnWidth, zoom in";
             // 第一步：先放大第一列
             int detalOne = 324 - columnOneWidth;
             if(detalOne - detal >= 0){ // 此时只需要放大第一列
+                qCDebug(appLog) << "Zoom in: expanding column 1 only.";
                 mp_View->setColumnWidth(1,columnOneWidth + detal);
                 return;
             }else {
@@ -215,6 +239,7 @@ void PageDriverTableView::resizeColumnWidth(int detal)
             // 第二步：放大第二列
             int detalTwo = 186 - columnTwoWidth;
             if(detalTwo - detal >= 0){ // 此时只需要放大第一列
+                qCDebug(appLog) << "Zoom in: expanding column 2.";
                 mp_View->setColumnWidth(2,columnTwoWidth + detal);
                 return;
             }else {
@@ -225,6 +250,7 @@ void PageDriverTableView::resizeColumnWidth(int detal)
             // 第三步：放大第四列
             int detalFour = 150 - columnFourWidth;
             if(detalFour - detal >= 0){ // 此时只需要放大第一列
+                qCDebug(appLog) << "Zoom in: expanding column 4.";
                 mp_View->setColumnWidth(4,columnFourWidth + detal);
                 return;
             }else {
@@ -234,12 +260,15 @@ void PageDriverTableView::resizeColumnWidth(int detal)
 
             // 第五步：继续放大第一列
             columnOneWidth = mp_View->columnWidth(1);
+            qCDebug(appLog) << "Zoom in: expanding column 1 further.";
             mp_View->setColumnWidth(1, columnOneWidth + detal);
 
         }else{ // 缩小
+            qCDebug(appLog) << "PageDriverTableView::resizeColumnWidth, zoom out";
             // 第一步：先缩小第一列
             int detalOne = columnOneWidth - 120; // 计算第一列可缩小距离
             if(detalOne + detal >= 0){ // 此时只需要降低第一列
+                qCDebug(appLog) << "Zoom out: shrinking column 1 only.";
                 mp_View->setColumnWidth(1,columnOneWidth + detal);
                 return;
             }else { // 此时需要降低第二列，但是先把第一列降低了再说
@@ -248,8 +277,9 @@ void PageDriverTableView::resizeColumnWidth(int detal)
             }
 
             // 第二步：缩小第二列
-            int detalTwo = columnTwoWidth - 120;
+            int detalTwo = columnTwoWidth - 120; // 计算第二列可缩小距离
             if(detalTwo + detal >= 0){ // 此时只需要降低第一列
+                qCDebug(appLog) << "Zoom out: shrinking column 2.";
                 mp_View->setColumnWidth(2,columnTwoWidth + detal);
                 return;
             }else { // 此时需要降低第二列，但是先把第一列降低了再说
@@ -260,6 +290,7 @@ void PageDriverTableView::resizeColumnWidth(int detal)
             // 第三步：缩小第四列
             int detalFour = columnFourWidth - 120;
             if(detalFour + detal >= 0){ // 此时只需要降低第一列
+                qCDebug(appLog) << "Zoom out: shrinking column 4.";
                 mp_View->setColumnWidth(4,columnFourWidth + detal);
             }else { // 此时需要降低第二列，但是先把第一列降低了再说
                 mp_View->setColumnWidth(4,columnFourWidth - detalFour);

--- a/deepin-devicemanager/src/Page/PageInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageInfo.cpp
@@ -30,17 +30,17 @@ PageInfo::PageInfo(QWidget *parent)
 
 void PageInfo::updateInfo(const QMap<QString, QString> &)
 {
-
+    qCDebug(appLog) << "PageInfo::updateInfo";
 }
 
 void PageInfo::setLabel(const QString &, const QString &)
 {
-
+    qCDebug(appLog) << "PageInfo::setLabel";
 }
 
 void PageInfo::clearContent()
 {
-
+    qCDebug(appLog) << "PageInfo::clearContent";
 }
 
 void PageInfo::setDeviceInfoNum(int num)
@@ -52,17 +52,20 @@ void PageInfo::setDeviceInfoNum(int num)
 
 int PageInfo::getDeviceInfoNum()
 {
+    qCDebug(appLog) << "PageInfo::getDeviceInfoNum, num:" << m_AllInfoNum;
     // 获取设备信息数目
     return m_AllInfoNum;
 }
 
 void PageInfo::setMultiFlag(const bool &flag)
 {
+    // qCDebug(appLog) << "PageInfo::setMultiFlag, flag:" << flag;
     m_multiFlag = flag;
 }
 
 bool PageInfo::getMultiFlag()
 {
+    // qCDebug(appLog) << "PageInfo::getMultiFlag, flag:" << m_multiFlag;
     return m_multiFlag;
 }
 
@@ -75,11 +78,14 @@ bool PageInfo::packageHasInstalled(const QString &packageName)
     p.waitForFinished(-1);
 
     QByteArray r = p.readAll();
-    return r.contains("installed");
+    bool installed = r.contains("installed");
+    qCDebug(appLog) << "Package" << packageName << "is" << (installed ? "installed" : "not installed");
+    return installed;
 }
 
 void PageInfo::paintEvent(QPaintEvent *e)
 {
+    // qCDebug(appLog) << "PageInfo::paintEvent";
     QPainter painter(this);
     painter.save();
     painter.setRenderHints(QPainter::Antialiasing, true);
@@ -97,10 +103,13 @@ void PageInfo::paintEvent(QPaintEvent *e)
     // 获取窗口当前的状态,激活，禁用，未激活
     DPalette::ColorGroup cg;
     DWidget *wid = DApplication::activeWindow();
-    if (wid /* && wid == this*/)
+    if (wid /* && wid == this*/) {
+        // qCDebug(appLog) << "PageInfo::paintEvent, active window";
         cg = DPalette::Active;
-    else
+    } else {
+        // qCDebug(appLog) << "PageInfo::paintEvent, inactive window";
         cg = DPalette::Inactive;
+    }
 
     // 开始绘制边框 *********************************************************
     // 计算绘制区域

--- a/deepin-devicemanager/src/Page/PageInfoWidget.cpp
+++ b/deepin-devicemanager/src/Page/PageInfoWidget.cpp
@@ -72,6 +72,7 @@ void PageInfoWidget::updateTable(const QString &itemStr, const QList<DeviceBaseI
 
         // 判断是否是BIOS界面
         if (bios) {
+            qCDebug(appLog) << "Showing board info page";
             mp_PageInfo = mp_PageBoardInfo;
             mp_PageBoardInfo->setVisible(true);
             mp_PageMutilInfo->setVisible(false);
@@ -86,6 +87,7 @@ void PageInfoWidget::updateTable(const QString &itemStr, const QList<DeviceBaseI
 
     // 设置页面Label以及显示设备信息
     if (mp_PageInfo) {
+        qCDebug(appLog) << "Updating page info";
         mp_PageInfo->setLabel(itemStr);
         mp_PageInfo->updateInfo(lst);
     }
@@ -101,6 +103,7 @@ void PageInfoWidget::updateTable(const QMap<QString, QString> &map)
     mp_PageBoardInfo->setVisible(false);
     mp_PageInfo = mp_PageOverviewInfo;
     if (mp_PageInfo) {
+        qCDebug(appLog) << "Updating page info with map";
         mp_PageInfo->updateInfo(map);
         mp_PageInfo->setLabel(map["Overview"], map["OS"]);
     }
@@ -108,11 +111,13 @@ void PageInfoWidget::updateTable(const QMap<QString, QString> &map)
 
 void PageInfoWidget::setFontChangeFlag()
 {
+    qCDebug(appLog) << "PageInfoWidget::setFontChangeFlag";
     mp_PageBoardInfo->setFontChangeFlag();
 }
 
 void PageInfoWidget::clear()
 {
+    qCDebug(appLog) << "PageInfoWidget::clear";
     mp_PageOverviewInfo->clearWidgets();
     mp_PageMutilInfo->clearWidgets();
     mp_PageSignalInfo->clearWidgets();
@@ -121,11 +126,13 @@ void PageInfoWidget::clear()
 
 void PageInfoWidget::resizeEvent(QResizeEvent *event)
 {
+    qCDebug(appLog) << "PageInfoWidget::resizeEvent";
     DWidget::resizeEvent(event);
 }
 
 void PageInfoWidget::initWidgets()
 {
+    qCDebug(appLog) << "PageInfoWidget::initWidgets";
     // 初始化页面布局
     QHBoxLayout *hLayout = new QHBoxLayout(this);
     hLayout->setContentsMargins(10, 10, 10, 10);

--- a/deepin-devicemanager/src/Page/PageListView.cpp
+++ b/deepin-devicemanager/src/Page/PageListView.cpp
@@ -63,6 +63,7 @@ void PageListView::updateListItems(const QList<QPair<QString, QString> > &lst)
 
     // 更新 list
     foreach (auto it, lst) {
+        qCDebug(appLog) << "Adding item:" << it.first;
         mp_ListView->addItem(it.first, it.second);
     }
 
@@ -74,19 +75,24 @@ void PageListView::updateListItems(const QList<QPair<QString, QString> > &lst)
 
 QString PageListView::currentIndex()
 {
+    QString index = mp_ListView->currentIndex().data(Qt::UserRole).toString();
+    // qCDebug(appLog) << "PageListView::currentIndex, index:" << index;
     // 获取当前Index的UserRole
-    return mp_ListView->currentIndex().data(Qt::UserRole).toString();
+    return index;
 }
 
 QString PageListView::currentType()
 {
+    // qCDebug(appLog) << "PageListView::currentType, type:" << m_CurType;
     // 获取当前设备类型
     return m_CurType;
 }
 
 void PageListView::clear()
 {
+    qCDebug(appLog) << "PageListView::clear";
     if (!mp_ListView) {
+        qCWarning(appLog) << "ListView is null";
         return;
     }
 
@@ -96,12 +102,14 @@ void PageListView::clear()
 
 void PageListView::setCurType(QString type)
 {
+    qCDebug(appLog) << "PageListView::setCurType, type:" << type;
     m_CurType = type;
     mp_ListView->setCurItem(m_CurType);
 }
 
 void PageListView::paintEvent(QPaintEvent *event)
 {
+    // qCDebug(appLog) << "PageListView::paintEvent"; //This log is too frequent
     // 让背景色适合主题颜色
     DPalette pa = DPaletteHelper::instance()->palette(this);
     pa.setBrush(DPalette::ItemBackground, pa.brush(DPalette::Base));
@@ -117,14 +125,18 @@ void PageListView::paintEvent(QPaintEvent *event)
 
 void PageListView::slotShowMenu(const QPoint &point)
 {
+    qCDebug(appLog) << "PageListView::slotShowMenu";
     // 右键菜单
     mp_Menu->clear();
 
-    if (m_CurType == tr("Driver Install") || m_CurType == tr("Driver Backup") || m_CurType == tr("Driver Restore"))
+    if (m_CurType == tr("Driver Install") || m_CurType == tr("Driver Backup") || m_CurType == tr("Driver Restore")) {
+        qCDebug(appLog) << "Driver related item, no context menu";
         return;
+    }
 
     // 导出/刷新
     if (mp_ListView->indexAt(point).isValid()) {
+        qCDebug(appLog) << "Show context menu";
         mp_Menu->addAction(mp_Export);
         mp_Menu->addAction(mp_Refresh);
 
@@ -134,10 +146,12 @@ void PageListView::slotShowMenu(const QPoint &point)
 
 void PageListView::slotListViewItemClicked(const QModelIndex &index)
 {
+    // qCDebug(appLog) << "PageListView::slotListViewItemClicked";
     // Item 点击事件
     QString concateStr = mp_ListView->getConcatenateStrings(index);
     qCDebug(appLog) << "List item clicked:" << concateStr;
     if (!concateStr.isEmpty() && concateStr != QString("Separator")) {
+        qCDebug(appLog) << "Emit itemClicked signal";
         emit itemClicked(concateStr);
         m_CurType = concateStr;
     }

--- a/deepin-devicemanager/src/Page/PageMultiInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageMultiInfo.cpp
@@ -64,10 +64,12 @@ PageMultiInfo::~PageMultiInfo()
     qCDebug(appLog) << "PageMultiInfo destructor start";
     // 清空指针
     if (mp_Table) {
+        qCDebug(appLog) << "Deleting table";
         delete mp_Table;
         mp_Table = nullptr;
     }
     if (mp_Detail) {
+        qCDebug(appLog) << "Deleting detail";
         delete mp_Detail;
         mp_Detail = nullptr;
     }
@@ -101,6 +103,7 @@ void PageMultiInfo::updateInfo(const QList<DeviceBaseInfo *> &lst)
 
 void PageMultiInfo::setLabel(const QString &itemstr)
 {
+    qCDebug(appLog) << "PageMultiInfo::setLabel, itemstr:" << itemstr;
     if (mp_Label) {
         mp_Label->setText(itemstr);
 
@@ -119,21 +122,27 @@ void PageMultiInfo::setLabel(const QString &itemstr)
 
 void PageMultiInfo::clearWidgets()
 {
+    qCDebug(appLog) << "PageMultiInfo::clearWidgets";
     m_lstDevice.clear();
     mp_Detail->clearWidget();
 }
 
 void PageMultiInfo::resizeEvent(QResizeEvent *e)
 {
-    if (m_lstDevice.size() < 1)
+    qCDebug(appLog) << "PageMultiInfo::resizeEvent";
+    if (m_lstDevice.size() < 1) {
+        qCDebug(appLog) << "No device, skip resize";
         return PageInfo::resizeEvent(e);
+    }
 
     // 先获取当前窗口大小
     int curHeight = this->height();
     if (curHeight < LEAST_PAGE_HEIGHT) {
+        qCDebug(appLog) << "Height too small, resize table";
         //  获取多个设备界面表格信息
         mp_Table->updateTable(m_deviceList, m_menuControlList, true, (LEAST_PAGE_HEIGHT - curHeight) / TREE_ROW_HEIGHT + 1);
     } else {
+        qCDebug(appLog) << "Height is enough, resize table";
         //  获取多个设备界面表格信息
         mp_Table->updateTable(m_deviceList, m_menuControlList, true, 0);
     }
@@ -143,6 +152,7 @@ void PageMultiInfo::resizeEvent(QResizeEvent *e)
 
 void PageMultiInfo::slotItemClicked(int row)
 {
+    qCDebug(appLog) << "PageMultiInfo::slotItemClicked, row:" << row;
     // 显示表格中选择设备的详细信息
     if (mp_Detail)
         mp_Detail->showInfoOfNum(row);
@@ -150,17 +160,22 @@ void PageMultiInfo::slotItemClicked(int row)
 
 void PageMultiInfo::slotEnableDevice(int row, bool enable)
 {
-    if (!mp_Detail)
+    qCDebug(appLog) << "PageMultiInfo::slotEnableDevice, row:" << row << "enable:" << enable;
+    if (!mp_Detail) {
+        qCWarning(appLog) << "mp_Detail is null";
         return;
+    }
 
     // 禁用/启用设备
     EnableDeviceStatus res = mp_Detail->enableDevice(row, enable);
 
     // 除设置成功的情况，其他情况需要提示设置失败
     if (res == EDS_Success) {
+        qCDebug(appLog) << "Enable device success";
         // 设置成功,更新界面
         emit updateUI();
     } else if (res == EDS_Faild) {
+        qCWarning(appLog) << "Enable device failed";
         // 设置失败
         QString con;
         if (enable)
@@ -173,6 +188,7 @@ void PageMultiInfo::slotEnableDevice(int row, bool enable)
         // 禁用、启用失败提示
         DMessageManager::instance()->sendMessage(this->window(), QIcon::fromTheme("warning"), con);
     } else if (res == EDS_NoSerial) {
+        qCWarning(appLog) << "Enable device failed, no serial";
         QString con = tr("Failed to disable it: unable to get the device SN");
         DMessageManager::instance()->sendMessage(this->window(), QIcon::fromTheme("warning"), con);
     }
@@ -180,8 +196,11 @@ void PageMultiInfo::slotEnableDevice(int row, bool enable)
 
 void PageMultiInfo::slotWakeupMachine(int row, bool wakeup)
 {
-    if (!mp_Detail)
+    qCDebug(appLog) << "PageMultiInfo::slotWakeupMachine, row:" << row << "wakeup:" << wakeup;
+    if (!mp_Detail) {
+        qCWarning(appLog) << "mp_Detail is null";
         return;
+    }
     mp_Detail->setWakeupMachine(row, wakeup);
 }
 
@@ -214,6 +233,7 @@ void PageMultiInfo::slotActionRemoveDriver(int row)
     QString printerModel;
     DevicePrint *printer = qobject_cast<DevicePrint *>(device);
     if (printer) {
+        qCDebug(appLog) << "Printer device detected";
         printerVendor = printer->getVendor();
         printerModel = printer->getModel();
     }
@@ -225,11 +245,15 @@ void PageMultiInfo::slotActionRemoveDriver(int row)
 
 void PageMultiInfo::slotCheckPrinterStatus(int row, bool &isPrinter, bool &isInstalled)
 {
+    qCDebug(appLog) << "PageMultiInfo::slotCheckPrinterStatus, row:" << row;
     DeviceBaseInfo *device = m_lstDevice.value(row, nullptr);
-    if (!device)
+    if (!device) {
+        qCWarning(appLog) << "No device at row:" << row;
         return;
+    }
     DevicePrint *printer = qobject_cast<DevicePrint *>(device);
     if (printer) {
+        qCDebug(appLog) << "Device is a printer";
         isPrinter = true;
         isInstalled = PageInfo::packageHasInstalled("dde-printer");
     }
@@ -237,6 +261,7 @@ void PageMultiInfo::slotCheckPrinterStatus(int row, bool &isPrinter, bool &isIns
 
 void PageMultiInfo::initWidgets()
 {
+    qCDebug(appLog) << "PageMultiInfo::initWidgets";
     // 初始化界面布局
     QVBoxLayout *hLayout = new QVBoxLayout();
     QHBoxLayout *labelLayout = new QHBoxLayout();
@@ -259,10 +284,12 @@ void PageMultiInfo::initWidgets()
 
 void PageMultiInfo::getTableListInfo(const QList<DeviceBaseInfo *> &lst, QList<QStringList> &deviceList, QList<QStringList> &menuControlList)
 {
+    qCDebug(appLog) << "PageMultiInfo::getTableListInfo, device count:" << lst.size();
     //  获取多个设备界面表格信息
      if(lst[0] == nullptr) return;
     deviceList.append(lst[0]->getTableHeader());
     foreach (DeviceBaseInfo *info, lst) {
+        // qCDebug(appLog) << "Processing device:" << info->name();
         if(info == nullptr) continue;
         QStringList lstDeviceInfo = info->getTableData();
         deviceList.append(lstDeviceInfo);
@@ -283,4 +310,5 @@ void PageMultiInfo::getTableListInfo(const QList<DeviceBaseInfo *> &lst, QList<Q
 
         menuControlList.append(menuControl);
     }
+    qCDebug(appLog) << "PageMultiInfo::getTableListInfo end";
 }

--- a/deepin-devicemanager/src/Page/PageOverview.cpp
+++ b/deepin-devicemanager/src/Page/PageOverview.cpp
@@ -56,11 +56,12 @@ PageOverview::PageOverview(DWidget *parent)
     connect(mp_Refresh, &QAction::triggered, this, &PageOverview::refreshInfo);
     connect(mp_Export, &QAction::triggered, this, &PageOverview::exportInfo);
     connect(mp_Copy, &QAction::triggered, this, &PageOverview::slotActionCopy);
+    qCDebug(appLog) << "PageOverview constructor end";
 }
 
 void PageOverview::updateInfo(const QList<DeviceBaseInfo *> &)
 {
-
+    // qCDebug(appLog) << "PageOverview::updateInfo with list, doing nothing";
 }
 
 void PageOverview::updateInfo(const QMap<QString, QString> &map)
@@ -73,8 +74,10 @@ void PageOverview::updateInfo(const QMap<QString, QString> &map)
     // 根据页面高度确定表格最多显示行数
     int maxRow = this->height() / ROW_HEIGHT - 4;
     if (maxRow < 1) {
+        qCDebug(appLog) << "Max row is less than 1, set to 11";
         mp_Overview->setLimitRow(11);
     } else {
+        qCDebug(appLog) << "Set max row to" << std::min(11, maxRow);
         mp_Overview->setLimitRow(std::min(11, maxRow));
     }
 
@@ -87,11 +90,13 @@ void PageOverview::updateInfo(const QMap<QString, QString> &map)
 
     foreach (auto iter, types) {
         if (iter.first == tr("Overview")) {
+            qCDebug(appLog) << "Skipping overview item";
             continue;
         }
 
         // 按设备类型列表顺序显示概况信息
         if (map.find(iter.first) != map.end()) {
+            qCDebug(appLog) << "Adding item:" << iter.first;
             QTableWidgetItem *itemFirst = new QTableWidgetItem(iter.first);
             mp_Overview->setItem(i, 0, itemFirst);
             QTableWidgetItem *itemSecond = new QTableWidgetItem(map.find(iter.first).value());
@@ -103,12 +108,13 @@ void PageOverview::updateInfo(const QMap<QString, QString> &map)
 
 void PageOverview::clearWidgets()
 {
+    qCDebug(appLog) << "PageOverview::clearWidgets";
     mp_Overview->clear();
 }
 
 void PageOverview::setLabel(const QString &)
 {
-
+    qCDebug(appLog) << "PageOverview::setLabel with one arg, doing nothing";
 }
 
 void PageOverview::setLabel(const QString &str1, const QString &str2)
@@ -119,10 +125,14 @@ void PageOverview::setLabel(const QString &str1, const QString &str2)
 
     // 设置ToolTip
     QString tips = str2;
-    if (tips.length() > ENTER_ONE)
+    if (tips.length() > ENTER_ONE) {
+        qCDebug(appLog) << "Adding newline to tips at" << ENTER_ONE;
         tips.insert(ENTER_ONE, QChar('\n'));
-    if (tips.length() > ENTER_TWO)
+    }
+    if (tips.length() > ENTER_TWO) {
+        qCDebug(appLog) << "Adding newline to tips at" << ENTER_TWO;
         tips.insert(ENTER_TWO, QChar('\n'));
+    }
 
     mp_OSLabel->setToolTip(tips);
 
@@ -133,6 +143,7 @@ void PageOverview::setLabel(const QString &str1, const QString &str2)
     // 社区版链接不同
     DSysInfo::UosEdition type = DSysInfo::uosEditionType();
     if (DSysInfo::UosCommunity == type) {
+        qCDebug(appLog) << "Community edition detected, using deepin link";
         linkStr = DEEPIN_LINK;
     }
 
@@ -161,17 +172,23 @@ void PageOverview::setLabel(const QString &str1, const QString &str2)
     // 资源文件获取
     QString path = "";
     if (str1.contains("desktop", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "Device is desktop";
         path = "device_desktop";
     } else if (str1.contains("laptop", Qt::CaseInsensitive) ||
                str1.contains("notebook", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "Device is laptop";
         path = "device_laptop";
     } else if (str1.contains("ternimal", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "Device is terminal";
         path = "device_terminal";
     } else if (str1.contains("Tablet", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "Device is tablet";
         path = "device_tablet";
     } else if (str1.contains("server", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "Device is server";
         path = "device_server";
     } else {
+        qCDebug(appLog) << "Device is unknown, using desktop icon";
         path = "device_desktop";
     }
 
@@ -183,6 +200,7 @@ void PageOverview::setLabel(const QString &str1, const QString &str2)
 
 void PageOverview::slotShowMenu(const QPoint &)
 {
+    qCDebug(appLog) << "Showing context menu";
     // 右键菜单
     mp_Menu->clear();
     mp_Menu->addAction(mp_Copy);
@@ -201,6 +219,7 @@ void PageOverview::slotActionCopy()
 
 void PageOverview::initWidgets()
 {
+    qCDebug(appLog) << "PageOverview::initWidgets start";
     // 初始化页面布局
     mp_OSLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     mp_DeviceLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
@@ -228,4 +247,5 @@ void PageOverview::initWidgets()
     vLayout->addWidget(mp_Overview);
     vLayout->addStretch();
     setLayout(vLayout);
+    qCDebug(appLog) << "PageOverview::initWidgets end";
 }

--- a/deepin-devicemanager/src/Page/PageTableHeader.cpp
+++ b/deepin-devicemanager/src/Page/PageTableHeader.cpp
@@ -45,6 +45,7 @@ PageTableHeader::~PageTableHeader()
 {
     qCDebug(appLog) << "PageTableHeader destructor start";
     if (mp_Table) {
+        qCDebug(appLog) << "Deleting table widget";
         delete mp_Table;
         mp_Table = nullptr;
     }
@@ -52,6 +53,7 @@ PageTableHeader::~PageTableHeader()
 
 void PageTableHeader::initWidgets()
 {
+    qCDebug(appLog) << "Initializing widgets";
     // 布局
     QHBoxLayout *hLayout = new QHBoxLayout(this);
     hLayout->setContentsMargins(0, 0, 0, 10);
@@ -63,12 +65,16 @@ void PageTableHeader::updateTable(const QList<QStringList> &lst, const QList<QSt
 {
     qCInfo(appLog) << "Updating table with" << lst.size() << "rows, resize:" << resizeTable << "step:" << step;
     int configRowNum = ROW_NUM;
-    if(resizeTable)
+    if(resizeTable) {
+        qCDebug(appLog) << "Resizing table, step:" << step;
         configRowNum = ROW_NUM - step;
+    }
 
     // 如果lst.size() == 1 则说明改设备只有一个
-    if (lst.size() <= 1)
+    if (lst.size() <= 1) {
+        qCDebug(appLog) << "List size <= 1, no data to display.";
         return;
+    }
 
     // 提前清楚内容
     mp_Table->clear();
@@ -86,10 +92,12 @@ void PageTableHeader::updateTable(const QList<QStringList> &lst, const QList<QSt
         // 表格内容行数小于4,表格高度与行数一致，为保证treewidget横向滚动条与item不重叠，添加滚动条高度
         mp_Table->setRowNum(row - 1);
         this->setFixedHeight(TREE_ROW_HEIGHT * row + HORSCROLL_WIDTH + WIDGET_MARGIN * 2 + BOTTOM_MARGIN);
+        qCDebug(appLog) << "Row count < configRowNum, setting row number to" << row - 1;
     } else {
         // 表格内容行数大于等于4,表格行数固定为4，为保证treewidget横向滚动条与item不重叠，添加滚动条高度
         mp_Table->setRowNum(configRowNum);
         this->setFixedHeight(TREE_ROW_HEIGHT * (configRowNum + 1) + HORSCROLL_WIDTH + WIDGET_MARGIN * 2  + BOTTOM_MARGIN);
+        qCDebug(appLog) << "Row count >= configRowNum, setting row number to" << configRowNum;
     }
 
     for (int i = 0; i < row - 1; i++) {
@@ -99,6 +107,7 @@ void PageTableHeader::updateTable(const QList<QStringList> &lst, const QList<QSt
                 for(int index = 0; index < lstMenuControl[i].size(); index++){
                     item->setData(lstMenuControl[i][index],Qt::UserRole+index);
                 }
+                qCDebug(appLog) << "Set data for header item at row:" << i << "column:" << j;
             }
             mp_Table->setItem(i, j, item);
         }
@@ -118,6 +127,7 @@ void PageTableHeader::setColumnAverage()
 
 void PageTableHeader::paintEvent(QPaintEvent *e)
 {
+    // qCDebug(appLog) << "Painting table header";
     DWidget::paintEvent(e);
 }
 

--- a/deepin-devicemanager/src/Page/PageTableWidget.cpp
+++ b/deepin-devicemanager/src/Page/PageTableWidget.cpp
@@ -48,18 +48,21 @@ void PageTableWidget::setColumnAndRow(int row, int column)
 
 void PageTableWidget::setItem(int row, int column, QTableWidgetItem *item)
 {
+    // qCDebug(appLog) << "Setting item at row:" << row << "column:" << column;
     // 设置Item
     mp_Table->setItem(row, column, item);
 }
 
 QString PageTableWidget::toString()
 {
+    // qCDebug(appLog) << "Converting table content to QString";
     // table 内容转为QString
     return mp_Table->toString();
 }
 
 bool PageTableWidget::isOverview()
 {
+    // qCDebug(appLog) << "Checking if it is an overview page";
     // 是否是概况界面
     PageInfo *par = dynamic_cast<PageInfo *>(this->parent());
     return par->isOverview();
@@ -67,6 +70,7 @@ bool PageTableWidget::isOverview()
 
 bool PageTableWidget::isBaseBoard()
 {
+    // qCDebug(appLog) << "Checking if it is a baseboard page";
     // 是否是主板界面
     PageInfo *par = dynamic_cast<PageInfo *>(this->parent());
     return par->isBaseBoard();
@@ -74,49 +78,63 @@ bool PageTableWidget::isBaseBoard()
 
 void PageTableWidget::clear()
 {
+    // qCDebug(appLog) << "Clearing table content";
     // 清空Table内容
     mp_Table->clear();
 }
 
 void PageTableWidget::setRowHeight(int row, int height)
 {
+    // qCDebug(appLog) << "Setting row height:" << height;
     // 设置行高
     mp_Table->setRowHeight(row, height);
 }
 
 void PageTableWidget::setItemDelegateForRow(int row, RichTextDelegate *itemDelegate)
 {
+    qCDebug(appLog) << "Setting item delegate for row:" << row;
     // 设置单元格代理
     if (itemDelegate == nullptr) {
+        qCDebug(appLog) << "Using default item delegate.";
         mp_Table->setItemDelegateForRow(row, mp_Table->itemDelegate());
     } else {
+        qCDebug(appLog) << "Using rich text item delegate.";
         mp_Table->setItemDelegateForRow(row, itemDelegate);
     }
 }
 
 bool PageTableWidget::isCurDeviceEnable()
 {
+    qCDebug(appLog) << "Checking if the current device is enabled";
     // 当前设备是否可用
     return mp_Table->isCurDeviceEnable();
 }
 
 void PageTableWidget::setCurDeviceState(bool enable, bool available)
 {
+    qCDebug(appLog) << "Setting current device state - enabled:" << enable << "available:" << available;
     // 设置当前设备状态
     mp_Table->setCurDeviceState(enable, available);
 }
 
 void PageTableWidget::expandTable()
 {
+    qCDebug(appLog) << "Expanding table";
     // 表格展开
-    if (mp_Table)
+    if (mp_Table) {
+        qCDebug(appLog) << "Expanding table";
         mp_Table->expandCommandLinkClicked();
+    }
 }
 
 bool PageTableWidget::isExpanded()
 {
-    if (mp_Table)
+    // qCDebug(appLog) << "Checking if the table is expanded";
+    if (mp_Table) {
+        // qCDebug(appLog) << "Table is expanded";
         return mp_Table->isExpanded();
+    }
+    // qCDebug(appLog) << "Table is not expanded";
     return false;
 }
 
@@ -129,11 +147,13 @@ void PageTableWidget::setDeviceEnable(bool enable, bool available)
 
 void PageTableWidget::paintEvent(QPaintEvent *event)
 {
+    // qCDebug(appLog) << "Painting table";
     DWidget::paintEvent(event);
 }
 
 void PageTableWidget::initUI()
 {
+    qCDebug(appLog) << "Initializing UI";
     // 初始化页面布局
     QVBoxLayout *whLayout = new QVBoxLayout();
 


### PR DESCRIPTION
Add more logs for device manager.

Log: More logs for device manager.

## Summary by Sourcery

Add extensive debug logging across the deepin-devicemanager codebase to improve visibility into device detection, command execution, driver management, and UI workflows.

Enhancements:
- Add debug statements in DeviceGenerator and related generators to log each device detection and parsing step
- Instrument CmdTool with logs for command outputs, filtering, and map updates
- Log D-Bus calls and replies in DBusDriverInterface, DBusInterface, and DBusTouchPad to trace IPC interactions
- Add tracing in PageDriverManager, MainWindow, and other page classes to monitor scanning, installation, backup, and UI events
- Insert logs in driver control, backup thread, HTTP interface, and driver scanner to follow workflow progression and error conditions
- Add logging in UI widgets (Page*, DeviceWidget, TableView) to track events, painting, resizing, and context menu actions