### PR TITLE
fix: Format graphics card resolution display

### DIFF
--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -78,7 +78,7 @@ void ThreadExecXrandr::loadXrandrInfo(QList<QMap<QString, QString>> &lstMap, con
             QRegExp re(".*([0-9]{1,5}\\sx\\s[0-9]{1,5}).*([0-9]{1,5}\\sx\\s[0-9]{1,5}).*([0-9]{1,5}\\sx\\s[0-9]{1,5}).*");
             if (re.exactMatch(line)) {
                 lstMap[lstMap.count() - 1].insert("minResolution", re.cap(1));
-                lstMap[lstMap.count() - 1].insert("curResolution", re.cap(2).replace("x", "×", Qt::CaseInsensitive));
+                lstMap[lstMap.count() - 1].insert("curResolution", re.cap(2).replace(" ", "").replace("x", "×", Qt::CaseInsensitive));
                 lstMap[lstMap.count() - 1].insert("maxResolution", re.cap(3));
             }
             continue;


### PR DESCRIPTION
Fixed the formatted resolution display of graphics cards by removing redundant spaces.

Log: Improve resolution display formatting
Bug: https://pms.uniontech.com/bug-view-324363.html
Change-Id: I9c2ee6868354bc2c55c45ffec42ba6a34f3e961d

## Summary by Sourcery

Bug Fixes:
- Strip spaces from the captured resolution string before replacing 'x' with '×' to correct the formatted display.