### PR TITLE
feat: [GPU] Add logic to show GPU info.

### DIFF
--- a/deepin-devicemanager-server/CMakeLists.txt
+++ b/deepin-devicemanager-server/CMakeLists.txt
@@ -2,6 +2,7 @@ project(deepin-devicemanager-server C CXX)
 
 add_subdirectory(deepin-deviceinfo)
 add_subdirectory(deepin-devicecontrol)
+add_subdirectory(customgpuinfo)
 
 #TEST--------------------------------------------------
 if (CMAKE_COVERAGE_ARG STREQUAL "CMAKE_COVERAGE_ARG_ON")

--- a/deepin-devicemanager-server/customgpuinfo/CMakeLists.txt
+++ b/deepin-devicemanager-server/customgpuinfo/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.7)
+
+set(BIN_NAME "customgpuinfo")
+
+find_package(Qt5 COMPONENTS Core REQUIRED)
+
+file(GLOB_RECURSE SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+)
+
+add_executable(${BIN_NAME}
+    ${SRC}
+)
+
+target_include_directories(${BIN_NAME} PUBLIC
+    Qt5::Core
+)
+
+target_link_libraries(${BIN_NAME} PRIVATE
+    Qt5::Core
+)
+
+install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/deepin-devicemanager)

--- a/deepin-devicemanager-server/customgpuinfo/main.cpp
+++ b/deepin-devicemanager-server/customgpuinfo/main.cpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QProcess>
+#include <QMap>
+#include <QRegularExpression>
+#include <QFile>
+#include <QDebug>
+
+#include <iostream>
+
+//  名称("Name") 厂商("Vendor") 型号("Model") 显存("Graphics Memory")
+
+constexpr char kName[] { "Name" };
+constexpr char kVendor[] { "Vendor" };
+constexpr char kModel[] { "Model" };
+constexpr char kGraphicsMemory[] { "Graphics Memory" };
+
+bool getGpuBaseInfo(QMap<QString, QString> &mapInfo)
+{   
+    QProcess process;
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    process.setProcessEnvironment(env);
+    process.start("/usr/bin/glxinfo", QStringList() << "-B");
+    if (!process.waitForFinished(3000)) {
+        qCritical() << "Error executing glxinfo:" << process.errorString();
+        return false;
+    }
+
+    QString output = QString::fromLocal8Bit(process.readAllStandardOutput());
+    QStringList lines = output.split('\n');
+    QRegularExpression regex("^([^:]+):\\s*(.+)$");
+    for (const QString &line : lines) {
+        QRegularExpressionMatch match = regex.match(line);
+        if (match.hasMatch()) {
+            QString key = match.captured(1).trimmed();
+            QString value = match.captured(2).trimmed();
+            if (key == "OpenGL renderer string") {
+                mapInfo.insert(kName, value);
+                mapInfo.insert(kModel, value);
+            } else if (key == "OpenGL vendor string") {
+                mapInfo.insert(kVendor, value);
+            }
+        }
+    }
+
+    return true;
+}
+
+bool getGpuMemInfoForFTDTM(QMap<QString, QString> &mapInfo)
+{
+    const QString filePath = "/sys/kernel/debug/gc/meminfo";
+    QString totalValue;
+    bool foundTotal = false;
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qCritical() << "Error opening /sys/kernel/debug/gc/meminfo:" << file.errorString();
+        return false;
+    }
+
+    QString content = QString::fromUtf8(file.readAll());
+    file.close();
+
+    if (content.isEmpty()) {
+        qCritical() << "Error: /sys/kernel/debug/gc/meminfo File is empty!";
+        return false;
+    }
+
+    QRegularExpression system0Regex(R"(POOL SYSTEM0:*(.*?)POOL VIRTUAL:)",
+                                    QRegularExpression::DotMatchesEverythingOption);
+    QRegularExpressionMatch system0Match = system0Regex.match(content);
+
+    if (!system0Match.hasMatch()) {
+        qCritical() << "Error: Failed to find SYSTEM0 section";
+        return false;
+    }
+
+    QString system0Content = system0Match.captured(1);
+    QRegularExpression totalRegex(R"(Total\s*:\s*(\d+)\s+B)");
+    QRegularExpressionMatch totalMatch = totalRegex.match(system0Content);
+    if (totalMatch.hasMatch()) {
+        totalValue = totalMatch.captured(1);
+        foundTotal = true;
+    }
+
+    if (!foundTotal || totalValue.isEmpty()) {
+        qCritical() << "Error: Failed to find Total value in SYSTEM0 content";
+        return false;
+    }
+
+    bool ok;
+    quint64 memSize = totalValue.trimmed().toULong(&ok, 10);
+    if (ok && memSize >= 1048576) {
+        memSize /= 1048576;
+        auto curSize = memSize / 1024.0;
+        if (curSize >= 1) {
+            totalValue = QString::number(curSize) + "GB";
+        } else {
+            totalValue = QString::number(memSize) + "MB";
+        }
+    }
+
+    mapInfo.insert(kGraphicsMemory, totalValue);
+
+    return true;
+}
+
+int main(int argc, char *argv[])
+{
+    QMap<QString, QString> mapInfo;
+    if (getGpuBaseInfo(mapInfo) && getGpuMemInfoForFTDTM(mapInfo)) {
+        for (auto it = mapInfo.begin(); it != mapInfo.end(); ++it)
+            std::cout << it.key().toStdString() << ": " << it.value().toStdString() << std::endl;
+        return 0;
+    } else {
+        return 1;
+    }
+}

--- a/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/deviceinterface.h
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/deviceinterface.h
@@ -39,6 +39,8 @@ public slots:
      */
     Q_SCRIPTABLE void setMonitorDeviceFlag(bool flag);
 
+    Q_SCRIPTABLE QString getGpuInfoByCustom(const QString &cmd, const QStringList &arguments);
+
 private:
     bool getUserAuthorPasswd();
 };

--- a/deepin-devicemanager/assets/org.deepin.devicemanager.json
+++ b/deepin-devicemanager/assets/org.deepin.devicemanager.json
@@ -34,6 +34,16 @@
             "description": "此配置项默认为无效的。如需让toml文件内容显示生效，请配置对应文件名。需保证操作者具备读取权限。",
             "permissions": "readwrite",
             "visibility": "private"
+          },
+          "CommandToGetGPUInfo": {
+            "value": "",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Command to get GPU infomation",
+            "name[zh_CN]": "获取GPU信息的命令",
+            "description": "此配置项默认为空。如果specialComType==8,程序则启用此项配置。",
+            "permissions": "readwrite",
+            "visibility": "private"
           }
   }
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
@@ -284,6 +284,15 @@ void DeviceGpu::setGpuInfo(const QMap<QString, QString> &mapInfo)
     getOtherMapInfo(mapInfo);
 }
 
+//  名称(Name) 厂商(Vendor) 型号(Model) 显存(Graphics Memory)
+void DeviceGpu::setGpuInfoByCustom(const QMap<QString, QString> &mapInfo)
+{
+    setAttribute(mapInfo, "Name", m_Name);
+    setAttribute(mapInfo, "Vendor", m_Vendor);
+    setAttribute(mapInfo, "Model", m_Model);
+    setAttribute(mapInfo, "Graphics Memory", m_GraphicsMemory);
+}
+
 const QString &DeviceGpu::name() const
 {
     return m_Name;

--- a/deepin-devicemanager/src/DeviceManager/DeviceGpu.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceGpu.h
@@ -56,6 +56,8 @@ public:
        */
     void setGpuInfo(const QMap<QString, QString> &mapInfo);
 
+    void setGpuInfoByCustom(const QMap<QString, QString> &mapInfo);
+
     /**
      * @brief name:获取名称属性值
      * @return QString 名称属性值

--- a/deepin-devicemanager/src/GenerateDevice/CustomGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CustomGenerator.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "CustomGenerator.h"
+#include "DeviceGpu.h"
+#include "DBusInterface.h"
+#include "commontools.h"
+
+#include <QProcess>
+#include <QRegularExpression>
+#include <QDir>
+#include <QDBusInterface>
+#include <QDBusReply>
+
+CustomGenerator::CustomGenerator(QObject *parent)
+    : DeviceGenerator(parent)
+{
+}
+
+void CustomGenerator::generatorGpuDevice()
+{
+    QString cmd = CommonTools::getGpuInfoCommandFromDConfig();
+    if (cmd.isEmpty()) {
+        DeviceGenerator::generatorGpuDevice();
+        return;
+    }
+
+    QStringList arguments;
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    QString display = env.value("DISPLAY");
+    QString xauthority = env.value("XAUTHORITY");
+    if (display.isEmpty() || xauthority.isEmpty()) {
+        qWarning() << "DISPLAY or XAUTHORITY is not set!";
+    } else {
+        arguments << display << xauthority;
+    }
+
+    QString tmpGpuInfo;
+    DBusInterface::getInstance()->getGpuInfoByCustom(cmd, arguments, tmpGpuInfo);
+    if (tmpGpuInfo.isEmpty()) {
+        qCritical() << "Failed to get gpu info by commad " << cmd;
+        return;
+    }
+
+    QList<QMap<QString, QString>> gpuInfo;
+    QStringList mapBlocks = tmpGpuInfo.split("\n\n");
+    for (const QString &block : mapBlocks) {
+        QMap<QString, QString> infoMap;
+        QStringList lines = block.split("\n");
+        for (const QString &line : lines) {
+            int colonIndex = line.indexOf(':');
+            if (colonIndex != -1) {
+                QString key = line.left(colonIndex).trimmed();
+                QString value = line.mid(colonIndex + 1).trimmed();
+                infoMap.insert(key, value);
+            }
+        }
+        if (!infoMap.isEmpty())
+            gpuInfo.push_back(infoMap);
+    }
+
+    for(int i = 0; i < gpuInfo.count(); ++i) {
+        DeviceGpu *device = new DeviceGpu();
+        device->setCanUninstall(false);
+        device->setForcedDisplay(true);
+        device->setGpuInfoByCustom(gpuInfo.at(i));
+        DeviceManager::instance()->addGpuDevice(device);
+    }
+}
+
+void CustomGenerator::generatorMonitorDevice()
+{
+    QString toDir = "/sys/class/drm";
+    QDir toDir_(toDir);
+
+    if (!toDir_.exists())
+        return;
+
+    QFileInfoList fileInfoList = toDir_.entryInfoList(QDir::NoFilter, QDir::Name);
+    foreach(QFileInfo fileInfo, fileInfoList) {
+        if (fileInfo.fileName() == "." || fileInfo.fileName() == ".." || !fileInfo.fileName().startsWith("card"))
+            continue;
+
+        if (QFile::exists(fileInfo.filePath() + "/" + "edid")) {
+            QStringList allEDIDS_all;
+            allEDIDS_all.append(fileInfo.filePath() + "/" + "edid");
+            QString interface = fileInfo.fileName().remove("card0-").remove("card1-").remove("card2-");
+            CommonTools::parseEDID(allEDIDS_all, interface);
+         }
+    }
+}

--- a/deepin-devicemanager/src/GenerateDevice/CustomGenerator.h
+++ b/deepin-devicemanager/src/GenerateDevice/CustomGenerator.h
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef CUSTOMGENERATOR_H
+#define CUSTOMGENERATOR_H
+
+#include "DeviceGenerator.h"
+
+class CustomGenerator : public DeviceGenerator
+{
+public:
+    CustomGenerator(QObject *parent = nullptr);
+
+    /**
+     * @brief generatorGpuDevice:生成显卡信息
+     */
+    void generatorGpuDevice() override;
+
+    /**
+     * @brief generatorMonitorDevice:生成显示设备信息
+     */
+    void generatorMonitorDevice() override;
+};
+
+#endif // CUSTOMGENERATOR_H

--- a/deepin-devicemanager/src/GenerateDevice/DBusInterface.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DBusInterface.cpp
@@ -46,6 +46,18 @@ void DBusInterface::refreshInfo()
     mp_Iface->asyncCall("refreshInfo");
 }
 
+bool DBusInterface::getGpuInfoByCustom(const QString &cmd, const QStringList &arguments, QString &gpuInfo)
+{
+    QDBusReply<QString> replyList = mp_Iface->call("getGpuInfoByCustom", cmd, arguments);
+    if (replyList.isValid()) {
+        gpuInfo = replyList.value();
+        return true;
+    } else {
+        qCritical() << "Error: failed to call dbus to get gpu memery info! ";
+        return false;
+    }
+}
+
 void DBusInterface::init()
 {
     // 1. 连接到dbus

--- a/deepin-devicemanager/src/GenerateDevice/DBusInterface.h
+++ b/deepin-devicemanager/src/GenerateDevice/DBusInterface.h
@@ -47,6 +47,8 @@ public:
      */
     void refreshInfo();
 
+    bool getGpuInfoByCustom(const QString &cmd, const QStringList &arguments, QString &gpuInfo);
+
 protected:
     DBusInterface();
 

--- a/deepin-devicemanager/src/GenerateDevice/DeviceFactory.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceFactory.cpp
@@ -8,6 +8,7 @@
 #include "MipsGenerator.h"
 #include "ArmGenerator.h"
 #include "HWGenerator.h"
+#include "CustomGenerator.h"
 #include "commonfunction.h"
 
 // Qt库文件
@@ -41,6 +42,8 @@ DeviceGenerator *DeviceFactory::getDeviceGenerator()
                 generator = new HWGenerator();
             else if (type == "PGUX")
                 generator = new HWGenerator();
+            else if (type == "CustomType")
+                generator = new CustomGenerator();
             else
                 generator = new HWGenerator();
         } else

--- a/deepin-devicemanager/src/Tool/commontools.cpp
+++ b/deepin-devicemanager/src/Tool/commontools.cpp
@@ -4,6 +4,8 @@
 
 #include "commontools.h"
 #include "DDLog.h"
+#include "EDIDParser.h"
+#include "DeviceMonitor.h"
 
 #include <QLoggingCategory>
 #include <QDateTime>
@@ -11,6 +13,8 @@
 #include <QDBusReply>
 #include <QFile>
 #include <QDir>
+#include <QProcess>
+#include <DConfig>
 
 DWIDGET_USE_NAMESPACE
 using namespace DDLog;
@@ -161,4 +165,57 @@ QString CommonTools::getUrl()
 QString CommonTools::getBackupPath()
 {
     return "/usr/share/deepin-devicemanager/";
+}
+
+void CommonTools::parseEDID(const QStringList &allEDIDS, const QString &input)
+{
+    for (auto edid:allEDIDS) {
+        QProcess process;
+        process.start(QString("hexdump %1").arg(edid));
+        process.waitForFinished(-1);
+
+        QString deviceInfo = process.readAllStandardOutput();
+        if (deviceInfo.isEmpty())
+            continue;
+
+        QString edidStr;
+        QStringList lines = deviceInfo.split("\n");
+        for (auto line:lines) {
+            QStringList words = line.trimmed().split(" ");
+            if (words.size() != 9)
+                continue;
+
+            words.removeAt(0);
+            QString l = words.join("");
+            l.append("\n");
+            edidStr.append(l);
+        }
+
+        lines = edidStr.split("\n");
+        if (lines.size() > 3){
+            EDIDParser edidParser;
+            QString errorMsg;
+            edidParser.setEdid(edidStr,errorMsg,"\n", false);
+
+            QMap<QString, QString> mapInfo;
+            mapInfo.insert("Vendor",edidParser.vendor());
+            mapInfo.insert("Model",edidParser.model());
+            //mapInfo.insert("Date",edidParser.releaseDate());
+            mapInfo.insert("Size",edidParser.screenSize());
+            mapInfo.insert("Display Input",input);
+
+            DeviceMonitor *device = new DeviceMonitor();
+            device->setInfoFromEdid(mapInfo);
+            DeviceManager::instance()->addMonitor(device);
+        }
+    }
+}
+
+QString CommonTools::getGpuInfoCommandFromDConfig()
+{
+    QString cmd;
+    DConfig *dconfig = DConfig::create("org.deepin.devicemanager","org.deepin.devicemanager");
+    if (dconfig && dconfig->isValid() && dconfig->keyList().contains("CommandToGetGPUInfo"))
+        cmd = dconfig->value("CommandToGetGPUInfo").toString();
+    return cmd;
 }

--- a/deepin-devicemanager/src/Tool/commontools.h
+++ b/deepin-devicemanager/src/Tool/commontools.h
@@ -78,6 +78,9 @@ public:
      */
     static QString getBackupPath();
 
+    static void parseEDID(const QStringList &allEDIDS, const QString &input);
+    static QString getGpuInfoCommandFromDConfig();
+
 signals:
 
 public slots:

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -137,6 +137,9 @@ QString Common::checkBoardVendorFlag()
         case PGUX:
             boardVendorKey = "PGUX";
             break;
+        case kCustomType:
+            boardVendorKey = "CustomType";
+            break;
         default:
             boardVendorKey = "PGUW";
             break;

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -22,7 +22,10 @@ public:
         KLVV,
         KLVU,
         PGUV,
-        PGUX
+        PGUX,
+        kSpecialType6,
+        kSpecialType7,
+        kCustomType
     };
     static QString getArch();
 


### PR DESCRIPTION
-- In some special computer, the GPU info not show. -- Add logic to show GPU info.

Log: add feature for GPU.
Task: https://pms.uniontech.com/task-view-378987.html

## Summary by Sourcery

Provide enhanced GPU information support by adding configurable command-based retrieval, EDID parsing for monitors, and integration via a new CustomGenerator and D-Bus method.

New Features:
- Allow specifying a custom GPU info command in DConfig and retrieve its output.
- Implement a stand-alone customgpuinfo binary that uses glxinfo and kernel meminfo to extract GPU details.
- Add CommonTools::parseEDID to parse EDID blobs and register display monitors.
- Introduce CustomGenerator to generate GPU and monitor devices using custom commands and EDID parsing.
- Expose a new getGpuInfoByCustom D-Bus method for fetching GPU info on the server.

Enhancements:
- Extend DeviceGpu with setGpuInfoByCustom and register a new 'CustomType' in the device factory.

Build:
- Add customgpuinfo subdirectory and binary to the server CMake configuration.