### PR TITLE
fix: Improve supported resolution detection for display devices

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -1050,7 +1050,7 @@ void DeviceManager::addMonitor(DeviceMonitor *const device)
     m_ListDeviceMonitor.append(device);
 }
 
-void DeviceManager::setMonitorInfoFromXrandr(const QString &main, const QString &edid, const QString &rate)
+void DeviceManager::setMonitorInfoFromXrandr(const QString &main, const QString &edid, const QString &rate, const QString &xrandr)
 {
     // 从xrandr中添加显示设备信息
     QList<DeviceBaseInfo *>::iterator it = m_ListDeviceMonitor.begin();
@@ -1059,7 +1059,7 @@ void DeviceManager::setMonitorInfoFromXrandr(const QString &main, const QString 
         if (!device)
             continue;
 
-        if (device->setInfoFromXradr(main, edid, rate))
+        if (device->setInfoFromXradr(main, edid, rate, xrandr))
             return;
     }
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.h
@@ -268,7 +268,7 @@ public:
      * @param main:主显示器信息
      * @param edid:edid信息
      */
-    void setMonitorInfoFromXrandr(const QString &main, const QString &edid, const QString &rate = "");
+    void setMonitorInfoFromXrandr(const QString &main, const QString &edid, const QString &rate = "", const QString &xrandr = "");
 
     /**
      * @brief setMonitorInfoFromDbus:设置由 dbus 获取的显示设备信息

--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -16,6 +16,7 @@
 
 // 其它头文件
 #include <math.h>
+#include <QProcess>
 
 DWIDGET_USE_NAMESPACE
 
@@ -95,7 +96,7 @@ void DeviceMonitor::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "", m_DisplayInput);
     setAttribute(mapInfo, "Size", m_ScreenSize);
     setAttribute(mapInfo, "", m_MainScreen);
-    setAttribute(mapInfo, "Resolution", m_SupportResolution);
+//    setAttribute(mapInfo, "Resolution", m_SupportResolution);
 
     double inch = 0.0;
     QSize size(0, 0);
@@ -103,19 +104,19 @@ void DeviceMonitor::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     m_ScreenSize = inchValue;
 
     // 获取当前分辨率 和 当前支持分辨率
-    QStringList listResolution = m_SupportResolution.split(" ");
-    m_SupportResolution = "";
-    foreach (const QString &word, listResolution) {
-        if (word.contains("@")) {
-            m_SupportResolution.append(word);
-            m_SupportResolution.append(", ");
-        }
-    }
+//    QStringList listResolution = m_SupportResolution.split(" ");
+//    m_SupportResolution = "";
+//    foreach (const QString &word, listResolution) {
+//        if (word.contains("@")) {
+//            m_SupportResolution.append(word);
+//            m_SupportResolution.append(", ");
+//        }
+//    }
 
     // 计算显示比例
     caculateScreenRatio();
 
-    m_SupportResolution.replace(QRegExp(", $"), "");
+//    m_SupportResolution.replace(QRegExp(", $"), "");
 
     m_ProductionWeek  = transWeekToDate(mapInfo["Year of Manufacture"], mapInfo["Week of Manufacture"]);
     setAttribute(mapInfo, "Serial ID", m_SerialNumber);
@@ -174,7 +175,7 @@ QString DeviceMonitor::transWeekToDate(const QString &year, const QString &week)
     return date.toString("yyyy-MM");
 }
 
-bool DeviceMonitor::setInfoFromXradr(const QString &main, const QString &edid, const QString &rate)
+bool DeviceMonitor::setInfoFromXradr(const QString &main, const QString &edid, const QString &rate, const QString &xrandr)
 {
     if(m_IsTomlSet)
         return false;
@@ -204,6 +205,19 @@ bool DeviceMonitor::setInfoFromXradr(const QString &main, const QString &edid, c
                 } else
                     m_CurrentResolution = QString("%1").arg(reScreenSize.cap(1)).replace("x", "×", Qt::CaseInsensitive);
             }
+        }
+
+        QMap<QString, QStringList> monitorResolutionMap = getMonitorResolutionMap(xrandr, m_RawInterface);
+
+        if (monitorResolutionMap.size() == 1) {
+            m_SupportResolution.clear();
+            foreach (const QString &word, monitorResolutionMap.value(m_RawInterface)) {
+                if (word.contains("@")) {
+                    m_SupportResolution.append(word);
+                    m_SupportResolution.append(", ");
+                }
+            }
+            m_SupportResolution.replace(QRegExp(", $"), "");
         }
         return false;
     }
@@ -324,6 +338,13 @@ bool DeviceMonitor::setMainInfoFromXrandr(const QString &info, const QString &ra
     QRegExp reStart("^([a-zA-Z]*)-[\\s\\S]*");
     if (reStart.exactMatch(info)) {
         m_Interface = reStart.cap(1);
+    }
+
+    if (info.contains("connected")) {
+        QStringList monitorInfoList = info.split(" ", QString::SkipEmptyParts);
+        if (monitorInfoList.size() > 0){
+            m_RawInterface = monitorInfoList.at(0).trimmed();
+        }
     }
 
     // wayland xrandr --verbose无primary信息
@@ -451,4 +472,64 @@ bool DeviceMonitor::caculateScreenSize(const QString &edid)
     double inch = std::sqrt(height * height + width * width) / 2.54 / 10;
     m_ScreenSize = QString("%1 %2(%3mm×%4mm)").arg(QString::number(inch, '0', 1)).arg(translateStr("inch")).arg(width).arg(height);
     return true;
+}
+
+QMap<QString, QStringList> DeviceMonitor::getMonitorResolutionMap(QString rawText, QString key, bool round)
+{
+    QMap<QString, QStringList> monitorResolutionMap;
+
+    if (!rawText.isEmpty()) {
+        QStringList rawLines = rawText.split("\n", QString::SkipEmptyParts);
+
+        // get the resolution
+        for (auto line : rawLines) {
+
+            // handel disconnected monitor
+            if (line.contains("disconnected", Qt::CaseInsensitive))
+                continue;
+
+            // handel connected monitor
+            if (!line.startsWith(" ") && line.contains("connected")) {
+                QStringList monitorInfoList = line.split(" ", QString::SkipEmptyParts);
+                if (monitorInfoList.size() > 0){
+                    monitorResolutionMap.insert(monitorInfoList.at(0).trimmed(), QStringList());
+                }
+            }
+
+            // handel resolution
+            if (line.startsWith(" ") && !line.contains("connect") && !line.contains(":")){
+                QStringList resolutions = line.trimmed().replace("*", "").replace("+", "").split(" ", QString::SkipEmptyParts);
+                if (resolutions.size() >= 2 && monitorResolutionMap.size() > 0) {
+                    QString resolution = resolutions.at(0);
+                    resolutions.pop_front();
+
+                    for(auto rate : resolutions) {
+                        QString realResolution;
+
+                        if (round) {
+                            bool ok = false;
+                            double realRate = rate.toDouble(&ok);
+                            if (ok) {
+                                realResolution = tr("%1@%2Hz").arg(resolution).arg(QString::number(realRate, 'g', realRate >=100 ? 3 : 2));
+                            }
+                        } else {
+                            realResolution = tr("%1@%2Hz").arg(resolution).arg(rate);
+                        }
+
+                        if (!monitorResolutionMap.value(monitorResolutionMap.lastKey()).contains(realResolution)) {
+                            monitorResolutionMap[monitorResolutionMap.lastKey()].append(realResolution);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (monitorResolutionMap.keys().contains(key)) {
+        return QMap<QString, QStringList>{{key, monitorResolutionMap.value(key)}};
+    } else {
+        monitorResolutionMap.clear();
+    }
+
+    return monitorResolutionMap;
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.h
@@ -38,7 +38,7 @@ public:
      * @param edid:edid信息
      * @return 布尔值，true:信息设置成功；false:信息设置失败
      */
-    bool setInfoFromXradr(const QString &main, const QString &edid, const QString &rate);
+    bool setInfoFromXradr(const QString &main, const QString &edid, const QString &rate, const QString &xrandr);
 
     // 将年周转化为年月
     /**
@@ -178,7 +178,14 @@ private:
      */
     bool caculateScreenSize(const QString &edid);
 
-
+    /**
+     * @brief getMonitorResolutionMap:从xrandr字符串获取格式化
+     * @param rawText:原始xrandr输出字符串
+     * @param key:显示器编号:如 HDMI-0, VGA-1
+     * @param round:是否保留整数，如60.00Hz保留后为60Hz
+     * @return 显示器编号键值对，如{"HDMI-0": ["1920x1080@60Hz, "1920x1080@50Hz",..]}
+     */
+    QMap<QString, QStringList> getMonitorResolutionMap(QString rawText, QString key = "", bool round = true);
 
 private:
     QString         m_Model;             //<! 【型号】
@@ -186,7 +193,7 @@ private:
     QString         m_VGA;               //<! 【VGA】
     QString         m_HDMI;              //<! 【HDMI】
     QString         m_DVI;               //<! 【DVI】
-    QString         m_Interface;         //<! 【显示屏借口类型】
+    QString         m_Interface;         //<! 【显示屏接口类型】
     QString         m_ScreenSize;        //<! 【屏幕尺寸】
     QString         m_AspectRatio;       //<! 【显示比例】
     QString         m_MainScreen;        //<! 【主显示器】
@@ -199,6 +206,7 @@ private:
     int             m_Width;             //<!  屏幕的宽度
     int             m_Height;            //<!  屏幕的高度
     bool            m_IsTomlSet;
+    QString         m_RawInterface;      //<! 【原始显示屏接口类型】
 };
 
 #endif // DEVICEMONITOR_H

--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -43,6 +43,7 @@
 #include <QDir>
 #include <QVBoxLayout>
 #include <QTimer>
+#include <QtConcurrent/QtConcurrent>
 
 DWIDGET_USE_NAMESPACE
 using namespace DDLog;
@@ -521,6 +522,15 @@ void MainWindow::slotLoadingFinish(const QString &message)
 
         if (ret && lst.size() > 0) {//当设备大小为0时，显示概况信息
             mp_DeviceWidget->updateDevice(mp_DeviceWidget->currentIndex(), lst);
+
+            // bug-325731
+            if (mp_DeviceWidget->currentIndex() == QObject::tr("Monitor")) {
+                QtConcurrent::run([=](){
+                    QThread::msleep(700);
+                    emit mp_DeviceWidget->itemClicked(mp_DeviceWidget->currentIndex());
+                    qWarning() << mp_DeviceWidget->currentIndex();
+                });
+            }
         } else {
             QMap<QString, QString> overviewMap = DeviceManager::instance()->getDeviceOverview();
             mp_DeviceWidget->updateOverview(overviewMap);

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -104,6 +104,8 @@ void ThreadExecXrandr::loadXrandrVerboseInfo(QList<QMap<QString, QString>> &lstM
 {
     QString deviceInfo;
     runCmd(deviceInfo, cmd);
+    QString xrandInfo;
+    runCmd(xrandInfo, "xrandr");
 
     QStringList lines = deviceInfo.split("\n");
     QStringList::iterator it = lines.begin();
@@ -116,10 +118,11 @@ void ThreadExecXrandr::loadXrandrVerboseInfo(QList<QMap<QString, QString>> &lstM
         if (reg.exactMatch(*it) && !(*it).contains("disconnected")) {
             // 新的显示屏
             QMap<QString, QString> newMap;
-            newMap.insert("mainInfo", (*it).trimmed());
+            newMap.insert("mainInfo", (*it).trimmed());            
             auto mainInfoList = (*it).trimmed().split(" ");
             if (mainInfoList.size() > 0) {
                 newMap.insert("port", mainInfoList.at(0));
+                newMap.insert("xrandr", xrandInfo);
             }
             lstMap.append(newMap);
             continue;
@@ -147,9 +150,10 @@ void ThreadExecXrandr::loadXrandrVerboseInfo(QList<QMap<QString, QString>> &lstM
 
         // 获取当前频率
         if ((*it).contains("*current")) {
+            // QString ss = *it;
             if ((it += 2) >= lines.end())
                 return;
-            QRegExp regRate(".*([0-9]{1,5}\\.[0-9]{1,5}Hz).*");
+             QRegExp regRate(".*([0-9]{1,5}\\.[0-9]{1,5}Hz).*");
             if (regRate.exactMatch(*it))
                 last.insert("rate", regRate.cap(1));
         }
@@ -246,7 +250,7 @@ void ThreadExecXrandr::getMonitorInfoFromXrandrVerbose()
         if ((*it).size() < 1)
             continue;
 
-        DeviceManager::instance()->setMonitorInfoFromXrandr((*it)["mainInfo"], (*it)["edid"], (*it)["rate"]);
+        DeviceManager::instance()->setMonitorInfoFromXrandr((*it)["mainInfo"], (*it)["edid"], (*it)["rate"], (*it)["xrandr"]);
     }
 }
 


### PR DESCRIPTION
Fixed refresh rate errors and spelling mistakes in Device Manager → Display → Supported Resolutions. Now accurately obtains resolutions from xrandr output (keeping only integer values) instead of potentially problematic hwinfo detection.

Log: Fix display resolution detection method
Bug: https://pms.uniontech.com/bug-view-325731.html
Change-Id: I377caf0def3455191a3189eac734a608443b47e6

## Summary by Sourcery

Replace the old hwinfo-based resolution detection with a new xrandr parsing approach to accurately gather supported resolutions and refresh rates, add a helper function for mapping resolutions, update the data flow to include raw xrandr output, and implement a UI refresh workaround for the Monitor page.

New Features:
- Parse xrandr output to reliably detect supported display resolutions and refresh rates
- Automatically refresh the Monitor view after loading to ensure updated display details

Bug Fixes:
- Fix refresh rate errors by rounding and trimming Hz values to integers
- Correct spelling mistakes in display interface comments

Enhancements:
- Introduce getMonitorResolutionMap helper for extracting monitor‐specific resolutions from raw xrandr data
- Extend DeviceMonitor and DeviceManager APIs to propagate raw xrandr output through the resolution detection pipeline
- Extract and store the raw interface identifier from xrandr lines for accurate resolution mapping

Chores:
- Comment out the deprecated hwinfo-based resolution parsing code