### PR TITLE
fix: maintain the monitor info in special machine.

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -96,7 +96,9 @@ void DeviceMonitor::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "", m_DisplayInput);
     setAttribute(mapInfo, "Size", m_ScreenSize);
     setAttribute(mapInfo, "", m_MainScreen);
-//    setAttribute(mapInfo, "Resolution", m_SupportResolution);
+    if (Common::specialComType > 0){
+        setAttribute(mapInfo, "Resolution", m_SupportResolution);
+    }
 
     double inch = 0.0;
     QSize size(0, 0);
@@ -104,19 +106,22 @@ void DeviceMonitor::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     m_ScreenSize = inchValue;
 
     // 获取当前分辨率 和 当前支持分辨率
-//    QStringList listResolution = m_SupportResolution.split(" ");
-//    m_SupportResolution = "";
-//    foreach (const QString &word, listResolution) {
-//        if (word.contains("@")) {
-//            m_SupportResolution.append(word);
-//            m_SupportResolution.append(", ");
-//        }
-//    }
+    if (Common::specialComType > 0){
+        QStringList listResolution = m_SupportResolution.split(" ");
+        m_SupportResolution = "";
+        foreach (const QString &word, listResolution) {
+            if (word.contains("@")) {
+                m_SupportResolution.append(word);
+                m_SupportResolution.append(", ");
+            }
+        }
+    }
 
     // 计算显示比例
     caculateScreenRatio();
-
-//    m_SupportResolution.replace(QRegExp(", $"), "");
+    if (Common::specialComType > 0){
+        m_SupportResolution.replace(QRegExp(", $"), "");
+    }
 
     m_ProductionWeek  = transWeekToDate(mapInfo["Year of Manufacture"], mapInfo["Week of Manufacture"]);
     setAttribute(mapInfo, "Serial ID", m_SerialNumber);
@@ -207,17 +212,19 @@ bool DeviceMonitor::setInfoFromXradr(const QString &main, const QString &edid, c
             }
         }
 
-        QMap<QString, QStringList> monitorResolutionMap = getMonitorResolutionMap(xrandr, m_RawInterface);
+        if (Common::specialComType <= 0) {
+            QMap<QString, QStringList> monitorResolutionMap = getMonitorResolutionMap(xrandr, m_RawInterface);
 
-        if (monitorResolutionMap.size() == 1) {
-            m_SupportResolution.clear();
-            foreach (const QString &word, monitorResolutionMap.value(m_RawInterface)) {
-                if (word.contains("@")) {
-                    m_SupportResolution.append(word);
-                    m_SupportResolution.append(", ");
+            if (monitorResolutionMap.size() == 1) {
+                m_SupportResolution.clear();
+                foreach (const QString &word, monitorResolutionMap.value(m_RawInterface)) {
+                    if (word.contains("@")) {
+                        m_SupportResolution.append(word);
+                        m_SupportResolution.append(", ");
+                    }
                 }
+                m_SupportResolution.replace(QRegExp(", $"), "");
             }
-            m_SupportResolution.replace(QRegExp(", $"), "");
         }
         return false;
     }

--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -524,12 +524,14 @@ void MainWindow::slotLoadingFinish(const QString &message)
             mp_DeviceWidget->updateDevice(mp_DeviceWidget->currentIndex(), lst);
 
             // bug-325731
-            if (mp_DeviceWidget->currentIndex() == QObject::tr("Monitor")) {
-                QtConcurrent::run([=](){
-                    QThread::msleep(700);
-                    emit mp_DeviceWidget->itemClicked(mp_DeviceWidget->currentIndex());
-                    qWarning() << mp_DeviceWidget->currentIndex();
-                });
+            if (Common::specialComType <= 0) {
+                if (mp_DeviceWidget->currentIndex() == QObject::tr("Monitor")) {
+                    QtConcurrent::run([=](){
+                        QThread::msleep(700);
+                        emit mp_DeviceWidget->itemClicked(mp_DeviceWidget->currentIndex());
+                        qWarning() << mp_DeviceWidget->currentIndex();
+                    });
+                }
             }
         } else {
             QMap<QString, QString> overviewMap = DeviceManager::instance()->getDeviceOverview();

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -150,7 +150,6 @@ void ThreadExecXrandr::loadXrandrVerboseInfo(QList<QMap<QString, QString>> &lstM
 
         // 获取当前频率
         if ((*it).contains("*current")) {
-            // QString ss = *it;
             if ((it += 2) >= lines.end())
                 return;
              QRegExp regRate(".*([0-9]{1,5}\\.[0-9]{1,5}Hz).*");


### PR DESCRIPTION
Maintain the monitor info of supported resolutions in special machine.

Log: Maintain the monitor info in special machine.
Bug: https://pms.uniontech.com/bug-view-325731.html
Change-Id: Iddfadc1ab05f3b81df5469240fde4346ac35e378

## Summary by Sourcery

Ensure monitor resolution information is correctly maintained for special machines and restrict certain operations to normal machines.

Bug Fixes:
- Restore support resolution extraction and formatting for special machines by enabling it only when specialComType > 0.
- Prevent xrandr-based resolution parsing and automated Monitor tab refresh for special machines by wrapping these operations behind specialComType <= 0 checks.

Enhancements:
- Remove unused commented debug code from ThreadExecXrandr.