### PR TITLE
Perf: [cppcheck] parameter should be passed by const reference.

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
@@ -168,12 +168,12 @@ bool DeviceGpu::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
             foreach (const QString &item, items) {
                 if (item.isEmpty())
                     continue;
-                QStringList items = allStr.split(":", QString::SkipEmptyParts);
-                if (items.size() != 2)
+                QStringList tmpItems = allStr.split(":", QString::SkipEmptyParts);
+                if (tmpItems.size() != 2)
                     continue;
-                if (items.first().trimmed() == "VRAM total size") {
+                if (tmpItems.first().trimmed() == "VRAM total size") {
                     bool ok;
-                    quint64 vramSize = items.last().trimmed().toULong(&ok, 16);
+                    quint64 vramSize = tmpItems.last().trimmed().toULong(&ok, 16);
                     if (ok && vramSize >= 1048576) {
                         vramSize /= 1048576;
                         auto curSize = vramSize / 1024.0;

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -1299,7 +1299,7 @@ DeviceBaseInfo *DeviceManager::getNetworkDevice(const QString &unique_id)
     return nullptr;
 }
 
-void DeviceManager::correctNetworkLinkStatus(QString linkStatus, QString networkDriver)
+void DeviceManager::correctNetworkLinkStatus(const QString &linkStatus, const QString &networkDriver)
 {
     if (m_ListDeviceNetwork.size() == 0)
         return;

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.h
@@ -387,7 +387,7 @@ public:
      * @brief correctNetworkLinkStatus:校正网络连接状态
      * @param linkStatus:连接状态
      */
-    void correctNetworkLinkStatus(QString linkStatus, QString networkDriver);
+    void correctNetworkLinkStatus(const QString &linkStatus, const QString &networkDriver);
 
     /**
      * @brief networkDriver:获取所有网络驱动

--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
@@ -224,7 +224,7 @@ bool DeviceNetwork::enable()
     return m_Enable;
 }
 
-void DeviceNetwork::correctCurrentLinkStatus(QString linkStatus)
+void DeviceNetwork::correctCurrentLinkStatus(const QString &linkStatus)
 {
     if (m_Link != linkStatus)
         m_Link = linkStatus;

--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.h
@@ -92,7 +92,7 @@ public:
      * @brief correctCurrentLinkStatus
      * @param linkStatus
      */
-    void correctCurrentLinkStatus(QString linkStatus);
+    void correctCurrentLinkStatus(const QString &linkStatus);
 
     /**
      * @brief logicalName: 获取网卡逻辑名称


### PR DESCRIPTION
-- Local variable "items" shadows outer variable.
-- Function parameter should be passed by const reference.