### PR TITLE
fix: add null check for QNetworkInformation instance

### DIFF
--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -1060,9 +1060,13 @@ bool PageDriverManager::networkIsOnline()
     qCDebug(appLog) << "Network is" << (isOnline ? "online" : "offline");
     return isOnline;
 #else
-    auto interfaces = QNetworkInformation::instance()->reachability();
-    qCDebug(appLog) << "Network reachability:" << interfaces;
-    return interfaces == QNetworkInformation::Reachability::Disconnected;
+    bool networkFlag = false;
+    if (QNetworkInformation::instance()) {
+        auto interfaces = QNetworkInformation::instance()->reachability();
+        qCDebug(appLog) << "Network reachability:" << interfaces;
+        networkFlag = (interfaces == QNetworkInformation::Reachability::Disconnected);
+    }
+    return networkFlag;
 #endif
 }
 


### PR DESCRIPTION
- Added null pointer validation before accessing QNetworkInformation::instance() in networkIsOnline()
- Prevents potential crash when network information service is unavailable
- Updated return logic to handle disconnected state properly

Log: add null check for QNetworkInformation instance
pms: BUG-325409

## Summary by Sourcery

Add null check around QNetworkInformation::instance() in networkIsOnline and update return logic to handle disconnected state properly

Bug Fixes:
- Add null pointer validation for QNetworkInformation::instance() to avoid crashes when the network service is unavailable
- Adjust networkIsOnline return logic to correctly indicate a disconnected state when no network information is available