### PR TITLE
chore: bump version to 6.0.47

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-devicemanager (6.0.47) unstable; urgency=medium
+
+  * chore: More logs for ui.
+  * fix: add null check for QNetworkInformation instance.
+
+ -- Wang Yu <wangyu@uniontch.com>  Thu, 31 Jul 2025 16:41:04 +0800
+
 deepin-devicemanager (6.0.46) unstable; urgency=medium
 
   * chore: update the help manual


### PR DESCRIPTION
bump version to 6.0.47

Log: bump version to 6.0.47

## Summary by Sourcery

Chores:
- Update Debian changelog entry to reflect version 6.0.47