### PR TITLE
fix: [Net-Wakeup] The net card can not wakeup.

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/wakecontrol/wakeuputils.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/wakecontrol/wakeuputils.cpp
@@ -117,7 +117,12 @@ WakeupUtils::EthStatus WakeupUtils::wakeOnLanIsOpen(const QString &logicalName)
     struct ifreq ifr;
     struct ethtool_wolinfo wolinfo;
     memset(&ifr, 0, sizeof(ifr));
-    strncpy(ifr.ifr_name, logicalName.toStdString().c_str(), sizeof(logicalName.toStdString().c_str()));
+    memset(&wolinfo, 0, sizeof(wolinfo));
+
+    QByteArray nameBytes = logicalName.toLocal8Bit();
+    strncpy(ifr.ifr_name, nameBytes.constData(), IFNAMSIZ - 1);
+    ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+
     wolinfo.cmd = ETHTOOL_GWOL;
     ifr.ifr_data = reinterpret_cast<char *>(&wolinfo);
     if (0 != ioctl(fd, SIOCETHTOOL, &ifr)) {
@@ -147,7 +152,12 @@ bool WakeupUtils::setWakeOnLan(const QString &logicalName, bool open)
     struct ifreq ifr;
     struct ethtool_wolinfo wolinfo;
     memset(&ifr, 0, sizeof(ifr));
-    strncpy(ifr.ifr_name, logicalName.toStdString().c_str(), sizeof(logicalName.toStdString().c_str()));
+    memset(&wolinfo, 0, sizeof(wolinfo));
+
+    QByteArray nameBytes = logicalName.toLocal8Bit();
+    strncpy(ifr.ifr_name, nameBytes.constData(), IFNAMSIZ - 1);
+    ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+
     wolinfo.cmd = ETHTOOL_SWOL;
     if (open)
         wolinfo.wolopts = 0 | WAKE_MAGIC;


### PR DESCRIPTION
-- Code Logic error, "sizeof(logicalName::toStdString().c_str())" always return 8,
   not the length of logicalName.
-- So, When the length more than 8, the net card will can not find.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-326565.html

## Summary by Sourcery

Fix net card wake-on-lan detection for interface names longer than 8 characters by properly initializing wolinfo and correctly copying logicalName into ifr.ifr_name with a fixed-size limit and null termination.

Bug Fixes:
- Initialize the ethtool_wolinfo struct before use to avoid uninitialized data.
- Replace incorrect sizeof(logicalName.toStdString().c_str()) with IFNAMSIZ-1 for strncpy and explicitly null-terminate ifr.ifr_name to handle longer interface names.