### PR TITLE
fix: update translations

### DIFF
--- a/deepin-devicemanager/translations/deepin-devicemanager_lo.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_lo.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation>ກម្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>ຄຳຄິດເຫັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>កម្រាស់</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation>បន្ថែម</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation>ຫົວຫົວ</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>បន្ថែម</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>ການແຈ້ງເຕືອນເຄືອຂ່າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>ផ្ទុរឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>បន្ថែម</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>ຫົວຫົວ</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>បlok</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>មិនប្រើប្រាស់បាន</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>ឈ្មោះឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>ຜີ້ຜະລິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>ຊຳລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>ຄວາມສາມາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation>module alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation>ID ളື້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>ທາງ SysFS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation>ຄຳອະທິບາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ການປັບປຸງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>ຕົວຂັບຂີ່ໂໝດ Kernel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>ທີ່ຢູ່ຫນັງສື</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>ບໍ່ມີໃຫ້ໃຊ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>ປະຕິບັດງານບໍ່ໃຫ້ໃຊ້</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>ຜີ້ຜະລິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>ແບບຈໍາລອງ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>ຜູ້ຜະລິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ເວີຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>ຊິບເຊັດ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>ຊື່ສັ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>ຜູ້ຜະລິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ເວີຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>ແບບຈໍາລອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation>ອັງກີດແບບໍ້ແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation>ID ളະບົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>ຄວາມໄວ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>ຄວາມໄວ້ຫຼາຍສື່ອັງກີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>ເວີຊັນຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ຂັ້ນຕອນຂອບພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>ສະຫຼັດລະຫົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ຂໍ້ມູນບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>ຊື່ທີ່ສະຫຼັດໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC ສະຫຼັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>ບໍ່ມີໃຫ້ໃຊ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>ປັບປຸງເປັນບໍ່ເປັນໄດ້</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>ຜູ້ຜະລິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>ແບບແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>ເວີຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ຂໍ້ມູນບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>ຄວາມສາມາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ຜີ້ຄຳນຳພາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>ພຼັນພຼັນສັງເຄນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>ຄວາມໄວ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation>ຊື່ສັ້ນຂອງມັດຈຸ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation>ID ທາງກາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>មិនអាចប្រើបាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>បlok</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>ຜູ້ຜະລິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>ID CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>ID ຫົວໃຈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>ກະທູ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>ສະຖາປັດຕະຍະກໍາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>ຄອບຄົວ CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>ແບບຈໍາລອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>ຕົວປະມວນຜົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>ខ្លឹមលំនាំង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>ການສ້າງສະພາບເລືອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>ທຸງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>ສ່ວນຂະຫຍາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation>ຕົວເກັບ L4</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>ຕົວເກັບ L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>ຕົວເກັບ L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>ຕົວເກັບ L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>តែងតាំង L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>ການກ້າວໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>ល្បីល្បាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>ຄວາມໄວສູງສຸດ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>ຜູ້ຜະລິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>ແບບຈໍາລອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>ເວີຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ຫນັງສືກາຟິກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation>ການຕັ້ງຊື່ອຳນ຾ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ID ທາງກາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>ທີ່ຢຸດພາກສ້າງຄວາມຈຸງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>ພອດ IO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>ຂໍ້ມູນບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>ຄວາມລະອຽດສູງສຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>ຄວາມລະອຽດຕ່ຳສຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>ຄວາມລະອຽດປັດຈຸບັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>ຜູທີ່ບຳລຸງງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>ອະທິບາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>ອຸປະກອນພະບຼຸດຕິດຕື່ eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>ອຸປະກອນພະບຼຸດຕິດຕື່ HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Видеовыход цифровой</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Вывод дисплея</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Возможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Недоступно</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Название</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Поставщик</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>ຂໍ້ມູນບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation>ຊື່ສັ້ນຂອງມັດຈຸ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation>Физический ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Скорость</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>ລະបាស់ мощнាត្រិម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>សម្រាប់ប្រាថត្ភភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>លេខសម្ងាត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>មិនមានសម្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>បlok</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>ແບບຈໍາລອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Interface</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>ຂໍ້ມູນບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation>Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation>ID Physical</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>ຄວາມໄວ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>ກະແສສູງສຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>ຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>ຄວາມສາມາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>ເວີຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>ບໍ່ມີໃຫ້ໃຊ້ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>ປັບປຸງເປັນບໍ່ເປັນໄດ້</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>ລວມງོས</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>CPU ളະອຽດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Mainboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Display Adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Sound Adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Storage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>ອື່ PCI ഃື່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Battery</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation> Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation> ໩ནික් ལාහාුාු</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>ເມົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>ຄີບອດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation> ཤාරියුව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation> བ්‍යුන්තුන් རියලු ནරුපණා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>ກ້ອງຖ່າຍຮູບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>ອຸປະກອນອື່ນໆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation> དුකුණු</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation> དුකුණු དුවියුමි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation> བලපුැයි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation> མැණාණියුමි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>ຄວາມໄວ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>ຄວາມກວ້າງທັງໝົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>ຕົວຊີ້ບອກສະຖານທີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>លេខសម្របសម្ព័ន្ធ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>ແຮງດັນທີ່ຕັ້ງຄ່າ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>ແຮງດັນສູງສຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>តម្រូវការចំហាត់អាការតិចតួចបំផុត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>លំទិសត្រូវបានកំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ទទឹងទិន្នន៓ាសរុះ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គងែ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>ການປ້ອນຂໍ້ມູນຈໍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>ປະເພດສ່ວນຕິດຕໍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>ຄວາມລະອຽດທີ່ສະໜັບສະໜູນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>ຄວາມລະອຽດປັດຈຸບັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>อัตราส่วนបង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>ຈໍຫຼັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>ទំហំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>លំដាប់លេខ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>ເວີຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>ຂໍ້ມູນບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>លក្ខណៈសម្បត្តិ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>អ្នកជួសជុំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>ເວີຊັນຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation>លំដាប់អាគ្គិច</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation>ID ທາງກາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>ອັດຕາສູງສຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>ຄີວ່ຕ່ງແນວທາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Link</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>ສອງທາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto Negotiation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Memory Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logical Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>មិនមាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>ម៉ូដែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>ទំនាក់ទំនងបណ្តើ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>វែនស័ំណាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>ການປ້ອນ/ການສະແດງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>ຫນັງສື</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>ដានចំណាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>កម្មវិធីជំហ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>លក្ខណៈសម្បត្តិ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>ម៉ូដែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>バージョン</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>ຂໍ້ມູນບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ຄວາມສາມາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ドライバー</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>ພະລັງງານສູງສຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>ຄວາມໄວ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>ເລກລຳດັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>ບໍ່ມີໃຫ້ໃຊ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>ປັບປຸງເປັນບໍ່ເປັນໄດ້</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>ម៉ូដែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>ベンダー</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>ເລກລຳດັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>タイプ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>ສະຖານភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>ພະລັງງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>ຄວາມກົດດົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>ຊ່ອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>ຄວາມຈຸອອກແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>ຄວາມກົດດົນ ད຿자ນງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>ເວີຊັນ SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>ເລກລຳດັບ SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>ວັນທີ້ການຜັນແຜດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>ເຄມີ SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>ອຸນຫະພຼຼຸມ</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>ແບບຈໍາລອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>ຜູ້ຜະລິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>ລົງຄວາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>ແບ່ງປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>ສະຖານະ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Interface Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>ກັນໃຊ້ງານ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>ຜູ້ຜັງສ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Media Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>ຂະ້ອງຫວາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>ບຸນະເນຖ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>ຄວາມສາມາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation>Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation>Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Firmware Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>ຄວາມໄວ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>คำอธิบาย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>ເລກລຳດັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>อินเทอร์เฟส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>อัตราการหมุน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>เลือกขับเคลื่อน (driver) สำหรับการอัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>ບໍ່ພົບຕົວຂັບຂີ່ໃນໂຟລເດີນີ້</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>ກຳລັງໂຫຼດຂໍ້ມູນອຸປະກອນສຽງ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>กำลังโหลดข้อมูล BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>กำลังโหลดข้อมูล CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>กำลังโหลดข้อมูลระบบปฏิบัติการ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>ກຳລັງໂຫຼດຂໍ້ມູນ CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>กำลังโหลดข้อมูลอุปกรณ์อื่น...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>ກຳລັງໂຫຼດຂໍ້ມູນພະລັງງານ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>ກຳລັງໂຫຼດຂໍ້ມູນພຣິນເຕີ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>ກຳລັງໂຫຼດຂໍ້ມູນເມົາ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>ກຳລັງໂຫຼດຂໍ້ມູນອະເດບເຕີເຄືອຂ່າຍ...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file&apos;s name</comment>
+        <translation>ข้อมูลอุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>แสดง Shortcuts</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>ปิด</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>ช่วยเหลือ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>ระบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>รีเฟช</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Device Manager</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>ອື້ໄມສື່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>ກູ້ງກົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>ລວມທີ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>ອະເດບເຕີຈໍ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>ຈຸດປະສິວງພາກສ່ວນຫຼຳຂຸງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>ເຄື່ອງຈື່ອງເຄື່ອງສື່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>ແບັດເຕີຣີ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>ຫຼາຍຂ້ອບ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation>ເວີຊັນປັດຈຸບັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>ເວີຊັນແພລດຟອມຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation>ສະຖານະ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation>ການກະທຳ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>ຕົວຂັບຂີ່ທີ່ສາມາດສຳຮອງໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>ລាស៊ែរ ഷ້චිත ഷාක්</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>ກຳລັງອັບເດດ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລິກ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>ຕໍ່ໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>ຄຳເຕືອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ການລຸ່ມອອກຂອງ ഷ້චිත ഷාක් ഷົ່ງຈະສ້າງຄວາມບໍ່ສາມາດໃຊ້ງານຂອງອຸປະກອນໄດ້ພິ່ນນະພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>ລຸ່ມອອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>ກຳນຳລຸ່ມອອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>ອັດເປັນສຳເົາສຳເລື່ອງແນ່ນອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>ການລຸ່ມອອກສຳເົາສຳເລື່ອງແນ່ນອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>ອັດເປັນບໍ່ສຳເລື່ອງແນ່ນອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>ການລຸ່ມອອກບໍ່ສຳເລື່ອງແນ່ນອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>ຕໍ່ໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>ຖື່ງທີ່ເລື່ອງໄດ້ບໍ່ມີ, റຟresh ഷ້චිත ഷාක් ഷ້າງກຳນຳ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>ອັບເດດ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>ກ່ອນໜ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>ແພັກເກດທີ່ເສຍຫາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>ບູຮ່ງການບໍ່ຮອງກັບບຸນລະບຸນການປະສົງນະພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>ໄຟລ໌ທີ່ເລືອກບໍ່ມີ, ກະລຸນາເລືອກຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ບໍ່ແມ່ນຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>ບໍ່ສາມາດຕິດຕັ້ງໄດ້ - ບໍ່ມີລາຍເຊັນດິຈິຕອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>ບໍ່ພົບມັດຈຸຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>ຮູບແບບມັດຈຸບໍ່ຖືກຕ້ອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>ມັດຈຸຕົວຂັບຂີ່ມີການພົວພັນ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation>ຊື່ອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation>ເວີຊັນທີ່ມີ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation>ຂະໜາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation>ສະຖານະ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation>ການກະທຳ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation>ບັນທຍລືໃຫ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation>ປະຈັນສະຕິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation>ຂັ້ນຕົນບ່າຍ (%1) ເປັນໄປບໍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation>ຕົວຂັບຂີ່ທີ່ລື່ນເວລາ (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation>ຂັ້ນຕົນເຄື່ອງໃຫ້ (%1) ເປັນໄປບໍ່</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ຕິດຕັ້ງຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>ຂັ້ນຕົນກັບຄັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>ຄືນຄົງຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>ຄຳເຫັນ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>ທ່ານບໍ່ມີຕົວຂັບຂີ່ໃດໆທີ່ຈະຄືນຄົງ, ກະລຸນາສຳຮອງກ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>ໄປຫາກັບຄັບຂັ້ນຕົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation>ເວີຊັນປັດຈຸບັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>ບន្ទាក់ទំរងេ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation>ຈົນປະຕິບັດຕຳນິ້ງງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>ສາມາດປະຕິບັດຕຳນິ້ງງານໄດ້</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>ລື່ນໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>ອອກແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>ການສະຫຼອງລວມ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>ຕິດຕັ້ງຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>ສຳຮອງຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>ຄືນຄົງຕົວຂັບຂີ່</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>ບໍ່ສາມາດປະຕິບັດຕຳນິ້ງງານອຸປະກອນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>ບໍ່ສາມາດປະຕິບັດຕຳນິ້ງງານປະຕິບັດຕຳນິ້ງງານອຸປະກອນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>ບໍ່ສາມາດປະຕິບັດຕຳນິ້ງງານມັນ: ບໍ່ສາມາດບັງເກັນລະຫປ້ງອຸປະກອນ SNໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>ອັບເດດຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ລຶບຕົວຂັບຂີ່</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>ລື່ນໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ចាក់ចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>ຄັດລອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>ລວມທີ້ງ</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>ផ្ទុរឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ສົ່ງອອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>ចូល_COPIED_</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>បុកសូម្បីប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>ផ្ទុរប្រមេចប្រាក់ឡើងទៅ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ដោះគំរូប្រាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>ອະນຸຍາດໃຫ້ມັນປຸກຄອມພິວເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>ປັບປຸງເປັນບໍ່ເປັນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>ບໍ່ສາມາດປັບປຸງເປັນບໍ່ເປັນໄດ້: ບໍ່ສາມາດບັງເກັນລະຫປ້ງອຸປະກອນ SN ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>បានចាញ់បុកគំរូបានជ្រើនតែច្រើនពេលមិនបានដោយសារតែមានបញ្ហាប្រកប់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>បានបុកសូម្បីប្រើប្រាស់គំរូបានជ្រើនតែច្រើនពេលមិនបានដោយសារតែមានបញ្ហាប្រកប់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>ອັບເດດຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ລຶບຕົວຂັບຂີ່</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>ຜູ້ຜະລິດຍ່ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>ອຸປະກອນຍ່ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>ສະຖານະຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>ຄຳສັ່ງກະຕຸກຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>ສະຖານະການຕັ້ງຄ່າ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>ຄວາມຊ້າຊາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>ທາງກາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>ຕົວຈັດການ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>ເວີຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>ບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ຂໍ້ມູນ BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>ຂໍ້ມູນແຜ່ນຖານ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>ຂໍ້ມູນລະບົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>ຂໍ້າງໂຄງສ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>ອາເລຫນັງສືທາງກາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>ວັນທີ່ອອກແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>ທີ່ຢົວ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>ຂະໍ້າງຂະໍ້າງຂະໍ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ຂະໍ້າງຂະໍ້າງ ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>ລັກສະນະ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>ການປັບປຸງ BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>ຂໍ້າງປະຕິບັດລະບຸບ ສະບັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>ຊື່ຜະລິດຕະພັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>ເລກລຳດັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>ແທັກຊັບສິນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>លក្ខណៈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ក្នុងរាងកាយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>ຈັບໂຄງສ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>គ្រប់គ្រងធាតុ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>ប្រភេទប្រតិបត្តិការប្រើប្រាស់ឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>លេខ SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>គ្រួសក្រុម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>ລັອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>ស្ថានភាពចាប់ផ្តើម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>ស្ថានភាពផ្តល់ថ្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>ສະຖານະຄວາມຮ້ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>ស្ថានភាពសុវត្ថិភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ຂំនួນអតិថិបរិ uses ព័ត៌មាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>កម្ពស់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>ចំនួនខ្សែភ្លើង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>ធាតុផ្សំដែលបញ្ជាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>ទីតាំង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>ប្រភេទការពារសំខាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>ຄວາມຈຸສູງສຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>គ្រប់គ្រងព័ត៌មានខូច</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>ចំនួនឧបកម្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>ຂະໜາດ ROM BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>ວັນທີ່ອອກແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>ឈ្មោះតាមតំបន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>ទំរងំ SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>ຮູບແບບຄຳອະທິບາຍພາສາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>ພາສາທີ່ສາມາດຕິດຕັ້ງໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>ພາສາທີ່ຕິດຕັ້ງປັດຈຸບັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>អាសយ៍ BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>MTU ACL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>MTU SCO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>ប្រភេទគោរពបន្ត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>ນະໂຍບາຍການເຊື່ອມຕໍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>ប្រភេទសន្ទាតិ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>ថ្នាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>ថ្នាក់សេវាផ្សេង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>ថ្នាក់ឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>ເວີຊັນ HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>バージョン LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>サブバージョン</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>ឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ID សি리얼</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>ຜົນิตູ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>ອະນາໄມສະຫຼຸບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>ມີພະລັງງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>ສາມາດພົນລະເຊຼໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>ສາມາດຈັບຄູ່ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>ກຳລັງຄົ້ນຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>ປະເພຼຎກຂັ້ນຕອນຂັນຕອນຂັນຕອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>ໄຟລ໌ອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>ອົງປະອົບພົວພັນໍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>ເລກອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>ການນຳໃຊ້ງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>ສະພາບແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ຊື່ທີ່ອົງຮູບແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ເວີຊັນ ansi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU អនិត្តករ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU វិសាលភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU ប្រភេទកំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU ផ្នែក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>ການປັບປຸງ CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>មួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>ពីរ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>បួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>แปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>sembilan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>sepuluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>dua belas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>empat belas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>enam belas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>ສ្របាប់ពីពេលទីប្រាំព្រមទៅដល់ពេលទីប្រាំប្រាំមួយនៃថ្ងៃ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>ຊາວ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>ຊາວສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>ຊາວສີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>ຊາວຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>ຊາວແປດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>ສາມສິບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>ສາມສິບສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>ສາມສິບສີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>ສາມສິບຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>ສາມສິບແປດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>ສີ່ສິບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>ສີ່ສິບສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>ສີ່ສິບສີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>ສີ່ສິບຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>ສຬງ འຕ្រូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>ສຬງ དີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>ສຬງ དີ້ གານ དີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>ສຬງ དີ້ བ້າງ དີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>ສຬງ དີ້ བ້າງ དີ້ བ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>ສຬງ དີ້ བ້າງ དີ້ བ້າງ དີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>ຫົກສິບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>ຫ້າຫວາດ ཁວາງ དີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>ຫົກສິບສີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ຫົກສິບຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ຫົກສິບແປດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>ເຄີ້ງ མີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>ເຄີ້ງ མີ້ ཁວາງ དີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>ເຄີ້ງ མີ້ བ້າງ དີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>ເຈັດສິບຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>ເຈັດສິບແປດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ແປດສິບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ແປດສິບສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ແປດສິບສີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ແປດສິບຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ແປດສິບແປດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>សំរុបចំនួនប្រាំប្រាំប្រាំបុរាណប្រាំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>ເກົ້າສິບສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>ເກົ້າສິບສີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>ເກົ້າສິບຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>ເກົ້າສິບແປດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>ចំនួនមួយរយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>ចំនួនមួយរយនឹងពីរ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>ຫນຶ່ງຮ້ອຍສີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>ຫນຶ່ງຮ້ອຍຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>ຫນຶ່ງຮ້ອຍແປດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>ຫນຶ່ງຮ້ອຍສິບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>ສິ່ງທີ່ຫຼາຍສອງສຬເຈຸສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>ສິ່ງທີ່ຫຼາຍສອງສຬເຈຸສອງສຬເຈຸ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>ສິ່ງທີ່ຫຼາຍສອງສຬເຈຸສອງສຬເຈຸສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>ຫນຶ່ງຮ້ອຍສິບແປດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>ຫນຶ່ງຮ້ອຍຊາວ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>ສິ່ງທີ່ຫຼາຍສອງສຬເຈຸສອງສຬເຈຸສອງສຬເຈຸສອງສຬເຈຸ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>ສິ່ງທີ່ຫຼາຍສອງສຬເຈຸສອງສຬເຈຸສອງສຬເຈຸສອງສຬເຈຸສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>ຫນຶ່ງຮ້ອຍຊາວຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>ຫນຶ່ງຮ້ອຍຊາວແປດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>ສິ່ງທີ່ຫຼາຍສອງສຬເຈຸສອງສຬເຈຸສອງສຬເຈຸສອງສຬເຈຸສອງສຬເຈຸສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>ສອງຮ້ອຍຫ້າສິບຫົກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR ഷື່ພະລັງງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>ຜູ້ຜະລິດ GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>ລង្អូង GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>バージョン EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>クライ언트 API EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>ເວີຊັນ GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>バージョン GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>មិនស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>ບໍ່ຊ້ຳກັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>ថ្លេក 하드eware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>CPU មិនរកឃើញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Mainboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Mainboard មិនរកឃើញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>ບໍ່ພົບຫນັງສື</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>ການເກັບຮັກສາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>ບໍ່ພຸດ ം</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ຕັ້ງຊື່ລະບຯ ം</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>ກະລຸນາລອງຄືນຫຼືໃຫ້ຄຳຄິດເຫັນກັບພວກເຮົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ບັນທົກລະບຯ ം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>ອະເດບເຕີຈໍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>ບໍ່ພຸດ ം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>ເຄື່ອງຈຸດຈົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>ບໍ່ພຸດ ം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>ເຄື່ອງມຸງສານະນີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>ບໍ່ພຸດ ം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>ອະເດບເຕີສຽງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>ບໍ່ພຸດ ം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>ບໍ່ພຸດ ം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>อุปกรณ์ PCI อื่น ๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>ไม่พบอุปกรณ์ PCI อื่น ๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>พลังงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>ไม่พบแบ Congress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>ຄີບອດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>ไม่พบคีย์บอร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>เมาส์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>ไม่พบเมาส์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>プリンター</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>ไม่พบプリンター</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>กล้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>ไม่พบกล้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>ไม่พบ CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>อุปกรณ์อื่น ๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>ບໍ່ພີ່ນ຾ນົດໄປບໍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>ຈັບອາເລ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>ຮູບແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>ຕັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>ບັນທົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>ລາຍລະອຽດປະເພດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>ເລກສ່ວນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>ອົງການ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>ລະບົບຄວາມຈຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>ຄວາມສາມາດໂໝດການເຮັດວຽກຫນັງສື</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ເວີຊັນຟີມແວ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ລະຫຼົງຜູ້ຜະລິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ID ຜະລິດຕະພັນມັດຈຸ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ລະຫຼົງຜູ້ຄວບຄຸມ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ລະຫຼົງຜະລິດຕະພັນຄວບຄຸມ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>ຂະໜາດບໍ່ລື່ນເວລາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>ຂະໜາດລື່ນເວລາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Размер кэш-памяти</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Логический размер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>дюйм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Дата</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>сеть</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>батарея</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>путь в собственной системе</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>питание</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>обновленный</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>имеет историю</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>имеет статистику</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>заряжаемый</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>상태</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>경고-레벨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>에너지</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>에너지-빈</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>에너지-풀</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>에너지-풀-디자인</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>에너지-레이트</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>볼타지</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>퍼센티지</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>기술</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>아이콘-이름</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>온라인</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>데몬-버전</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>ໃຊ້ແບັດເຕີຣີ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>커버-닫힘</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>ມີຝາປິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>ການກະທຳສຳຄັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>ສຳເນົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>ຍົກເລີກວຽກຫຼັງຈາກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>ຖືວຽກຈົນກ່ວາ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>ລຳດັບວຽກ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>ເວລາປ້ອມແທນພົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>ຈຳນວນຂຶ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>ທິດທາງທີ່ຮ້ອງຂໍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>ໂໝດສີພິມ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>ພັມພັນກັນຮັບງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>ຖືກແບ່ງປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>ພຣິນເຕີຊົ່ວຄາວ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>ຜູ້ຜະລິດແລະແບບຈຳລອງພຣິນເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>ເວລາປ້ອມແທນພົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>reasons for printer state</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>type of printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI ພຣິນເຕີທີ່ສະໜັບສະໜູນ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>sides</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>ข้อมูลบัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>ขนาด sector logikal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>ขนาด sector</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>GUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>เรขาคさ (Logikal)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Device Manager</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Device Manager ແມ່ນເຄື່ອງມືທີ່ສະດວກສຳລັບການເບິ່ງຂໍ້ມູນອື້ໄມສື່ແລະການຈັດການອຸປະກອນ.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Driver terbaru tersedia! Install atau update sekarang juga.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Lihat</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>ລວມໂຟລເດີຍ່ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ຄົ້ນຫາຕົວຂັບຂີ່ໃນທາງນີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>ມີການອັບເດດຕົວຂັບຂີ່ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>ពេលស្វែងយល់: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>កំពូលទាញយកប្រភេទប្រគួសសម្រាប់ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>ល្បីល្បាប់ទាញយក: %1 ទាញយកបាន %2/%3</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>ກຳລັງຕິດຕັ້ງຕົວຂັບຂີ່ສຳລັບ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>ຕິດຕັ້ງຕົວຂັບຂີ່ %1, ລົ້ມເຫລວ %2 ຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>ຕິດຕັ້ງຕົວຂັບຂີ່ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>មិនអាចតាំងឡើងជំនួសប្រភេទប្រគួសបានទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>ຂໍ້ຜິດພາດເຄືອຂ່າຍ. ກຳລັງເຊື່ອມຕໍ່ຄືນ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>ຄວາມໄວດາວໂຫຼດ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>ຕົວຂັບຂີ່ຂອງທ່ານທັນສະໄໝແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>ຕົວຂັບຂີ່ທັງໝົດໄດ້ຮັບການສຳຮອງແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>សរុបមាន %1 ប្រភេទប្រគួស, ក្នុងនោះ %2 បានទុកសន្ធឹង</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Вы имеете %1 драйверов, которые можно сохранить, рекомендуется немедленно это сделать</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Вы имеете %1 драйверов, которые можно сохранить</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Сохранение драйвера %1, всего %2 драйверов</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>ກຳລັງສຳຮອງ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>ສຳຮອງຕົວຂັບຂີ່ %1, ລົ້ມເຫລວ %2 ຕົວຂັບຂີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Неудачное сохранение драйверов</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>%1 драйверов сохранено</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>У вас есть %1 драйверов, которые можно восстановить</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Пожалуйста, выберите драйвер для восстановления</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Драйвер восстанавливается...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Восстановление: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>перезагрузка</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Пожалуйста, %1 для вступления установленных драйверов в силу</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Просмотреть путь резервного копирования</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Резервное копирование всего</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>ສະຫນອງຄຳເຫັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>ກະລຸນາລອງຄືນຫຼື %1 ກັບພວກເຮົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>ຕິດຕັ້ງທັງໝົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>ສະເໜີຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>ກຳລັງສະເໜີຕົວຂັບຂີ່ອຸປະກອນອື້ໄມສື່, ກະລຸນາລໍຖ້າ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>ກຳລັງສະເໜີ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>ການສະເໜີລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>ເຄືອຂ່າຍບໍ່ມີໃຫ້ໃຊ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>ກະລຸນາກວດສອບການເຊື່ອມຕໍ່ເຄືອຂ່າຍຂອງທ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>ກະລຸນາສະເໜີຄືນຫຼື %1 ກັບພວກເຮົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>ທ່ານກຳລັງຕິດຕັ້ງຕົວຂັບຂີ່, ຈະຖືກຂັດຂວາງຖ້າທ່ານອອກ.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການອອກ?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>ອອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>ທ່ານກຳລັງສຳຮອງຕົວຂັບຂີ່, ຈະຖືກຂັດຂວາງຖ້າທ່ານອອກ.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>ທ່ານກຳລັງຄືນຄົງຕົວຂັບຂີ່, ຈະຖືກຂັດຂວາງຖ້າທ່ານອອກ.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>ឧបករណ៍ Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>ឧបករណ៍រូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>ឧបករណ៍បង្កិចបង្កើតរូប</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>សំបុកសំឡេង</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>ឧបករណ៍ប្រតិបត្តិកម្មបណ្តាល់ទូរស័ព្វ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>ឧបករណ៍ប្រតិបត្តិកម្មបណ្តេចទូរស័ព្វមិនបានបង្ក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>កំណត់បញ្ជាក់ជំនិតបានបញ្ចប់ជាសេចក្តិស្វែងយល់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>ການຕິດຕັ້ງລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>ກຳລັງດາວໂຫຼດ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>ກຳລັງຕິດຕັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>ບໍ່ໄດ້ຕິດຕັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>ລື່ນເວລາ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>ກຳລັງລໍຖ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>ບໍ່ໄດ້ສຳຮອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>ກຳລັງສຳຮອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>ການສຳຮອງລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>ການສຳຮອງສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>ກຳລັງຄືນຄົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>ຂໍ້ຜິດພາດທີ່ບໍ່ຮູ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>ຂໍ້ຜິດພາດເຄືອຂ່າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>ຍົກເລີກແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ບໍ່ສາມາດບັງເກັນໄຟລ໌ຕົວຂັບຂີ່ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>ອັບເດດ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>ສຳຮອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>ຄືນຄົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ຕິດຕັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>ລວມທີ້ງ</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>ປັບປຸງເປັນບໍ່ເປັນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>รีเฟรส</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>เอ็กซ์ポート</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>อัปเดตไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ถอนติดตั้งไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>อนุญาตให้ตื่นเครื่อง</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>เปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>รีเฟรส</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>เอ็กซ์ポート</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>ไม่พร้อมใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>ກະລຸນາເລືອກໂຟລເດີທ້ອງຖິ່ນ</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>กำลังโหลด...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/desktop/desktop_lo.ts
+++ b/deepin-devicemanager/translations/desktop/desktop_lo.ts
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<context>
+    <name>desktop</name>
+    <message>
+        <location filename="Desktop Entry]Comment" line="0"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>ຕົວຈັດການອຸປະກອນແມ່ນເຄື່ອງມືທີ່ສະດວກສຳລັບເບິ່ງຂໍ້ມູນຮາດແວແລະຈັດການອຸປະກອນ.</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]GenericName" line="0"/>
+        <source>Device Manager</source>
+        <translation>ຕົວຈັດການອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]Name" line="0"/>
+        <source>Deepin Device Manager</source>
+        <translation>ຕົວຈັດການອຸປະກອນ Deepin</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/policy/policy_lo.ts
+++ b/deepin-devicemanager/translations/policy/policy_lo.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<context>
+    <name>policy</name>
+    <message>
+        <source>Authentication is required to read hardware information</source>
+        <translation>ຕ້ອງການການຢືນຢັນເພື່ອອ່ານຂໍ້ມູນຮາດແວ</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
log:

## Summary by Sourcery

Add Lao language translations for the Device Manager UI, desktop entry, and authentication policy prompts

New Features:
- Introduce Lao translations for deepin-devicemanager interface strings
- Add Lao localization for the desktop entry descriptions
- Provide Lao translations for hardware-info authentication policy messages