### PR TITLE
fix: Handle display configuration for specific device models

### DIFF
--- a/deepin-devicemanager/src/Page/PageMultiInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageMultiInfo.cpp
@@ -92,12 +92,11 @@ void PageMultiInfo::updateInfo(const QList<DeviceBaseInfo *> &lst)
     mp_Table->setFixedHeight(TABLE_HEIGHT);
     mp_Table->updateTable(m_deviceList, m_menuControlList);
     if (Common::specialComType >= 1) {
-        if (mp_Label->text() == tr("Storage") || mp_Label->text() == tr("Memory")) {
+        if (mp_Label->text() == tr("Storage") || mp_Label->text() == tr("Memory") || mp_Label->text() == tr("Monitor")) {
             mp_Table->setVisible(false);
             mp_Table->setFixedHeight(0);
         }
     }
-
     // 更新详细信息
     mp_Detail->showDeviceInfo(lst);
 }
@@ -134,7 +133,7 @@ void PageMultiInfo::resizeEvent(QResizeEvent *e)
         if (Common::specialComType <= 0) {
             mp_Table->updateTable(m_deviceList, m_menuControlList, true, (LEAST_PAGE_HEIGHT - curHeight) / TREE_ROW_HEIGHT + 1);
         } else {
-            if (mp_Label->text() != tr("Storage") && mp_Label->text() != tr("Memory"))
+            if (mp_Label->text() != tr("Storage") && mp_Label->text() != tr("Memory") && mp_Label->text() != tr("Monitor"))
                 mp_Table->updateTable(m_deviceList, m_menuControlList, true, (LEAST_PAGE_HEIGHT - curHeight) / TREE_ROW_HEIGHT + 1);
         }
     } else {
@@ -142,7 +141,7 @@ void PageMultiInfo::resizeEvent(QResizeEvent *e)
         if (Common::specialComType <= 0) {
             mp_Table->updateTable(m_deviceList, m_menuControlList, true, 0);
         } else {
-            if (mp_Label->text() != tr("Storage") && mp_Label->text() != tr("Memory"))
+            if (mp_Label->text() != tr("Storage") && mp_Label->text() != tr("Memory") && mp_Label->text() != tr("Monitor"))
                 mp_Table->updateTable(m_deviceList, m_menuControlList, true, 0);
         }
     }

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
@@ -2468,6 +2468,13 @@
         <translation>内存</translation>
     </message>
     <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="145"/>
+        <source>Monitor</source>
+        <translation>显示设备</translation>
+    </message>
+    <message>
         <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Failed to enable the device</source>
         <translation>启用失败</translation>


### PR DESCRIPTION
Implemented information masking for certain display configurations on special hardware models.

Log: Add display info filtering for special devices
Bug: https://pms.uniontech.com/bug-view-328971.html
Change-Id: Ie2826605b25bdb1ef1c4956bd6856af95284b108

## Summary by Sourcery

Filter out monitor information on special hardware models to prevent its display and resizing issues, and add corresponding translation.

Bug Fixes:
- Hide the device table for the "Monitor" label on special hardware models similar to storage and memory
- Exclude the "Monitor" label from table resizing logic when specialComType is positive

Documentation:
- Add Chinese translation for the "Monitor" label