### PR TITLE
feat: hide button box in main window title bar

### DIFF
--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -491,6 +491,8 @@ void MainWindow::initWindowTitle()
 #ifdef DISABLE_DRIVER
     mp_ButtonBox->hide();
 #endif
+    // Hide hardware info and driver management buttons from title bar
+    mp_ButtonBox->hide();
 }
 
 void MainWindow::initWidgets()


### PR DESCRIPTION
- Added mp_ButtonBox->hide() call to remove hardware info and driver management buttons from display.

Log: hide button box in main window title bar
pms: STORY-39105

## Summary by Sourcery

New Features:
- Hide hardware info and driver management buttons in the main window title bar by default.