### PR TITLE
fix: update monitor of subtitle for specific device models

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -282,6 +282,9 @@ bool DeviceMonitor::available()
 
 QString DeviceMonitor::subTitle()
 {
+    if (Common::specialComType >= 1) {
+        m_Name.clear();
+    }
     return m_Name;
 }
 


### PR DESCRIPTION
update monitor of subtitle for specific device models

Log: update monitor of subtitle for specific device models
Bug: https://pms.uniontech.com/bug-view-328971.html
Change-Id: Ica04bfa281acf49fde7fcdbbd8b84bf0d357afbe

## Summary by Sourcery

Bug Fixes:
- Add condition to DeviceMonitor::subTitle to clear m_Name if Common::specialComType > 1