### PR TITLE
fix: update filter for some unkown netcard

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -588,7 +588,7 @@ void CmdTool::getMulHwinfoInfo(const QString &info)
         if (mapInfo["Hardware Class"] == "sound" || (mapInfo["Device"].contains("USB Audio") && mapInfo["Device"].contains("snd-usb-audio"))) {
             // mapInfo["Device"].contains("USB Audio") 是为了处理未识别的USB声卡 Bug-118773
             addMapInfo("hwinfo_sound", mapInfo);
-        } else if (mapInfo["Hardware Class"].contains("network")) {
+        } else if (mapInfo["Hardware Class"].contains("network") || mapInfo["Device"].toUpper().contains("WI-FI")) {
             addMapInfo("hwinfo_network", mapInfo);
         } else if ("keyboard" == mapInfo["Hardware Class"]) {
             addMouseKeyboardInfoMapInfo("hwinfo_keyboard", mapInfo);


### PR DESCRIPTION
update filter for some unkown netcard

Log: update filter for some unkown netcard
Bug: https://pms.uniontech.com/bug-view-328939.html
Change-Id: I31e2da109343b3646f497389fa8735c9b6bb3c7b

## Summary by Sourcery

Bug Fixes:
- Include devices with 'WI-FI' in the device name when classifying network hardware