### PR TITLE
Pref: [cppcheck] fix cppcheck warning.

### DIFF
--- a/deepin-devicemanager/src/Page/PageDriverControl.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverControl.cpp
@@ -32,7 +32,9 @@
 
 using namespace PolkitQt1;
 
-PageDriverControl::PageDriverControl(QWidget *parent, QString operation, bool install, QString deviceName, QString driverName, QString printerVendor, QString printerModel)
+PageDriverControl::PageDriverControl(QWidget *parent, const QString &operation, bool install,
+                                     const QString &deviceName, const QString &driverName,
+                                     const QString &printerVendor, const QString &printerModel)
     : DDialog(parent)
     , mp_stackWidget(new DStackedWidget)
     , m_Install(install)
@@ -142,13 +144,13 @@ void PageDriverControl::slotBtnNext()
     }
 }
 
-void PageDriverControl::slotProcessChange(qint32 value, QString detail)
+void PageDriverControl::slotProcessChange(qint32 value, const QString &detail)
 {
     Q_UNUSED(detail)
     mp_WaitDialog->setValue(value);
 }
 
-void PageDriverControl::slotProcessEnd(bool sucess, QString errCode)
+void PageDriverControl::slotProcessEnd(bool sucess, const QString &errCode)
 {
     QString successStr = m_Install ? tr("Update successful") : tr("Uninstallation successful");
     QString failedStr = m_Install ? tr("Update failed") : tr("Uninstallation failed");

--- a/deepin-devicemanager/src/Page/PageDriverControl.h
+++ b/deepin-devicemanager/src/Page/PageDriverControl.h
@@ -27,8 +27,9 @@ public:
      * @param install 标识卸载还是更新
      * @param parent
      */
-    PageDriverControl(QWidget *parent, QString operation, bool install,
-                      QString deviceName, QString driverName, QString printerVendor = "", QString printerModel = "");
+    PageDriverControl(QWidget *parent, const QString &operation, bool install,
+                      const QString &deviceName, const QString &driverName,
+                      const QString &printerVendor = "", const QString &printerModel = "");
 
     /**
      * @brief hasWidgetIsVisible 有驱动界面显示
@@ -68,13 +69,13 @@ private slots:
      * @param value 当前进度 0 ～ 100
      * @param detail 当前处理的详细信息
      */
-    void slotProcessChange(qint32 value, QString detail);
+    void slotProcessChange(qint32 value, const QString &detail);
 
     /**
      * @brief slotProcessEnd 更新处理结束的信号
      * @param sucess 更新是否成功
      */
-    void slotProcessEnd(bool sucess, QString errCode);
+    void slotProcessEnd(bool sucess, const QString &errCode);
 
     /**
      * @brief slotClose

--- a/deepin-devicemanager/src/Page/PageDriverManager.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverManager.cpp
@@ -201,6 +201,8 @@ void PageDriverManager::scanDriverInfo()
 
 void PageDriverManager::slotDriverOperationClicked(int index, int itemIndex, DriverOperationItem::Mode mode)
 {
+    Q_UNUSED(itemIndex)
+
     mp_DriverInstallInfoPage->headWidget()->setReDetectEnable(false);
     mp_DriverBackupInfoPage->headWidget()->setReDetectEnable(false);
     mp_DriverRestoreInfoPage->headWidget()->setReDetectEnable(false);
@@ -489,7 +491,7 @@ void PageDriverManager::slotListViewWidgetItemClicked(const QString &itemStr)
 
 void PageDriverManager::slotBackupProgressChanged(int progress)
 {
-
+    Q_UNUSED(progress)
 }
 
 void PageDriverManager::slotBackupFinished(bool bsuccess)
@@ -539,8 +541,10 @@ void PageDriverManager::slotBackupFinished(bool bsuccess)
     }
 }
 
-void PageDriverManager::slotRestoreProgress(int progress, QString strDeatils)
+void PageDriverManager::slotRestoreProgress(int progress, const QString &strDeatils)
 {
+    Q_UNUSED(strDeatils)
+
     if(mp_CurRestoreDriverInfo == nullptr)
         return;
     if (progress >= 100) {
@@ -550,11 +554,12 @@ void PageDriverManager::slotRestoreProgress(int progress, QString strDeatils)
     }
 }
 
-void PageDriverManager::slotRestoreFinished(bool success, QString msg)
+void PageDriverManager::slotRestoreFinished(bool success, const QString &msg)
 {
-    int index = -1;
+    Q_UNUSED(msg)
+
     if (mp_CurRestoreDriverInfo) {
-        index = m_ListDriverInfo.indexOf(mp_CurRestoreDriverInfo);
+        int index = m_ListDriverInfo.indexOf(mp_CurRestoreDriverInfo);
         for (int i = 0; i < m_ListRestorableIndex.size(); i++) {
             if (index == m_ListRestorableIndex[i]) {
                 if (success) {

--- a/deepin-devicemanager/src/Page/PageDriverManager.h
+++ b/deepin-devicemanager/src/Page/PageDriverManager.h
@@ -171,12 +171,12 @@ private slots:
     /**
      * @brief slotRestoreProgress 还原进度刷新
      */
-    void slotRestoreProgress(int progress, QString strDeatils);
+    void slotRestoreProgress(int progress, const QString &strDeatils);
 
     /**
      * @brief slotRestoreFinished 还原结束
      */
-    void slotRestoreFinished(bool success, QString msg);
+    void slotRestoreFinished(bool success, const QString &msg);
 
 signals:
     void startScanning();

--- a/deepin-devicemanager/src/Page/PageDriverRestoreInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverRestoreInfo.cpp
@@ -188,6 +188,9 @@ void PageDriverRestoreInfo::setItemOperationEnable(int index, bool enable)
 
 void PageDriverRestoreInfo::slotOperatorClicked(int index, int itemIndex, DriverOperationItem::Mode mode)
 {
+    Q_UNUSED(index)
+    Q_UNUSED(mode)
+
     PageDriverTableView *view = mp_ViewBackable;
     // 设置状态
     DriverStatusItem *statusItem = new DriverStatusItem(this, ST_DRIVER_RESTORING);

--- a/deepin-devicemanager/src/Page/PageListView.cpp
+++ b/deepin-devicemanager/src/Page/PageListView.cpp
@@ -86,7 +86,7 @@ void PageListView::clear()
     mp_ListView->clearItem();
 }
 
-void PageListView::setCurType(QString type)
+void PageListView::setCurType(const QString &type)
 {
     m_CurType = type;
     mp_ListView->setCurItem(m_CurType);

--- a/deepin-devicemanager/src/Page/PageListView.h
+++ b/deepin-devicemanager/src/Page/PageListView.h
@@ -46,7 +46,7 @@ public:
      */
     void clear();
 
-    void setCurType(QString type);
+    void setCurType(const QString &type);
 
 protected:
     /**@brief:事件重写*/


### PR DESCRIPTION
-- Funtion  parameter should be passed by const reference. -- Unused parameter.
-- The scope of the varible 'index' can reduced.

## Summary by Sourcery

Fix cppcheck warnings by marking unused parameters, passing string parameters by const reference, and narrowing variable scope.

Enhancements:
- Suppress unused parameter warnings by adding Q_UNUSED macros
- Pass QString parameters by const reference to avoid unnecessary copying
- Reduce the scope of the 'index' variable in slotRestoreFinished to its usage block