### PR TITLE
fix: Improve network adapter model detection

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
@@ -160,6 +160,9 @@ bool DeviceNetwork::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     // 判断是否是无线网卡
     setIsWireless(mapInfo["SysFS ID"]);
 
+    if (mapInfo.contains("Device")) {
+        m_Name = mapInfo["Device"];
+    }
     return true;
 }
 


### PR DESCRIPTION
Enhanced model identification for external adapter-based NICs (including Type-C to RJ45 converters) to ensure reliable device model retrieval.

Log: Fix NIC model detection failure
Bug: https://pms.uniontech.com/bug-view-329931.html
Change-Id: I25a5b0485228f8c431866608754601519c22b612

## Summary by Sourcery

Bug Fixes:
- Populate the network adapter name from the hwinfo "Device" property when available to fix model detection failures for external adapters.