### PR TITLE
Fix: [Monitor-Info] add hardware platform detection for monitor valid…

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -204,6 +204,14 @@ bool DeviceMonitor::setInfoFromXradr(const QString &main, const QString &edid, c
         }
     }
 
+    if (!Common::isHwPlatform()) {
+        QString monitorName = getMonitorNameFromEdid(edid);
+        if (!m_Model.isEmpty() && !monitorName.isEmpty() && monitorName != "Unknown Monitor") {
+            if (!m_Model.contains(monitorName))
+                return false;
+        }
+    }
+
     // 判断该显示器设备是否已经设置过从xrandr获取的消息
     if (!m_Interface.isEmpty()) {
         // 设置当前分辨率
@@ -491,6 +499,16 @@ bool DeviceMonitor::caculateScreenSize(const QString &edid)
     double inch = std::sqrt(height * height + width * width) / 2.54 / 10;
     m_ScreenSize = QString("%1 %2(%3mm×%4mm)").arg(QString::number(inch, '0', 1)).arg(translateStr("inch")).arg(width).arg(height);
     return true;
+}
+
+QString DeviceMonitor::getMonitorNameFromEdid(const QString &edid)
+{
+    EDIDParser edidParse;
+    QString errormsg;
+    if (!edidParse.setEdid(edid, errormsg))
+        return "";
+
+    return edidParse.monitorName();
 }
 
 QMap<QString, QStringList> DeviceMonitor::getMonitorResolutionMap(QString rawText, QString key, bool round)

--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.h
@@ -180,6 +180,8 @@ private:
      */
     bool caculateScreenSize(const QString &edid);
 
+    QString getMonitorNameFromEdid(const QString &edid);
+
     /**
      * @brief getMonitorResolutionMap:从xrandr字符串获取格式化
      * @param rawText:原始xrandr输出字符串

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -205,6 +205,13 @@ void Common::tomlFilesNameSet(const QString &name)
     tomlFilesName = name;
 }
 
+bool Common::isHwPlatform()
+{
+    if (specialComType == Unknow || specialComType == NormalCom || specialComType == kCustomType)
+        return false;
+    return true;
+}
+
 QString Common::tomlFilesNameGet()
 {
     return tomlFilesName;

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -38,6 +38,7 @@ public:
     static QString specialHString();
     static QString tomlFilesNameGet();
     static void tomlFilesNameSet(const QString &name);
+    static bool isHwPlatform();
 
     /**
      * @brief specialComType


### PR DESCRIPTION
…ation

- Add isHwPlatform() method to Common class for platform type checking
- Implement getMonitorNameFromEdid() in DeviceMonitor for EDID parsing
- Add monitor name validation logic in setInfoFromXradr() method
- Skip monitor name validation on non-hardware platforms
- Enhance monitor device detection accuracy by comparing EDID monitor names

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-330145.html

## Summary by Sourcery

Add hardware platform checks and EDID-based name validation to improve monitor information accuracy

New Features:
- Add hardware platform detection via Common::isHwPlatform()
- Introduce EDID parsing method getMonitorNameFromEdid() for monitor name extraction

Enhancements:
- Enhance monitor detection accuracy by validating device model against EDID-extracted names in setInfoFromXradr()
- Skip monitor name validation on non-hardware platforms to prevent false mismatches