### PR TITLE
fix: Improve input device Bus interface detection

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -13,6 +13,8 @@
 #include <QLoggingCategory>
 #include <QProcess>
 
+QStringList DeviceInput::m_supportInterfaces= {"PS/2", "Bluetooth", "I2C"};
+
 DeviceInput::DeviceInput()
     : DeviceBaseInfo()
     , m_Model("")
@@ -387,9 +389,9 @@ bool DeviceInput::available()
     if (driver().isEmpty()) {
         m_Available = false;
     }
-    if ("PS/2" == m_Interface || "Bluetooth" == m_Interface || "I2C" == m_Interface) {
-        m_Available = true;
-    }
+
+    m_Available = m_supportInterfaces.contains(m_Interface, Qt::CaseInsensitive);
+
     return m_forcedDisplay ? m_forcedDisplay : m_Available;
 }
 

--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.h
@@ -208,6 +208,8 @@ private:
     bool                m_wakeupChanged = true;                //<!   记录鼠标的唤醒状态
 
     QString             m_keysToPairedDevice;           //<! 【用来标识蓝牙键盘】
+
+    static QStringList m_supportInterfaces;             //<! 【支持的所有蓝牙接口】
 };
 
 #endif // DEVICEINPUT_H


### PR DESCRIPTION
- Use case-insensitive contains matching instead of exact string comparison
- Support interface name variations like 'ps/2', 'bluetooth low energy', etc.
- Refactor hardcoded interface checks to use static list and loop
- Fix device availability detection for input devices with non-standard interface names

Log: Improve input device Bus interface detection
Bug: https://pms.uniontech.com/bug-view-331181.html
Change-Id: Ifbc7c40f44f45e146f07fe101ed3fc960e945459

## Summary by Sourcery

Improve detection of supported input device interfaces by using case-insensitive substring matching and iterating over a static list of interfaces.

Bug Fixes:
- Fix availability detection for input devices with non-standard interface name variations

Enhancements:
- Refactor hardcoded interface comparisons into a static list and loop
- Switch to case-insensitive contains matching for interface names