### PR TITLE
Fix: [Audio] The audio device of usb not show.

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -585,7 +585,9 @@ void CmdTool::getMulHwinfoInfo(const QString &info)
             continue;
         QMap<QString, QString> mapInfo;
         getMapInfoFromHwinfo(item, mapInfo);
-        if (mapInfo["Hardware Class"] == "sound" || (mapInfo["Device"].contains("USB Audio") && mapInfo["Device"].contains("snd-usb-audio"))) {
+        if (mapInfo["Hardware Class"] == "sound"
+                || (mapInfo["Device"].contains("USB Audio") && mapInfo["Device"].contains("snd-usb-audio"))
+                || mapInfo["Driver"].contains("snd-usb-audio")) {
             // mapInfo["Device"].contains("USB Audio") 是为了处理未识别的USB声卡 Bug-118773
             addMapInfo("hwinfo_sound", mapInfo);
         } else if (mapInfo["Hardware Class"].contains("network") || mapInfo["Device"].toUpper().contains("WI-FI")) {


### PR DESCRIPTION
-- Add logic code to append usb audio.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-331293.html

## Summary by Sourcery

Bug Fixes:
- Add check for snd-usb-audio in the Driver field to ensure USB sound cards are recognized and displayed.