### PR TITLE
fix: add input device bus interface for USB Devices

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -13,7 +13,7 @@
 #include <QLoggingCategory>
 #include <QProcess>
 
-QStringList DeviceInput::m_supportInterfaces= {"PS/2", "Bluetooth", "I2C"};
+QStringList DeviceInput::m_supportInterfaces= {"PS/2", "Bluetooth", "I2C", "USB"};
 
 DeviceInput::DeviceInput()
     : DeviceBaseInfo()


### PR DESCRIPTION
improve input device Bus interface detectionadd, add input device bus interface for USB Devices

Log: add input device bus interface for USB Devices
Bug: https://pms.uniontech.com/bug-view-331181.html
Change-Id: Ie66f434275af797a31a083f9ea6eb8a63dd427ab

## Summary by Sourcery

Bug Fixes:
- Add "USB" to the supported input device bus interfaces list