### PR TITLE
Fix: [GPU] Not show gpu on some platform.

### DIFF
--- a/deepin-devicemanager-server/customgpuinfo/main.cpp
+++ b/deepin-devicemanager-server/customgpuinfo/main.cpp
@@ -98,7 +98,8 @@ bool getGpuMemInfoForFTDTM(QMap<QString, QString> &mapInfo)
 int main(int argc, char *argv[])
 {
     QMap<QString, QString> mapInfo;
-    if (getGpuBaseInfo(mapInfo) && getGpuMemInfoForFTDTM(mapInfo)) {
+    if (getGpuBaseInfo(mapInfo)) {
+        getGpuMemInfoForFTDTM(mapInfo);
         for (auto it = mapInfo.begin(); it != mapInfo.end(); ++it)
             std::cout << it.key().toStdString() << ": " << it.value().toStdString() << std::endl;
         return 0;


### PR DESCRIPTION
-- Not show gpu on some platform.

Log: fix issue
Bug: https://pms.uniontech.com/task-view-378987.html

## Summary by Sourcery

Bug Fixes:
- Always fetch and display GPU memory info after base info succeeds to prevent GPU from being hidden when memory retrieval fails