### PR TITLE
fix: Prevent music playback interruption when opening Device Manager with USB headphones

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -1203,7 +1203,10 @@ void DeviceManager::deleteDisableDuplicate_AudioDevice(void)
             continue;
         }
         m_ListDeviceAudio.push_back(enabledDevices.value(it));
-
+        qDebug() << enabledDevices.value(it)->name() << "is enable: " << enabledDevices.value(it)->enable();
+        if (enabledDevices.value(it)->enable()){
+            continue;
+        }
         setAudioDeviceEnable(enabledDevices.value(it), enabledDevices.value(it)->enable());
     }
     qWarning()<<"delete after: "<< m_ListDeviceAudio.size();


### PR DESCRIPTION
Fixed an issue where Device Manager's audio enable/disable functionality briefly toggled audio device states during initialization, causing USB headphone playback to pause. This occurred due to temporary audio device state switching logic during the initial setup phase.

Log: Fix USB audio playback interruption from Device Manager
Bug: https://pms.uniontech.com/bug-view-332095.html
Change-Id: Idd98f8cd92884d3f7b7297adf64901c49f9807a0