### PR TITLE
fix: Set timeout for device info loading to prevent infinite waiting

### DIFF
--- a/deepin-devicemanager-server/deepin-deviceinfo/src/mainjob.cpp
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/mainjob.cpp
@@ -166,7 +166,7 @@ void MainJob::updateAllDevice()
         m_pool->loadDeviceInfo();
     else
         m_pool->updateDeviceInfo();
-    m_pool->waitForDone(-1);
+    m_pool->waitForDone(60000);
     PERF_PRINT_END("POINT-01");
     m_firstUpdate = false;
 }


### PR DESCRIPTION
- Change waitForDone(-1) to waitForDone(60000) in MainJob::updateAllDevice()
- Add 60-second timeout to prevent device manager from hanging during device info loading
- Improve application responsiveness and user experience

Log: Set timeout for device info loading to prevent infinite waiting
Bug: https://pms.uniontech.com/bug-view-331983.html
Change-Id: Iab0310719df4cfa7e13176975ee0db59572d88ce

## Summary by Sourcery

Add a 60-second timeout to m_pool->waitForDone in MainJob::updateAllDevice to prevent the device manager from hanging indefinitely when loading device info.

Bug Fixes:
- Prevent infinite waiting in MainJob::updateAllDevice by setting a 60-second timeout for m_pool->waitForDone.

Enhancements:
- Improve application responsiveness and user experience by avoiding indefinite hangs during device info loading.