### PR TITLE
feat: Adjust CPU frequency values for specific device type

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
@@ -46,6 +46,11 @@ void DeviceCpu::setCpuInfo(const QMap<QString, QString> &mapLscpu, const QMap<QS
     m_Name.replace(QRegExp("/[0-9]*$"), "");
     m_Name.replace(QRegExp("x [0-9]*$"), "");
 
+    if (Common::specialComType == Common::kSpecialType6){
+        m_Frequency = m_Frequency.replace("2.189", "2.188");
+        m_MaxFrequency = m_MaxFrequency.replace("2189", "2188");
+    }
+
     //  获取逻辑数和core数
     m_LogicalCPUNum = logicalNum;
     m_CPUCoreNum = coreNum;


### PR DESCRIPTION
Modified CPU frequency display for kSpecialType6 devices include current frequency and max frequency to correct hardware reporting inaccuracies.

Log: Fix CPU frequency display for special device type
Task: https://pms.uniontech.com/task-view-381765.html
Change-Id: I3a715b263868c6825ee42941b64a7c5de6a53035

## Summary by Sourcery

Adjust CPU frequency display for kSpecialType6 devices to correct hardware reporting inaccuracies

Enhancements:
- Apply value correction for special type 6 devices by replacing reported current frequency "2.189" with "2.188"
- Apply value correction for special type 6 devices by replacing reported max frequency "2189" with "2188"