### PR TITLE
feat: Adjust CPU frequency for kSpecialType5 device

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
@@ -46,7 +46,8 @@ void DeviceCpu::setCpuInfo(const QMap<QString, QString> &mapLscpu, const QMap<QS
     m_Name.replace(QRegExp("/[0-9]*$"), "");
     m_Name.replace(QRegExp("x [0-9]*$"), "");
 
-    if (Common::specialComType == Common::kSpecialType6){
+    if (Common::specialComType == Common::kSpecialType5 ||
+        Common::specialComType == Common::kSpecialType6) {
         m_Frequency = m_Frequency.replace("2.189", "2.188");
         m_MaxFrequency = m_MaxFrequency.replace("2189", "2188");
     }

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -135,7 +135,7 @@ QString Common::checkBoardVendorFlag()
         case PGUV:
             boardVendorKey = "PGUV";
             break;
-        case PGUX:
+        case kSpecialType5:
             boardVendorKey = "PGUX";
             break;
         case kCustomType:

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -22,7 +22,7 @@ public:
         KLVV,
         KLVU,
         PGUV,
-        PGUX,
+        kSpecialType5,
         kSpecialType6,
         kSpecialType7,
         kCustomType


### PR DESCRIPTION
Modified CPU frequency display for kSpecialType5 devices include current frequency and max frequency to correct hardware reporting inaccuracies.

Log: Fix CPU frequency display for special device type
Task: https://pms.uniontech.com/task-view-381921.html
Change-Id: Ia80c7e9edf7618188874e0648cb599920f49eada

## Summary by Sourcery

Include support for kSpecialType5 devices in CPU frequency reporting and unify enum naming for better consistency.

Enhancements:
- Extend CPU frequency correction to apply to kSpecialType5 as well as kSpecialType6 devices
- Rename PGUX enum to kSpecialType5 in Common to standardize special device type identifiers