### PR TITLE
feat: Adjust CPU frequency values for kSpecialType7 device

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
@@ -47,7 +47,8 @@ void DeviceCpu::setCpuInfo(const QMap<QString, QString> &mapLscpu, const QMap<QS
     m_Name.replace(QRegExp("x [0-9]*$"), "");
 
     if (Common::specialComType == Common::kSpecialType5 ||
-        Common::specialComType == Common::kSpecialType6) {
+        Common::specialComType == Common::kSpecialType6 ||
+        Common::specialComType == Common::kSpecialType7) {
         m_Frequency = m_Frequency.replace("2.189", "2.188");
         m_MaxFrequency = m_MaxFrequency.replace("2189", "2188");
     }


### PR DESCRIPTION
Modified CPU frequency display for kSpecialType7 devices include current frequency and max frequency to correct hardware reporting inaccuracies.

Log: Fix CPU frequency display for special device type
Task: https://pms.uniontech.com/task-view-381765.html
Change-Id: Id37a4b03a83ccb6428a1bd3edf601d905edbd2c8

## Summary by Sourcery

Include special device type7 in the CPU frequency correction logic to ensure accurate display of current and maximum frequencies.

Bug Fixes:
- Add kSpecialType7 to the condition applying CPU frequency replacements
- Apply the same frequency value fixes (2.189→2.188 GHz and 2189→2188 MHz) to kSpecialType7 devices