### PR TITLE
fix: Clear driver field when value is usbfs

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
@@ -35,7 +35,8 @@ void DeviceOthers::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "maxpower", m_MaximumPower);
     setAttribute(mapInfo, "speed", m_Speed);
     setAttribute(mapInfo, "logical name", m_LogicalName);
-
+    if (m_Driver.toLower() == "usbfs")
+        m_Driver.clear();
     if(m_Driver.isEmpty() && !m_Avail.compare("yes", Qt::CaseInsensitive)){
         setForcedDisplay(true);
         setCanEnale(false);
@@ -85,7 +86,8 @@ void DeviceOthers::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Module Alias", m_Modalias);
     setAttribute(mapInfo, "VID_PID", m_VID_PID);
     m_PhysID = m_VID_PID;
-
+    if (m_Driver.toLower() == "usbfs")
+        m_Driver.clear();
     if (mapInfo["Hardware Class"] != "fingerprint") {
         m_HardwareClass = "others";
     } else {


### PR DESCRIPTION
Added condition to reset the driver information when its value is "usbfs" (case-insensitive comparison) to handle invalid driver identifiers.

Log: Filter out usbfs driver values
Bug: https://pms.uniontech.com/bug-view-333969.html
Change-Id: I4f2632c9ccef6f9df668460adda9b9078a65b932

## Summary by Sourcery

Bug Fixes:
- Clear the driver field when its value is 'usbfs' in both lshw- and hwinfo-based device information