### PR TITLE
fix: [typo] Correct method name spelling from setCanEnale to setCanEnable

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInfo.cpp
@@ -554,7 +554,7 @@ bool DeviceBaseInfo::driverIsKernelIn(const QString &driver)
     return !outInfo.contains("filename:");
 }
 
-void DeviceBaseInfo::setCanEnale(bool can)
+void DeviceBaseInfo::setCanEnable(bool can)
 {
     m_CanEnable = can;
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceInfo.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInfo.h
@@ -164,10 +164,10 @@ public:
     virtual bool driverIsKernelIn(const QString &driver);
 
     /**
-     * @brief setCanEnale : set can enable or not
+     * @brief setCanEnable : set can enable or not
      * @param can
      */
-    void setCanEnale(bool can);
+    void setCanEnable(bool can);
 
     /**
      * @brief canEnable : 该设备是否可以禁用

--- a/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceOthers.cpp
@@ -39,7 +39,7 @@ void DeviceOthers::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
         m_Driver.clear();
     if(m_Driver.isEmpty() && !m_Avail.compare("yes", Qt::CaseInsensitive)){
         setForcedDisplay(true);
-        setCanEnale(false);
+        setCanEnable(false);
         if(!(tmp_Name.contains("fingerprint", Qt::CaseInsensitive) || tmp_Name. contains("MOH", Qt::CaseInsensitive)))
             setCanUninstall(false);
     }

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -917,7 +917,7 @@ void DeviceGenerator::getKeyboardInfoFromHwinfo()
         DeviceInput *device = new DeviceInput();
         device->setInfoFromHwinfo(*it);
         device->setHardwareClass("keyboard");
-        device->setCanEnale(false);
+        device->setCanEnable(false);
         DeviceManager::instance()->addKeyboardDevice(device);
         addBusIDFromHwinfo((*it)["SysFS BusID"]);
     }

--- a/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
@@ -331,7 +331,7 @@ void HWGenerator::getAudioInfoFromCatAudio()
         }
 
         DeviceAudio *device = new DeviceAudio();
-        device->setCanEnale(false);
+        device->setCanEnable(false);
         device->setCanUninstall(false);
         device->setForcedDisplay(true);
         device->setInfoFromCatAudio(tempMap);
@@ -348,7 +348,7 @@ void HWGenerator::getBluetoothInfoFromHciconfig()
             continue;
         }
         DeviceBluetooth *device = new DeviceBluetooth();
-        device->setCanEnale(false);
+        device->setCanEnable(false);
         device->setForcedDisplay(true);
         device->setInfoFromHciconfig(*it);
         DeviceManager::instance()->addBluetoothDevice(device);


### PR DESCRIPTION
Fixed typo in method name across both declaration and implementation to ensure consistent and correct spelling for the device enablement control function.

Log: Fix method name spelling error
Change-Id: I4f67de86de7fc774495a00fb46cd3eb7c394b128