### PR TITLE
fix: [typo] Correct spelling errors in EDIDparser.

### DIFF
--- a/deepin-devicemanager/src/Tool/EDIDParser.cpp
+++ b/deepin-devicemanager/src/Tool/EDIDParser.cpp
@@ -73,7 +73,7 @@ bool EDIDParser::setEdid(const QString &edid, QString &errorMsg, const QString &
     }
 
     // 解析厂商信息
-    parserVendor();
+    parseVendor();
     // 解析发布日期
     parseReleaseDate();
     // 解析屏幕尺寸
@@ -119,7 +119,7 @@ int EDIDParser::height()
     return m_Height;
 }
 
-void EDIDParser::parserVendor()
+void EDIDParser::parseVendor()
 {
     // 获取制造商信息，edid中的 08h 和 09h 是厂商信息
     // 08表示 第0行  第9个字节

--- a/deepin-devicemanager/src/Tool/EDIDParser.h
+++ b/deepin-devicemanager/src/Tool/EDIDParser.h
@@ -66,16 +66,16 @@ public:
 
     /**
      * @brief height : get screen height
-     * @return
+     * @return screen height
      */
     int height();
 
 private:
 
     /**
-     * @brief parserVendor:从edid中获取厂商信息
+     * @brief parseVendor:从edid中获取厂商信息
      */
-    void parserVendor();
+    void parseVendor();
 
     /**
      * @brief parseReleaseDate:从edid中获取发布日期
@@ -154,7 +154,7 @@ private:
     QString                m_MonitorName;                      // 监视器名称
     bool                   m_LittleEndianMode;                 // 小端模式
     int                    m_Width;                            // width
-    int                    m_Height;                           // heigth
+    int                    m_Height;                           // height
     QStringList            m_ListEdid;                         // edid数据
     QMap<QString, QString> m_MapCh;                            // 二进制字符串映射到字母A-Z
 


### PR DESCRIPTION
Fixed typos in method name and variable comments to ensure consistent and correct spelling:
- Changed parserVendor() to parseVendor() across both declaration and implementation
- Fixed "heigth" to "height" in method comments and variable descriptions

Log: Fix spelling errors in EDID parser
Change-Id: Ia15db2bf96f2e145718981592e69dca3e740172c

## Summary by Sourcery

Fix typos in EDIDParser by renaming parserVendor to parseVendor and correcting height-related misspellings in code comments and variables

Bug Fixes:
- Rename parserVendor() to parseVendor() across declaration, implementation, and calls
- Correct 'heigth' typo to 'height' in method comments, variable descriptions, and documentation
- Update height() return comment to specify 'screen height'