### PR TITLE
fix: unify resolution display format to use ASCII 'x'

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -265,10 +265,10 @@ bool DeviceMonitor::setInfoFromXradr(const QString &main, const QString &edid, c
                     if (pos > 0 && curRate.size() > pos && !Common::boardVendorType().isEmpty()) {
                         curRate = QString::number(ceil(curRate.left(pos).toDouble())) + curRate.right(curRate.size() - pos);
                     }
-                    m_CurrentResolution = QString("%1@%2").arg(match.captured(1)).arg(curRate).replace("x", "×", Qt::CaseInsensitive);
+                    m_CurrentResolution = match.captured(1) + "@" + curRate;
                 } else {
                     qCDebug(appLog) << "Rate is empty";
-                    m_CurrentResolution = QString("%1").arg(match.captured(1)).replace("x", "×", Qt::CaseInsensitive);
+                    m_CurrentResolution = match.captured(1);
                 }
             }
         }
@@ -484,13 +484,13 @@ bool DeviceMonitor::setMainInfoFromXrandr(const QString &info, const QString &ra
                 m_RefreshRate = QString("%1").arg(curRate);
             }
             if (Common::specialComType == 5 || Common::specialComType == 6) {
-                m_CurrentResolution = QString("%1").arg(match.captured(1)).replace("x", "×", Qt::CaseInsensitive);
+                m_CurrentResolution = match.captured(1);
             } else {
-                m_CurrentResolution = QString("%1 @%2").arg(match.captured(1)).arg(curRate).replace("x", "×", Qt::CaseInsensitive);
+                m_CurrentResolution = match.captured(1) + "@" + curRate;
             }
         } else {
             qCDebug(appLog) << "Rate is empty, setting current resolution without rate";
-            m_CurrentResolution = QString("%1").arg(match.captured(1).replace("x", "×", Qt::CaseInsensitive));
+            m_CurrentResolution = match.captured(1);
         }
     }
 

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -101,9 +101,9 @@ void ThreadExecXrandr::loadXrandrInfo(QList<QMap<QString, QString>> &lstMap, con
             QRegularExpression re(".*\\s([0-9]{1,5}\\sx\\s[0-9]{1,5}).*\\s([0-9]{1,5}\\sx\\s[0-9]{1,5}).*\\s([0-9]{1,5}\\sx\\s[0-9]{1,5}).*");
             QRegularExpressionMatch match = re.match(line);
             if (match.hasMatch()) {
-                lstMap[lstMap.count() - 1].insert("minResolution", match.captured(1));
-                lstMap[lstMap.count() - 1].insert("curResolution", match.captured(2).replace(" ", "").replace("x", "×", Qt::CaseInsensitive));
-                lstMap[lstMap.count() - 1].insert("maxResolution", match.captured(3));
+                lstMap[lstMap.count() - 1].insert("minResolution", match.captured(1).replace(" ", ""));
+                lstMap[lstMap.count() - 1].insert("curResolution", match.captured(2).replace(" ", ""));
+                lstMap[lstMap.count() - 1].insert("maxResolution", match.captured(3).replace(" ", ""));
                 qCDebug(appLog) << "Parsed resolutions: min" << match.captured(1) << "cur" << match.captured(2) << "max" << match.captured(3);
             }
             continue;
@@ -395,8 +395,8 @@ void ThreadExecXrandr::getResolutionFromDBus(QMap<QString, QString> &lstMap)
     }
 
     if (maxResolutionWidth != -1) {
-        lstMap.insert("maxResolution", QString("%1 x %2").arg(maxResolutionWidth).arg(maxResolutionHeight));
-        lstMap.insert("minResolution", QString("%1 x %2").arg(minResolutionWidth).arg(minResolutionHeight));
+        lstMap.insert("maxResolution", QString("%1x%2").arg(maxResolutionWidth).arg(maxResolutionHeight));
+        lstMap.insert("minResolution", QString("%1x%2").arg(minResolutionWidth).arg(minResolutionHeight));
     }
 }
 


### PR DESCRIPTION
Remove Unicode multiplication sign replacement and extra spaces from resolution strings, standardizing to plain 'WxH' format across all display adapter resolution fields.

统一显示适配器分辨率格式，移除 Unicode 乘号和多余空格，
全部使用 ASCII 'x' 格式（如 1920x1080）。

Log: 统一分辨率显示格式为 ASCII x
PMS: BUG-351831
Influence: 显示适配器的当前分辨率、最小分辨率、最大分辨率显示格式统一，不再出现格式不一致的情况。

## Summary by Sourcery

Standardize display adapter resolution strings to a consistent ASCII-based format.

Bug Fixes:
- Normalize current, minimum, and maximum resolution strings to remove Unicode multiplication signs and extra spaces, preventing inconsistent resolution display formats across the UI.

Enhancements:
- Simplify construction of current resolution strings by avoiding unnecessary QString formatting helpers while keeping content unchanged.