### PR TITLE
fix: correct mouse/touchpad enable/disable button visibility

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -190,10 +190,6 @@ void DeviceInput::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     if ("PS/2" == m_Interface) {
         qCDebug(appLog) << "Interface is PS/2, getting PS2 Syspath.";
         getPS2Syspath(mapInfo["Device Files"]);
-        if (m_Model.contains("Mouse", Qt::CaseInsensitive)) {
-            qCDebug(appLog) << "Model contains Mouse, setting m_CanEnable to false.";
-            m_CanEnable = false;
-        }
     }
 
     // 获取映射到 lshw设备信息的 关键字
@@ -206,9 +202,36 @@ void DeviceInput::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     qCDebug(appLog) << "Info set from Bluetoothctl.";
 
     getMouseInfoFromBusDevice();
+
+    // PS/2鼠标不支持启用/禁用（需在getMouseInfoFromBusDevice之后判断，
+    // 因为接口类型可能在getMouseInfoFromBusDevice中被更正，如蓝牙鼠标）
+    if ("PS/2" == m_Interface && m_Model.contains("Mouse", Qt::CaseInsensitive)) {
+        qCDebug(appLog) << "PS/2 Mouse, setting m_CanEnable to false.";
+        m_CanEnable = false;
+    }
     // 获取其他设备信息
     getOtherMapInfo(mapInfo);
     qCDebug(appLog) << "Exiting setInfoFromHwinfo.";
+}
+
+void DeviceInput::validateCanEnableForMouse()
+{
+    // 触摸板使用DBusTouchPad接口，不需要检查sysfs
+    if (m_Name.contains("Touchpad", Qt::CaseInsensitive)) {
+        return;
+    }
+    // setEnable()需要SerialID、UniqueID、SysPath，缺少则禁用操作会失败
+    if (m_SerialID.isEmpty() || m_UniqueID.isEmpty() || m_SysPath.isEmpty()) {
+        m_CanEnable = false;
+        return;
+    }
+    // 如果sysfs路径下两者都没有，则该设备无法被禁用
+    QString sysfsPath = "/sys" + m_SysPath;
+    bool hasAuthorized = QFile::exists(sysfsPath + "/authorized");
+    bool hasRemove = QFile::exists(sysfsPath + "/remove");
+    if (!hasAuthorized && !hasRemove) {
+        m_CanEnable = false;
+    }
 }
 
 void DeviceInput::setInfoFromBluetoothctl()

--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.h
@@ -134,6 +134,12 @@ public:
 
     QString getInterface() const;
 
+    /**
+     * @brief validateCanEnableForMouse: 校验鼠标设备是否满足禁用所需的字段
+     * setEnable()需要SerialID、UniqueID、SysPath，缺少任何一个则禁用操作会失败
+     */
+    void validateCanEnableForMouse();
+
 protected:
     /**
      * @brief initFilterKey:初始化可现实的可显示的属性,m_FilterKey

--- a/deepin-devicemanager/src/EnableControl/DBusTouchPad.cpp
+++ b/deepin-devicemanager/src/EnableControl/DBusTouchPad.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,6 +24,7 @@ const QString Path_V20 = "/com/deepin/daemon/InputDevice/TouchPad";
 const QString Interface_V20 = "com.deepin.daemon.InputDevice.TouchPad";
 
 inline bool isV20() { return Dtk::Core::DSysInfo::majorVersion() == "20"; }
+inline bool isV25() { return Dtk::Core::DSysInfo::majorVersion() == "25"; }
 const QString Service = isV20() ? Service_V20 : Service_V23;
 const QString Path = isV20() ? Path_V20 : Path_V23;
 const QString Interface = isV20() ? Interface_V20 : Interface_V23;
@@ -65,7 +66,11 @@ void DBusTouchPad::setEnable(bool state)
 {
     qCDebug(appLog) << "Set touchpad enable state to:" << state;
     if (m_dbusTouchPad->isValid()) {
-        m_dbusTouchPad->setProperty("TPadEnable", state);
+        if (isV25()) {
+            m_dbusTouchPad->call("Enable", state);
+        } else {
+            m_dbusTouchPad->setProperty("TPadEnable", state);
+        }
         qCInfo(appLog) << "Touchpad state changed to:" << state;
     } else {
         qCWarning(appLog) << "Invalid DBus interface when setting touchpad state";

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1147,6 +1147,7 @@ void DeviceGenerator::getMouseInfoFromHwinfo()
         }
 
         //过滤触摸板，如果不是触摸板再检查
+        bool isTouchpad = (*it)["Model"].contains("Touchpad", Qt::CaseInsensitive);
         if ((*it)["Hotplug"] != "PS/2") {
             // 先判断是否存在
             QString path = pciPath(*it);
@@ -1173,8 +1174,15 @@ void DeviceGenerator::getMouseInfoFromHwinfo()
         device = new DeviceInput();
         device->setInfoFromHwinfo(*it);
         device->setHardwareClass("mouse");
-        if (device->bluetoothIsConnected()) {
-            // qCDebug(appLog) << "Adding bluetooth mouse device";
+
+        // 触摸板设备或蓝牙鼠标需要添加到设备列表
+        if (device->bluetoothIsConnected() || isTouchpad) {
+            // I2C接口的非触摸板设备（如触控屏、触控笔）不支持启用/禁用
+            if (!isTouchpad && device->getInterface() == "I2C") {
+                device->setCanEnable(false);
+            }
+            // 校验禁用所需的字段（SerialID、UniqueID、SysPath），缺少则不显示禁用按钮
+            device->validateCanEnableForMouse();
             DeviceManager::instance()->addMouseDevice(device);
             addBusIDFromHwinfo((*it)["SysFS BusID"]);
         } else {

--- a/deepin-devicemanager/src/Widget/TableWidget.cpp
+++ b/deepin-devicemanager/src/Widget/TableWidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -42,7 +42,6 @@ TableWidget::TableWidget(QWidget *parent)
     , mp_removeDriver(new QAction(tr("Uninstall drivers"), this))
     , mp_WakeupMachine(new QAction(tr("Allow it to wake the computer"), this))
     , mp_Menu(new DMenu(this))
-    , m_Enable(false)
 
 {
     qCDebug(appLog) << "TableWidget instance created";
@@ -106,12 +105,8 @@ void TableWidget::setHeaderLabels(const QStringList &lst)
 {
     qCDebug(appLog) << "Setting header labels to:" << lst;
     QStringList headers;
-    for (int i = 0; i < lst.size(); i++) {
-        if (i < lst.size() - 1) {
-            headers.append(lst[i]);
-        } else {
-            m_Enable = lst[i] == "yes" ? true : false;
-        }
+    for (int i = 0; i < lst.size() - 1; i++) {
+        headers.append(lst[i]);
     }
 
     if (mp_Table) {
@@ -270,12 +265,8 @@ void TableWidget::slotShowMenu(const QPoint &point)
     mp_Menu->addAction(mp_Refresh);
     mp_Menu->addAction(mp_Export);
     QModelIndexList selected = mp_Table->selectionModel()->selectedRows();
-    // 选中item状态下才有启用/禁用按钮
-    if (m_Enable && selected.size() > 0) {
-        mp_Menu->addAction(mp_Enable);
-    }
-    // 主板、内存、cpu等没有驱动，无需右键按钮
-    // 选中item状态下才有卸载、更新按钮
+
+    // 先获取当前行的设备能力
     bool canUninstall = true , canEnable = true;
     QStandardItem* item = mp_Table->item(row,0);
     if(item){ // 获取该设备是否可以更新卸载驱动
@@ -283,6 +274,13 @@ void TableWidget::slotShowMenu(const QPoint &point)
         canUninstall = item->data(Qt::UserRole).toString()=="true" ? true : false;
         canEnable = item->data(Qt::UserRole+1).toString()=="true" ? true : false;
     }
+
+    // 选中item状态下才有启用/禁用按钮
+    if (canEnable && selected.size() > 0) {
+        mp_Menu->addAction(mp_Enable);
+    }
+    // 主板、内存、cpu等没有驱动，无需右键按钮
+    // 选中item状态下才有卸载、更新按钮
     if(!canEnable){
         qCDebug(appLog) << "Device cannot be enabled/disabled, disabling action";
         mp_Enable->setEnabled(false);

--- a/deepin-devicemanager/src/Widget/TableWidget.h
+++ b/deepin-devicemanager/src/Widget/TableWidget.h
@@ -134,7 +134,6 @@ private:
     QAction          *mp_removeDriver;//<! 驱动卸载
     QAction          *mp_WakeupMachine;//<! 唤醒机器
     QMenu            *mp_Menu;        //<! 右键菜单
-    bool             m_Enable;
 };
 
 


### PR DESCRIPTION
Move PS/2 mouse canEnable check after getMouseInfoFromBusDevice() to avoid misidentifying bluetooth mice. Add validateCanEnableForMouse() to check sysfs authorized/remove files. Fix v25 touchpad disable by using DBus Enable method. Refactor TableWidget to use per-row canEnable from item data instead of global m_Enable flag.

修复鼠标/触摸板禁用按钮显示逻辑：将PS/2鼠标canEnable检查移到
getMouseInfoFromBusDevice之后避免误判蓝牙鼠标；新增sysfs文件
校验；v25触摸板禁用改用DBus Enable方法；TableWidget改为逐行
读取canEnable而非全局m_Enable标志。

Log: 修复鼠标触摸板禁用按钮显示和触控板禁用功能
PMS: BUG-355975
Influence: 蓝牙鼠标、I2C触控笔等无法禁用的设备不再显示禁用按钮；v25触摸板禁用功能恢复正常