### PR TITLE
Feat: add HeaderInfoTableWidget for displaying device information

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1935,8 +1935,6 @@ void DeviceManager::overviewToTxt(QTextStream &out)
     out << "\n";
 }
 
-
-
 void DeviceManager::overviewToHtml(QFile &html)
 {
     qCDebug(appLog) << "Exporting overview to html";
@@ -2177,6 +2175,16 @@ void DeviceManager::setCpuFrequencyIsCur(const bool &flag)
 
         device->setFrequencyIsCur(flag);
     }
+}
+
+void DeviceManager::setCpuHeaderInfo(const QList<QList<QPair<QString, QString> > > &info)
+{
+    m_ListCpuHeaderInfo = info;
+}
+
+void DeviceManager::getCpuHeaderInfo(QList<QList<QPair<QString, QString> > > &info) const
+{
+    info = m_ListCpuHeaderInfo;
 }
 
 bool DeviceManager::validateKeyboardVidPid(const QString &vid, const QString &pid, QString &normalizedVid, QString &normalizedPid)

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -632,6 +631,9 @@ public:
      */
     void setCpuFrequencyIsCur(const bool &flag);
 
+    void setCpuHeaderInfo(const QList<QList<QPair<QString, QString>>> &info);
+    void getCpuHeaderInfo(QList<QList<QPair<QString, QString>>> &info) const;
+
     /**
      * @brief validateKeyboardVidPid:校验有效的vid和pid
      * @param vid
@@ -680,6 +682,7 @@ private:
 
     static int m_CurrentXlsRow;       //<! xlsx表格当前行
     QStringList m_networkDriver; //网络驱动
+    QList<QList<QPair<QString, QString>>>          m_ListCpuHeaderInfo;    // 所有物理CPU个体的头部信息
 };
 
 #endif // DEVICEMANAGER_H

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -241,6 +241,10 @@ void DeviceGenerator::generatorCpuDevice()
         device->setCpuInfo(*it, lshw, dmidecode, coreNum, logicalNum);
         DeviceManager::instance()->addCpuDevice(device);
     }
+
+    // 计算并设置CPU头部信息(当前没有多个物理CPU的环境，所以只能编码单物理CPU的逻辑)
+    if (lsCpu.size() > 0)
+        calAndSetCpuHeaderInfo(lsCpu.at(0), coreNum, logicalNum);
 }
 
 void DeviceGenerator::generatorBiosDevice()
@@ -1510,6 +1514,67 @@ QString DeviceGenerator::uniqueID(const QMap<QString, QString> &mapInfo)
     }
     qCDebug(appLog) << "No unique ID found";
     return "";
+}
+
+void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &firstProcessorInfo,
+                                             int coreNum, int logicalNum)
+{
+    QList<QList<QPair<QString, QString>>> cpuHeaderInfo;
+    QList<QPair<QString, QString>> singleCpuHeaderInfo;
+
+    if (firstProcessorInfo.contains("model name")) {
+        QPair<QString, QString> modelName(tr("Model Name"), firstProcessorInfo.value("model name"));
+        singleCpuHeaderInfo.push_back(modelName);
+    }
+    if (firstProcessorInfo.contains("vendor_id")) {
+        QPair<QString, QString> vendorID(tr("Vendor ID"), firstProcessorInfo.value("vendor_id"));
+        singleCpuHeaderInfo.push_back(vendorID);
+    }
+    if (firstProcessorInfo.contains("Architecture")) {
+        QPair<QString, QString> arch(tr("Architecture"), firstProcessorInfo.value("Architecture"));
+        singleCpuHeaderInfo.push_back(arch);
+    }
+    if (coreNum > 0) {
+        QPair<QString, QString> coreCount(tr("Core(s)"), QString::number(coreNum));
+        singleCpuHeaderInfo.push_back(coreCount);
+        QPair<QString, QString> threadPerCore(tr("Thread(s)"), QString::number(logicalNum / coreNum));
+        singleCpuHeaderInfo.push_back(threadPerCore);
+    }
+    if (firstProcessorInfo.contains("L1d cache")) {
+        QString strL1dCache = firstProcessorInfo.value("L1d cache");
+        QString strTotalL1dCache = Common::formatTotalCache(strL1dCache, coreNum);
+        if (!strTotalL1dCache.isEmpty()) {
+            QPair<QString, QString> totalL1dCache(tr("L1d cache"), strTotalL1dCache);
+            singleCpuHeaderInfo.push_back(totalL1dCache);
+        }
+    }
+    if (firstProcessorInfo.contains("L1i cache")) {
+        QString strL1iCache = firstProcessorInfo.value("L1i cache");
+        QString strTotalL1iCache = Common::formatTotalCache(strL1iCache, coreNum);
+        if (!strTotalL1iCache.isEmpty()) {
+            QPair<QString, QString> totalL1iCache(tr("L1i cache"), strTotalL1iCache);
+            singleCpuHeaderInfo.push_back(totalL1iCache);
+        }
+    }
+    if (firstProcessorInfo.contains("L2 cache")) {
+        QString strL2Cache = firstProcessorInfo.value("L2 cache");
+        QString strTotalL2Cache = Common::formatTotalCache(strL2Cache, coreNum);
+        if (!strTotalL2Cache.isEmpty()) {
+            QPair<QString, QString> totalL2Cache(tr("L2 cache"), strTotalL2Cache);
+            singleCpuHeaderInfo.push_back(totalL2Cache);
+        }
+    }
+    if (firstProcessorInfo.contains("L3 cache")) {
+        QString strL3Cache = firstProcessorInfo.value("L3 cache");
+        QString strTotalL3Cache = Common::formatTotalCache(strL3Cache, 1);
+        if (!strTotalL3Cache.isEmpty()) {
+            QPair<QString, QString> totalL3Cache(tr("L3 cache"), strTotalL3Cache);
+            singleCpuHeaderInfo.push_back(totalL3Cache);
+        }
+    }
+
+    cpuHeaderInfo.push_back(singleCpuHeaderInfo);
+    DeviceManager::instance()->setCpuHeaderInfo(cpuHeaderInfo);
 }
 
 void DeviceGenerator::generatorInfoFromToml(DeviceType deviceType)

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.h
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -338,6 +337,10 @@ protected:
 
 protected:
     QStringList m_ListBusID;
+
+private:
+    void calAndSetCpuHeaderInfo(const QMap<QString, QString> &firstProcessorInfo,
+                                int coreNum, int logicalNum);
 };
 
 #endif // DEVICEGENERATOR_H

--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -50,7 +50,7 @@ DWIDGET_USE_NAMESPACE
 using namespace DDLog;
 // 主界面需要的一些宏定义
 #define INIT_WIDTH  1000    // 窗口的初始化宽度
-#define INIT_HEIGHT 720     // 窗口的初始化高度
+#define INIT_HEIGHT 802     // 窗口的初始化高度
 #define MIN_WIDTH  680      // 窗口的最小宽度
 #define MIN_HEIGHT 300      // 窗口的最小高度
 

--- a/deepin-devicemanager/src/Page/PageMultiInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageMultiInfo.cpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 // 项目自身文件
 #include "PageMultiInfo.h"
+#include "headerinfotablewidget.h"
 #include "PageTableHeader.h"
 #include "PageDetail.h"
 #include "MacroDefinition.h"
@@ -12,6 +13,7 @@
 #include "DevicePrint.h"
 #include "DeviceInput.h"
 #include "DeviceNetwork.h"
+#include "DeviceCpu.h"
 #include "DDLog.h"
 #include "commonfunction.h"
 
@@ -22,7 +24,6 @@
 #include <DMessageManager>
 
 // Qt库文件
-#include <QVBoxLayout>
 #include <QAction>
 #include <QIcon>
 #include <QLoggingCategory>
@@ -33,10 +34,14 @@ DWIDGET_USE_NAMESPACE
 using namespace DDLog;
 
 #define LEAST_PAGE_HEIGHT 315  // PageMultiInfo最小高度 当小于这个高度时，上方的表格就要变小
+static constexpr int kHeaderInfoDefaultHeight = 362; // 滚动区域默认高度
 
 PageMultiInfo::PageMultiInfo(QWidget *parent)
     : PageInfo(parent)
     , mp_Label(new DLabel(this))
+    , mp_HeaderInfoWidget(new DScrollArea(this))
+    , mp_HeaderInfoContainer(new DWidget(mp_HeaderInfoWidget))
+    , mp_HeaderInfoWidgetLay(new QVBoxLayout(mp_HeaderInfoContainer))
     , mp_Table(new PageTableHeader(this))
     , mp_Detail(new PageDetail(this))
 {
@@ -64,6 +69,11 @@ PageMultiInfo::~PageMultiInfo()
 {
     qCDebug(appLog) << "PageMultiInfo destructor start";
     // 清空指针
+    if (mp_HeaderInfoWidget) {
+        delete mp_HeaderInfoWidget;
+        mp_HeaderInfoWidget = nullptr;
+        mp_HeaderInfoContainer = nullptr;
+    }
     if (mp_Table) {
         qCDebug(appLog) << "Deleting table";
         delete mp_Table;
@@ -89,6 +99,26 @@ void PageMultiInfo::updateInfo(const QList<DeviceBaseInfo *> &lst)
         qCWarning(appLog) << "Empty device list provided";
         return;
     }
+
+    // 当前为CPU页面，显示头部信息视图
+    DeviceCpu *cpuInfo = dynamic_cast<DeviceCpu *>(lst.at(0));
+    if (cpuInfo) {
+        QList<QList<QPair<QString, QString>>> headerInfo;
+        DeviceManager::instance()->getCpuHeaderInfo(headerInfo);
+        clearLayout(mp_HeaderInfoWidgetLay);
+        for (int i = 0; i < headerInfo.size(); ++i) {
+            HeaderInfoTableWidget *headerWidget = new HeaderInfoTableWidget(mp_HeaderInfoWidget);
+            headerWidget->updateData(headerInfo.at(i));
+            mp_HeaderInfoWidgetLay->addWidget(headerWidget);
+        }
+        mp_HeaderInfoWidget->setMaximumHeight(kHeaderInfoDefaultHeight);
+        mp_HeaderInfoWidget->resize(this->width(), kHeaderInfoDefaultHeight);
+        mp_HeaderInfoWidget->setVisible(true);
+    } else {
+        mp_HeaderInfoWidget->setVisible(false);
+        mp_HeaderInfoWidget->setMaximumHeight(0);
+    }
+
     m_deviceList.clear();
     m_menuControlList.clear();
 
@@ -285,23 +315,35 @@ void PageMultiInfo::initWidgets()
 {
     qCDebug(appLog) << "PageMultiInfo::initWidgets";
     // 初始化界面布局
-    QVBoxLayout *hLayout = new QVBoxLayout();
+    QVBoxLayout *vLayout = new QVBoxLayout();
     QHBoxLayout *labelLayout = new QHBoxLayout();
     labelLayout->addSpacing(10);
     labelLayout->addWidget(mp_Label);
 
     // Label 距离上下控件的距离LABEL_MARGIN
-    hLayout->addSpacing(LABEL_MARGIN);
-    hLayout->addLayout(labelLayout);
-    hLayout->addSpacing(LABEL_MARGIN);
+    vLayout->addSpacing(LABEL_MARGIN);
+    vLayout->addLayout(labelLayout);
+    vLayout->addSpacing(LABEL_MARGIN);
+
+    // 添加头部信息视图
+    mp_HeaderInfoWidget->setWidget(mp_HeaderInfoContainer);
+    mp_HeaderInfoWidget->setWidgetResizable(true);
+    mp_HeaderInfoWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    mp_HeaderInfoWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    mp_HeaderInfoWidget->setFrameShape(QFrame::NoFrame);
+    mp_HeaderInfoWidget->setMaximumHeight(kHeaderInfoDefaultHeight);
+    mp_HeaderInfoWidget->setMinimumHeight(0);
+    mp_HeaderInfoWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    mp_HeaderInfoWidgetLay->setContentsMargins(0, 0, 0, 0);
+    mp_HeaderInfoWidget->setVisible(false);
+    vLayout->addWidget(mp_HeaderInfoWidget, 1);  // stretch=1，允许随窗口缩放
 
     mp_Table->setFixedHeight(TABLE_HEIGHT);
+    vLayout->addWidget(mp_Table);
+    vLayout->addWidget(mp_Detail);
+    vLayout->setContentsMargins(10, 10, 10, 0);
 
-    hLayout->addWidget(mp_Table);
-    hLayout->addWidget(mp_Detail);
-    hLayout->setContentsMargins(10, 10, 10, 0);
-
-    setLayout(hLayout);
+    setLayout(vLayout);
 }
 
 void PageMultiInfo::getTableListInfo(const QList<DeviceBaseInfo *> &lst, QList<QStringList> &deviceList, QList<QStringList> &menuControlList)
@@ -340,4 +382,17 @@ void PageMultiInfo::getTableListInfo(const QList<DeviceBaseInfo *> &lst, QList<Q
         menuControlList.append(menuControl);
     }
     qCDebug(appLog) << "PageMultiInfo::getTableListInfo end";
+}
+
+void PageMultiInfo::clearLayout(QLayout *layout)
+{
+    QLayoutItem *item;
+    while ((item = layout->takeAt(0)) != nullptr) {
+        // 如果布局项包含控件，删除该控件
+        if (QWidget *widget = item->widget()) {
+            widget->deleteLater();   // 安全删除，避免事件冲突
+        }
+        // 删除布局项本身（注意：如果 item 是子布局，需递归处理，本例仅处理直接控件）
+        delete item;
+    }
 }

--- a/deepin-devicemanager/src/Page/PageMultiInfo.h
+++ b/deepin-devicemanager/src/Page/PageMultiInfo.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,8 +6,10 @@
 #define DEVICEPAGE_H
 
 #include <QObject>
+#include <QVBoxLayout>
 #include <DWidget>
 #include <DLabel>
+#include <DScrollArea>
 
 #include "PageInfo.h"
 
@@ -122,8 +123,14 @@ private:
      */
     void getTableListInfo(const QList<DeviceBaseInfo *> &lst, QList<QStringList>& deviceList, QList<QStringList>& menuList);
 
+    // 清空布局中的所有 Widget
+    void clearLayout(QLayout *layout);
+
 private:
     DLabel                    *mp_Label;
+    DScrollArea               *mp_HeaderInfoWidget;
+    DWidget                   *mp_HeaderInfoContainer;
+    QVBoxLayout               *mp_HeaderInfoWidgetLay;
     PageTableHeader           *mp_Table;       //<! 上面的表格
     PageDetail                *mp_Detail;      //<! 下面的详细内容
     QList<DeviceBaseInfo *>   m_lstDevice;     //<! 保存设备列表

--- a/deepin-devicemanager/src/Widget/headerinfotableDelegate.cpp
+++ b/deepin-devicemanager/src/Widget/headerinfotableDelegate.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <DApplication>
+#include <DPaletteHelper>
+#include <DPalette>
+
+#include "headerinfotableDelegate.h"
+
+DWIDGET_USE_NAMESPACE
+
+HeaderInfoDelegate::HeaderInfoDelegate(QObject *parent)
+    : QStyledItemDelegate(parent)
+{
+}
+
+void HeaderInfoDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    QStyleOptionViewItem opt(option);
+    initStyleOption(&opt, index);
+
+    QWidget *wnd = DApplication::activeWindow();
+    DPalette::ColorGroup cg = wnd ? DPalette::Active : DPalette::Inactive;
+    auto palette = DPaletteHelper::instance()->palette(option.widget);
+
+    if (opt.state & QStyle::State_Selected) {
+        QColor highlightColor = palette.color(cg, DPalette::HighlightedText);
+        opt.palette.setColor(QPalette::Text, highlightColor);
+        opt.palette.setColor(QPalette::WindowText, highlightColor);
+    } else {
+        QColor normalColor = palette.color(cg, DPalette::Text);
+        opt.palette.setColor(QPalette::Text, normalColor);
+        opt.palette.setColor(QPalette::WindowText, normalColor);
+    }
+
+    QStyledItemDelegate::paint(painter, opt, index);
+}

--- a/deepin-devicemanager/src/Widget/headerinfotableDelegate.h
+++ b/deepin-devicemanager/src/Widget/headerinfotableDelegate.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef HEADERINFOTABLEDELEGATE_H
+#define HEADERINFOTABLEDELEGATE_H
+
+#include <QStyledItemDelegate>
+
+class HeaderInfoDelegate : public QStyledItemDelegate
+{
+public:
+    explicit HeaderInfoDelegate(QObject *parent = nullptr);
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &option,
+               const QModelIndex &index) const override;
+};
+
+#endif

--- a/deepin-devicemanager/src/Widget/headerinfotablewidget.cpp
+++ b/deepin-devicemanager/src/Widget/headerinfotablewidget.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "headerinfotablewidget.h"
+#include "headerinfotableDelegate.h"
+#include "MacroDefinition.h"
+
+#include <DApplication>
+#include <DPaletteHelper>
+
+#include <QHeaderView>
+#include <QPainter>
+#include <QPainterPath>
+
+DWIDGET_USE_NAMESPACE
+
+static constexpr int kColumnCount { 2 };
+
+HeaderInfoTableWidget::HeaderInfoTableWidget(DWidget *parent)
+    : DTableWidget(parent)
+{
+    initUI();
+}
+
+void HeaderInfoTableWidget::updateData(const QList<QPair<QString, QString>> &data)
+{
+    resetTableContents();
+    int nRow = data.size();
+    setRowCount(nRow);
+
+    QWidget *wnd = DApplication::activeWindow();
+    DPalette::ColorGroup cg = wnd ? DPalette::Active : DPalette::Inactive;
+    auto palette = DPaletteHelper::instance()->palette(this);
+    QColor colorEven = palette.color(cg, DPalette::Base);
+    QColor colorOdd = palette.color(cg, DPalette::ItemBackground);
+
+    for (int i = 0; i < nRow; ++i) {
+        QTableWidgetItem *itemFirst = new QTableWidgetItem(data[i].first);
+        itemFirst->setFlags(itemFirst->flags() & ~Qt::ItemIsSelectable);
+        itemFirst->setBackground(i % 2 == 0 ? colorEven : colorOdd);
+        setItem(i, 0, itemFirst);
+        QTableWidgetItem *itemSecond = new QTableWidgetItem(data[i].second);
+        itemSecond->setFlags(itemSecond->flags() & ~Qt::ItemIsSelectable);
+        itemSecond->setBackground(i % 2 == 0 ? colorEven : colorOdd);
+        setItem(i, 1, itemSecond);
+    }
+
+    // 调整控件高度，使内容刚好完全显示，不出现垂直滚动条
+    if (nRow > 0) {
+        // 为了保持底部圆角，给表格高度留出 2px 余量；避免内容铺满viewport导致圆角被覆盖
+        setFixedHeight(ROW_HEIGHT * nRow + 2);
+    } else {
+        setFixedHeight(0);
+    }
+}
+
+void HeaderInfoTableWidget::initUI()
+{
+    setColumnCount(kColumnCount);
+    this->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    this->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
+    setSelectionMode(QAbstractItemView::NoSelection);
+    setSelectionBehavior(QAbstractItemView::SelectItems);
+    this->setFocusPolicy(Qt::NoFocus);
+    // 设置无边框, 避免原始方形外框干扰圆角绘制
+    this->setFrameStyle(QFrame::NoFrame);
+    this->setShowGrid(false);
+    this->viewport()->setAutoFillBackground(true);
+    m_delegate = new HeaderInfoDelegate(this);
+    this->setItemDelegate(m_delegate);
+    setAlternatingRowColors(true);
+    this->verticalHeader()->setVisible(false);
+    this->horizontalHeader()->setVisible(false);
+    this->setSortingEnabled(false);
+    this->horizontalHeader()->setStretchLastSection(true);
+    this->verticalHeader()->setDefaultSectionSize(ROW_HEIGHT);
+    this->horizontalHeader()->setDefaultSectionSize(180);
+    this->setAttribute(Qt::WA_TranslucentBackground);
+    this->setWindowFlags(Qt::FramelessWindowHint);
+}
+
+void HeaderInfoTableWidget::paintEvent(QPaintEvent *event)
+{
+    DTableWidget::paintEvent(event);
+
+    QWidget *wnd = DApplication::activeWindow();
+    DPalette::ColorGroup cg = wnd ? DPalette::Active : DPalette::Inactive;
+
+    auto palette = DPaletteHelper::instance()->palette(this);
+
+    QRect rect = viewport()->rect().adjusted(0, 0, -1, -1);
+    int width = 1;
+    int radius = 8;
+
+    QPainter painter(this->viewport());
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    QPainterPath paintPathOut;
+    paintPathOut.addRoundedRect(rect, radius, radius);
+
+    QRect rectIn = QRect(rect.x() + width, rect.y() + width, rect.width() - width * 2, rect.height() - width * 2);
+    QPainterPath paintPathIn;
+    paintPathIn.addRoundedRect(rectIn, radius, radius);
+
+    QPainterPath paintPath = paintPathOut.subtracted(paintPathIn);
+    QBrush bgBrush(palette.color(cg, DPalette::FrameBorder));
+    painter.fillPath(paintPath, bgBrush);
+
+    QPen pen = painter.pen();
+    pen.setWidth(width);
+    pen.setColor(palette.color(cg, DPalette::FrameBorder));
+    painter.setPen(pen);
+    painter.drawRoundedRect(rectIn, radius, radius);
+
+    // Draw vertical divider between first and second columns (same as DetailTreeView)
+    QLine vline(rect.topLeft().x() + 179, rect.topLeft().y(), rect.bottomLeft().x() + 179, rect.bottomLeft().y());
+    painter.drawLine(vline);
+}
+
+void HeaderInfoTableWidget::resetTableContents()
+{
+    DTableWidget::clear();
+    setRowCount(0);
+}

--- a/deepin-devicemanager/src/Widget/headerinfotablewidget.h
+++ b/deepin-devicemanager/src/Widget/headerinfotablewidget.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef HEADERINFOTABLEWIDGET_H
+#define HEADERINFOTABLEWIDGET_H
+
+#include <DTableWidget>
+#include <DWidget>
+
+#include <QObject>
+
+class HeaderInfoTableWidget : public DTK_WIDGET_NAMESPACE::DTableWidget
+{
+    Q_OBJECT
+public:
+    explicit HeaderInfoTableWidget(DTK_WIDGET_NAMESPACE::DWidget *parent = nullptr);
+    void updateData(const QList<QPair<QString, QString>> &data);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    void initUI();
+    void resetTableContents();
+    class HeaderInfoDelegate *m_delegate = nullptr;
+};
+
+#endif

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -311,3 +311,65 @@ bool Common::isShowScreenSize()
 #endif
     return showScreenSize;
 }
+
+QString Common::formatTotalCache(const QString &perThreadCache, int coreCount)
+{
+    // 1. 清理并分离数字与单位
+    QString s = perThreadCache.trimmed();
+    if (s.isEmpty())
+        return QString();
+
+    int i = s.length() - 1;
+    while (i >= 0 && !s[i].isDigit() && s[i] != '.')
+        --i;
+
+    QString numStr = s.left(i + 1);
+    QString unitStr = s.mid(i + 1).toUpper();
+
+    bool ok;
+    double num = numStr.toDouble(&ok);
+    if (!ok)
+        return QString();
+
+    // 2. 将单核/单线程缓存转换为 KiB
+    double perCoreKiB = 0.0;
+    if (unitStr.startsWith("K") || unitStr == "KB" || unitStr == "KIB") {
+        perCoreKiB = num;
+    } else if (unitStr.startsWith("M") || unitStr == "MB" || unitStr == "MIB") {
+        perCoreKiB = num * 1024.0;
+    } else if (unitStr.startsWith("G") || unitStr == "GB" || unitStr == "GIB") {
+        perCoreKiB = num * 1024.0 * 1024.0;
+    } else if (unitStr.startsWith("T") || unitStr == "TB" || unitStr == "TIB") {
+        perCoreKiB = num * 1024.0 * 1024.0 * 1024.0;
+    } else if (unitStr.isEmpty() || unitStr == "B") {
+        // 无单位或纯字节，视为字节并转为 KiB
+        perCoreKiB = num / 1024.0;
+    } else {
+        // 未知单位，按原数值当作 KiB 处理
+        perCoreKiB = num;
+    }
+
+    double totalKiB = perCoreKiB * coreCount;
+
+    // 3. 选择最合适的单位并格式化数值
+    double value;
+    QString unit;
+    if (totalKiB >= 1024.0 * 1024.0) {
+        value = totalKiB / (1024.0 * 1024.0);
+        unit = "GiB";
+    } else if (totalKiB >= 1024.0) {
+        value = totalKiB / 1024.0;
+        unit = "MiB";
+    } else {
+        value = totalKiB;
+        unit = "KiB";
+    }
+
+    // 4. 数值显示：若为整数则无小数位，否则保留一位小数
+    double intPart;
+    if (std::abs(std::modf(value, &intPart)) < 1e-6) {
+        return QString::number(static_cast<long long>(value)) + " " + unit;
+    } else {
+        return QString::number(value, 'f', 1) + " " + unit;
+    }
+}

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -49,5 +49,7 @@ public:
     static QByteArray executeClientCmd(const QString& cmd, const QStringList& args = QStringList(), const QString& workPath = QString(), int msecsWaiting = 30000, bool useEnv = true);
 
     static bool isShowScreenSize();
+
+    static QString formatTotalCache(const QString& perThreadCache, int coreCount);
 };
 #endif // COMMONFUNCTION_H


### PR DESCRIPTION
Add a custom table widget with rounded border and alternating row colors for displaying device information as key-value pairs.

- Add HeaderInfoDelegate for custom text color handling in selection
- Add HeaderInfoTableWidget with rounded border painting and vertical divider
- Support dynamic height adjustment based on content
- Use DPalette for consistent theming with active/inactive states

Log: add feature for cpu info show.
Task: https://pms.uniontech.com/task-view-387697.html