### PR TITLE
chore: Update version to 6.0.59

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-devicemanager (6.0.59) unstable; urgency=medium
+
+  * feat: Add feature for cpu info show.
+
+ -- gongheng <gongheng@uniontech.com>  Sat, 11 Apr 2026 11:26:26 +0800
+
 deepin-devicemanager (6.0.58) unstable; urgency=medium
 
   * fix: Improve argument handling in QProcess commands


### PR DESCRIPTION
- update version to 6.0.59

log: update version to 6.0.59

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 6.0.59.