### PR TITLE
fix(cpu): Fix CPU vendor info from dmidecode

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -243,8 +243,13 @@ void DeviceGenerator::generatorCpuDevice()
     }
 
     // 计算并设置CPU头部信息(当前没有多个物理CPU的环境，所以只能编码单物理CPU的逻辑)
-    if (lsCpu.size() > 0)
-        calAndSetCpuHeaderInfo(lsCpu.at(0), coreNum, logicalNum);
+    if (lsCpu.size() > 0) {
+        QMap<QString, QString> baseCPUInfo = lsCpu.at(0);
+        if (dmidecode.contains("Manufacturer")) {
+            baseCPUInfo["vendor_id"] = dmidecode["Manufacturer"];
+        }
+        calAndSetCpuHeaderInfo(baseCPUInfo, coreNum, logicalNum);
+    }
 }
 
 void DeviceGenerator::generatorBiosDevice()


### PR DESCRIPTION
Add dmidecode manufacturer info to CPU vendor_id field.

从 dmidecode 获取厂商信息并设置到 CPU vendor_id 字段。

Log: 修复 CPU 厂商信息获取
PMS: BUG-357919
Influence: 修复后 CPU 厂商信息将正确显示，提升设备信息准确性。

## Summary by Sourcery

Bug Fixes:
- Correct CPU vendor identification by populating vendor_id from dmidecode Manufacturer when available.