### PR TITLE
Feat: add CPU header info storage and cache size formatting

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1949,4 +1949,14 @@ void DeviceManager::setCpuFrequencyIsCur(const bool &flag)
 
         device->setFrequencyIsCur(flag);
     }
+}
+
+void DeviceManager::setCpuHeaderInfo(const QList<QList<QPair<QString, QString> > > &info)
+{
+    m_ListCpuHeaderInfo = info;
+}
+
+void DeviceManager::getCpuHeaderInfo(QList<QList<QPair<QString, QString> > > &info) const
+{
+    info = m_ListCpuHeaderInfo;
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -631,6 +630,9 @@ public:
      */
     void setCpuFrequencyIsCur(const bool &flag);
 
+    void setCpuHeaderInfo(const QList<QList<QPair<QString, QString>>> &info);
+    void getCpuHeaderInfo(QList<QList<QPair<QString, QString>>> &info) const;
+
 protected:
     DeviceManager();
     ~DeviceManager();
@@ -669,6 +671,7 @@ private:
 
     static int m_CurrentXlsRow;       //<! xlsx表格当前行
     QStringList m_networkDriver; //网络驱动
+    QList<QList<QPair<QString, QString>>>          m_ListCpuHeaderInfo;    // 所有物理CPU个体的头部信息
 };
 
 #endif // DEVICEMANAGER_H

--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -49,7 +49,7 @@ DWIDGET_USE_NAMESPACE
 using namespace DDLog;
 // 主界面需要的一些宏定义
 #define INIT_WIDTH  1000    // 窗口的初始化宽度
-#define INIT_HEIGHT 720     // 窗口的初始化高度
+#define INIT_HEIGHT 802     // 窗口的初始化高度
 #define MIN_WIDTH  680      // 窗口的最小宽度
 #define MIN_HEIGHT 300      // 窗口的最小高度
 

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -16,6 +16,7 @@
 #include <QRegularExpression>
 
 #include <sys/utsname.h>
+#include <cmath>
 
 using namespace DDLog;
 
@@ -250,4 +251,66 @@ bool Common::isShowScreenSize()
     }
 #endif
     return showScreenSize;
+}
+
+QString Common::formatTotalCache(const QString &perThreadCache, int coreCount)
+{
+    // 1. 清理并分离数字与单位
+    QString s = perThreadCache.trimmed();
+    if (s.isEmpty())
+        return QString();
+
+    int i = s.length() - 1;
+    while (i >= 0 && !s[i].isDigit() && s[i] != '.')
+        --i;
+
+    QString numStr = s.left(i + 1);
+    QString unitStr = s.mid(i + 1).toUpper();
+
+    bool ok;
+    double num = numStr.toDouble(&ok);
+    if (!ok)
+        return QString();
+
+    // 2. 将单核/单线程缓存转换为 KiB
+    double perCoreKiB = 0.0;
+    if (unitStr.startsWith("K") || unitStr == "KB" || unitStr == "KIB") {
+        perCoreKiB = num;
+    } else if (unitStr.startsWith("M") || unitStr == "MB" || unitStr == "MIB") {
+        perCoreKiB = num * 1024.0;
+    } else if (unitStr.startsWith("G") || unitStr == "GB" || unitStr == "GIB") {
+        perCoreKiB = num * 1024.0 * 1024.0;
+    } else if (unitStr.startsWith("T") || unitStr == "TB" || unitStr == "TIB") {
+        perCoreKiB = num * 1024.0 * 1024.0 * 1024.0;
+    } else if (unitStr.isEmpty() || unitStr == "B") {
+        // 无单位或纯字节，视为字节并转为 KiB
+        perCoreKiB = num / 1024.0;
+    } else {
+        // 未知单位，按原数值当作 KiB 处理
+        perCoreKiB = num;
+    }
+
+    double totalKiB = perCoreKiB * coreCount;
+
+    // 3. 选择最合适的单位并格式化数值
+    double value;
+    QString unit;
+    if (totalKiB >= 1024.0 * 1024.0) {
+        value = totalKiB / (1024.0 * 1024.0);
+        unit = "GiB";
+    } else if (totalKiB >= 1024.0) {
+        value = totalKiB / 1024.0;
+        unit = "MiB";
+    } else {
+        value = totalKiB;
+        unit = "KiB";
+    }
+
+    // 4. 数值显示：若为整数则无小数位，否则保留一位小数
+    double intPart;
+    if (std::abs(std::modf(value, &intPart)) < 1e-6) {
+        return QString::number(static_cast<long long>(value)) + " " + unit;
+    } else {
+        return QString::number(value, 'f', 1) + " " + unit;
+    }
 }

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -56,5 +56,6 @@ public:
     static QByteArray executeClientCmd(const QString& cmd, const QStringList& args = QStringList(), const QString& workPath = QString(), int msecsWaiting = 30000);
 
     static bool isShowScreenSize();
+    static QString formatTotalCache(const QString& perThreadCache, int coreCount);
 };
 #endif // COMMONFUNCTION_H


### PR DESCRIPTION
- Add DeviceManager CPU header info getters/setters and storage member
- Adjust main window initial height to 802
- Rename HeaderInfoTableWidget clear() to resetTableContents()
- Add Common::formatTotalCache for converting per-thread cache to total cache and formatting with KiB/MiB/GiB units
- Update SPDX year range in DeviceManager files

Log: add feature for cpu info show
Task: https://pms.uniontech.com/task-view-387697.html

## Summary by Sourcery

Add storage and accessors for CPU header information and introduce formatted total CPU cache size display, alongside minor UI and metadata tweaks.

New Features:
- Store per-CPU header information in DeviceManager with corresponding setters and getters.
- Provide a utility to convert per-thread CPU cache values into formatted total cache sizes with KiB/MiB/GiB units.

Enhancements:
- Increase the main window initial height to 802 for improved layout.
- Update SPDX copyright year ranges in DeviceManager source files.