### PR TITLE
fix(security): VPLUS-2026-34718 - fix DBus permission configuration

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/org.deepin.devicecontrol.conf
+++ b/deepin-devicemanager-server/deepin-devicecontrol/org.deepin.devicecontrol.conf
@@ -4,16 +4,65 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
+  <!--
+    Security Policy for org.deepin.DeviceControl
 
-  <!-- Only root can own the service -->
+    This configuration implements method-level permission separation:
+    - Default policy: DENY all access
+    - Only whitelisted read-only methods are allowed for all users
+    - Dangerous methods (aptUpdate, installDriver, disableInDevice, etc.)
+      require authentication via Polkit
+
+    IMPORTANT: When adding new DBus methods to this service:
+    1. For read-only/query methods: Add them to the whitelist below
+    2. For privileged/modify methods: Do NOT add to whitelist (require Polkit auth)
+    3. Test both security scenarios before merging
+
+    Last updated: 2026-05-07 (VPLUS-2026-34718 security fix)
+  -->
+
   <policy user="root">
     <allow own="org.deepin.DeviceControl"/>
     <allow send_destination="org.deepin.DeviceControl"/>
   </policy>
 
-  <!-- Allow anyone to invoke methods on the interfaces -->
   <policy context="default">
-    <allow send_destination="org.deepin.DeviceControl"/>
+    <deny send_destination="org.deepin.DeviceControl"/>
+  </policy>
+
+  <!-- Whitelist: Read-only methods accessible to all users -->
+  <policy context="default">
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="getAuthorizedInfo"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="getRemoveInfo"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="isDeviceEnabled"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="monitorWorkingDBFlag"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="isNetworkWakeup"/>
+
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="checkModuleInUsed"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="isDriverPackage"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="isBlackListed"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="isArchMatched"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="isDebValid"/>
   </policy>
 
 </busconfig>


### PR DESCRIPTION
- Implement method-level permission separation for DBus service
- Default deny policy for all methods
- Whitelist read-only methods (getAuthorizedInfo, getRemoveInfo, etc.)
- Dangerous methods (aptUpdate, installDriver, disableInDevice) require authentication
- Add Debug build support with warning messages
- Ensure Release builds have Polkit enabled

Security impact:
- Fixes privilege escalation vulnerability (CVSS 8.1)
- Prevents unauthorized access to root-level operations
- Maintains developer convenience in Debug builds

CVSS: 8.1 (High)
Affected: All systems with deepin-devicemanager installed
Fix version: 6.0.62

## Summary by Sourcery

Tighten DBus access control for deepin-devicemanager and enforce safer Polkit behavior across build types.

New Features:
- Introduce method-level DBus permission rules allowing only specific read-only methods to be called without additional authorization.

Bug Fixes:
- Prevent unauthorized invocation of privileged DBus methods by switching to a default-deny DBus policy for the DeviceControl service.

Enhancements:
- Enable automatic Polkit disabling in Debug builds with explicit warning messages while ensuring Polkit remains enabled in non-Debug builds.