### PR TITLE
Feat: improve PageMultiInfo CPU header info display and device genera…

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -204,6 +204,10 @@ void DeviceGenerator::generatorCpuDevice()
         device->setCpuInfo(*it, lshw, dmidecode, coreNum, logicalNum);
         DeviceManager::instance()->addCpuDevice(device);
     }
+
+    // 计算并设置CPU头部信息(当前没有多个物理CPU的环境，所以只能编码单物理CPU的逻辑)
+    if (lsCpu.size() > 0)
+        calAndSetCpuHeaderInfo(lsCpu.at(0), coreNum, logicalNum);
 }
 
 void DeviceGenerator::generatorBiosDevice()
@@ -1254,6 +1258,66 @@ QString DeviceGenerator::uniqueID(const QMap<QString, QString> &mapInfo)
         return mapInfo["Serial ID"];
     }
     return "";
+}
+
+void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &firstProcessorInfo, int coreNum, int logicalNum)
+{
+    QList<QList<QPair<QString, QString>>> cpuHeaderInfo;
+    QList<QPair<QString, QString>> singleCpuHeaderInfo;
+
+    if (firstProcessorInfo.contains("model name")) {
+        QPair<QString, QString> modelName(tr("Model Name"), firstProcessorInfo.value("model name"));
+        singleCpuHeaderInfo.push_back(modelName);
+    }
+    if (firstProcessorInfo.contains("vendor_id")) {
+        QPair<QString, QString> vendorID(tr("Vendor ID"), firstProcessorInfo.value("vendor_id"));
+        singleCpuHeaderInfo.push_back(vendorID);
+    }
+    if (firstProcessorInfo.contains("Architecture")) {
+        QPair<QString, QString> arch(tr("Architecture"), firstProcessorInfo.value("Architecture"));
+        singleCpuHeaderInfo.push_back(arch);
+    }
+    if (coreNum > 0) {
+        QPair<QString, QString> coreCount(tr("Core(s)"), QString::number(coreNum));
+        singleCpuHeaderInfo.push_back(coreCount);
+        QPair<QString, QString> threadPerCore(tr("Thread(s)"), QString::number(logicalNum / coreNum));
+        singleCpuHeaderInfo.push_back(threadPerCore);
+    }
+    if (firstProcessorInfo.contains("L1d cache")) {
+        QString strL1dCache = firstProcessorInfo.value("L1d cache");
+        QString strTotalL1dCache = Common::formatTotalCache(strL1dCache, coreNum);
+        if (!strTotalL1dCache.isEmpty()) {
+            QPair<QString, QString> totalL1dCache(tr("L1d cache"), strTotalL1dCache);
+            singleCpuHeaderInfo.push_back(totalL1dCache);
+        }
+    }
+    if (firstProcessorInfo.contains("L1i cache")) {
+        QString strL1iCache = firstProcessorInfo.value("L1i cache");
+        QString strTotalL1iCache = Common::formatTotalCache(strL1iCache, coreNum);
+        if (!strTotalL1iCache.isEmpty()) {
+            QPair<QString, QString> totalL1iCache(tr("L1i cache"), strTotalL1iCache);
+            singleCpuHeaderInfo.push_back(totalL1iCache);
+        }
+    }
+    if (firstProcessorInfo.contains("L2 cache")) {
+        QString strL2Cache = firstProcessorInfo.value("L2 cache");
+        QString strTotalL2Cache = Common::formatTotalCache(strL2Cache, coreNum);
+        if (!strTotalL2Cache.isEmpty()) {
+            QPair<QString, QString> totalL2Cache(tr("L2 cache"), strTotalL2Cache);
+            singleCpuHeaderInfo.push_back(totalL2Cache);
+        }
+    }
+    if (firstProcessorInfo.contains("L3 cache")) {
+        QString strL3Cache = firstProcessorInfo.value("L3 cache");
+        QString strTotalL3Cache = Common::formatTotalCache(strL3Cache, 1);
+        if (!strTotalL3Cache.isEmpty()) {
+            QPair<QString, QString> totalL3Cache(tr("L3 cache"), strTotalL3Cache);
+            singleCpuHeaderInfo.push_back(totalL3Cache);
+        }
+    }
+
+    cpuHeaderInfo.push_back(singleCpuHeaderInfo);
+    DeviceManager::instance()->setCpuHeaderInfo(cpuHeaderInfo);
 }
 
 void DeviceGenerator::generatorInfoFromToml(DeviceType deviceType)

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.h
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -338,6 +337,10 @@ protected:
 
 protected:
     QStringList m_ListBusID;
+
+private:
+    void calAndSetCpuHeaderInfo(const QMap<QString, QString> &firstProcessorInfo,
+                                int coreNum, int logicalNum);
 };
 
 #endif // DEVICEGENERATOR_H

--- a/deepin-devicemanager/src/Page/PageMultiInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageMultiInfo.cpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 // 项目自身文件
 #include "PageMultiInfo.h"
+#include "headerinfotablewidget.h"
 #include "PageTableHeader.h"
 #include "PageDetail.h"
 #include "MacroDefinition.h"
@@ -12,6 +13,7 @@
 #include "DevicePrint.h"
 #include "DeviceInput.h"
 #include "DeviceNetwork.h"
+#include "DeviceCpu.h"
 #include "DDLog.h"
 #include "commonfunction.h"
 
@@ -33,10 +35,14 @@ DWIDGET_USE_NAMESPACE
 using namespace DDLog;
 
 #define LEAST_PAGE_HEIGHT 315  // PageMultiInfo最小高度 当小于这个高度时，上方的表格就要变小
+static constexpr int kHeaderInfoDefaultHeight = 362; // 滚动区域默认高度
 
 PageMultiInfo::PageMultiInfo(QWidget *parent)
     : PageInfo(parent)
     , mp_Label(new DLabel(this))
+    , mp_HeaderInfoWidget(new DScrollArea(this))
+    , mp_HeaderInfoContainer(new DWidget(mp_HeaderInfoWidget))
+    , mp_HeaderInfoWidgetLay(new QVBoxLayout(mp_HeaderInfoContainer))
     , mp_Table(new PageTableHeader(this))
     , mp_Detail(new PageDetail(this))
 {
@@ -62,6 +68,11 @@ PageMultiInfo::PageMultiInfo(QWidget *parent)
 PageMultiInfo::~PageMultiInfo()
 {
     // 清空指针
+    if (mp_HeaderInfoWidget) {
+        delete mp_HeaderInfoWidget;
+        mp_HeaderInfoWidget = nullptr;
+        mp_HeaderInfoContainer = nullptr;
+    }
     if (mp_Table) {
         delete mp_Table;
         mp_Table = nullptr;
@@ -81,6 +92,26 @@ void PageMultiInfo::updateInfo(const QList<DeviceBaseInfo *> &lst)
 
     if (lst.size() < 1)
         return;
+
+    // 当前为CPU页面，显示头部信息视图
+    DeviceCpu *cpuInfo = dynamic_cast<DeviceCpu *>(lst.at(0));
+    if (cpuInfo) {
+        QList<QList<QPair<QString, QString>>> headerInfo;
+        DeviceManager::instance()->getCpuHeaderInfo(headerInfo);
+        clearLayout(mp_HeaderInfoWidgetLay);
+        for (int i = 0; i < headerInfo.size(); ++i) {
+            HeaderInfoTableWidget *headerWidget = new HeaderInfoTableWidget(mp_HeaderInfoWidget);
+            headerWidget->updateData(headerInfo.at(i));
+            mp_HeaderInfoWidgetLay->addWidget(headerWidget);
+        }
+        mp_HeaderInfoWidget->setMaximumHeight(kHeaderInfoDefaultHeight);
+        mp_HeaderInfoWidget->resize(this->width(), kHeaderInfoDefaultHeight);
+        mp_HeaderInfoWidget->setVisible(true);
+    } else {
+        mp_HeaderInfoWidget->setVisible(false);
+        mp_HeaderInfoWidget->setMaximumHeight(0);
+    }
+
     m_deviceList.clear();
     m_menuControlList.clear();
 
@@ -242,23 +273,36 @@ void PageMultiInfo::slotCheckPrinterStatus(int row, bool &isPrinter, bool &isIns
 void PageMultiInfo::initWidgets()
 {
     // 初始化界面布局
-    QVBoxLayout *hLayout = new QVBoxLayout();
+    QVBoxLayout *vLayout = new QVBoxLayout();
     QHBoxLayout *labelLayout = new QHBoxLayout();
     labelLayout->addSpacing(10);
     labelLayout->addWidget(mp_Label);
 
     // Label 距离上下控件的距离LABEL_MARGIN
-    hLayout->addSpacing(LABEL_MARGIN);
-    hLayout->addLayout(labelLayout);
-    hLayout->addSpacing(LABEL_MARGIN);
+    vLayout->addSpacing(LABEL_MARGIN);
+    vLayout->addLayout(labelLayout);
+    vLayout->addSpacing(LABEL_MARGIN);
+
+    // 添加头部信息视图
+    mp_HeaderInfoWidget->setWidget(mp_HeaderInfoContainer);
+    mp_HeaderInfoWidget->setWidgetResizable(true);
+    mp_HeaderInfoWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    mp_HeaderInfoWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    mp_HeaderInfoWidget->setFrameShape(QFrame::NoFrame);
+    mp_HeaderInfoWidget->setMaximumHeight(kHeaderInfoDefaultHeight);
+    mp_HeaderInfoWidget->setMinimumHeight(0);
+    mp_HeaderInfoWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    mp_HeaderInfoWidgetLay->setContentsMargins(0, 0, 0, 0);
+    mp_HeaderInfoWidget->setVisible(false);
+    vLayout->addWidget(mp_HeaderInfoWidget, 1);  // stretch=1，允许随窗口缩放
 
     mp_Table->setFixedHeight(TABLE_HEIGHT);
 
-    hLayout->addWidget(mp_Table);
-    hLayout->addWidget(mp_Detail);
-    hLayout->setContentsMargins(10, 10, 10, 0);
+    vLayout->addWidget(mp_Table);
+    vLayout->addWidget(mp_Detail);
+    vLayout->setContentsMargins(10, 10, 10, 0);
 
-    setLayout(hLayout);
+    setLayout(vLayout);
 }
 
 void PageMultiInfo::getTableListInfo(const QList<DeviceBaseInfo *> &lst, QList<QStringList> &deviceList, QList<QStringList> &menuControlList)
@@ -293,5 +337,18 @@ void PageMultiInfo::getTableListInfo(const QList<DeviceBaseInfo *> &lst, QList<Q
         }
 
         menuControlList.append(menuControl);
+    }
+}
+
+void PageMultiInfo::clearLayout(QLayout *layout)
+{
+    QLayoutItem *item;
+    while ((item = layout->takeAt(0)) != nullptr) {
+        // 如果布局项包含控件，删除该控件
+        if (QWidget *widget = item->widget()) {
+            widget->deleteLater();   // 安全删除，避免事件冲突
+        }
+        // 删除布局项本身（注意：如果 item 是子布局，需递归处理，本例仅处理直接控件）
+        delete item;
     }
 }

--- a/deepin-devicemanager/src/Page/PageMultiInfo.h
+++ b/deepin-devicemanager/src/Page/PageMultiInfo.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,8 +6,11 @@
 #define DEVICEPAGE_H
 
 #include <QObject>
+#include <QVBoxLayout>
+
 #include <DWidget>
 #include <DLabel>
+#include <DScrollArea>
 
 #include "PageInfo.h"
 
@@ -122,8 +124,14 @@ private:
      */
     void getTableListInfo(const QList<DeviceBaseInfo *> &lst, QList<QStringList>& deviceList, QList<QStringList>& menuList);
 
+    // 清空布局中的所有 Widget
+    void clearLayout(QLayout *layout);
+
 private:
     DLabel                    *mp_Label;
+    DScrollArea               *mp_HeaderInfoWidget;
+    DWidget                   *mp_HeaderInfoContainer;
+    QVBoxLayout               *mp_HeaderInfoWidgetLay;
     PageTableHeader           *mp_Table;       //<! 上面的表格
     PageDetail                *mp_Detail;      //<! 下面的详细内容
     QList<DeviceBaseInfo *>   m_lstDevice;     //<! 保存设备列表


### PR DESCRIPTION
…tion

- Update PageMultiInfo to use scroll area container layout for CPU header detail widgets
- Add/adjust accessor usage for header info in CPU page
- Refactor scroll area content resizing and visibility behavior
- Update DeviceGenerator logic and declarations (internal feature updates)
- Keep UI behavior consistent with latest header info widget layout

Log: add feature for cpu info show.
Task: https://pms.uniontech.com/task-view-387697.html

## Summary by Sourcery

Add scrollable CPU header info display to the multi-info page and generate corresponding header data during CPU device creation.

New Features:
- Display CPU header information in the CPU device page using a scrollable header info widget populated from DeviceManager data
- Compute and expose aggregate CPU header information (model, vendor, architecture, cores/threads, cache totals) during CPU device generation

Enhancements:
- Refine PageMultiInfo layout to integrate a scroll area for header information and keep table/detail sections responsive to resizing