### PR TITLE
Feat: Add translate for cpu info.

### DIFF
--- a/deepin-devicemanager/translations/deepin-devicemanager.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager.ts
@@ -31,17 +31,17 @@
 <context>
     <name>CommonTools</name>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="99"/>
+        <location filename="../src/Tool/commontools.cpp" line="101"/>
         <source>EC_NOTIFY_NETWORK</source>
         <translation>EC_NOTIFY_NETWORK</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="100"/>
+        <location filename="../src/Tool/commontools.cpp" line="102"/>
         <source>EC_REINSTALL</source>
         <translation>EC_REINSTALL</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="101"/>
+        <location filename="../src/Tool/commontools.cpp" line="103"/>
         <source>EC_6</source>
         <translation>EC_6</translation>
     </message>
@@ -1504,13 +1504,13 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="200"/>
         <source>Processor</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="198"/>
         <source>Core(s)</source>
         <translation>Core(s)</translation>
     </message>
@@ -1851,6 +1851,54 @@
     </message>
 </context>
 <context>
+    <name>DeviceGenerator</name>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <source>Model Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <source>Vendor ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <source>Architecture</source>
+        <translation type="unfinished">Architecture</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
+        <source>Core(s)</source>
+        <translation type="unfinished">Core(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <source>Thread(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <source>L1d cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <source>L1i cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <source>L2 cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <source>L3 cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DeviceManager</name>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="142"/>
@@ -1994,8 +2042,8 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="562"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="565"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="573"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="576"/>
         <source>%1@%2Hz</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2187,7 +2235,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="310"/>
         <source>More</source>
         <translation>More</translation>
     </message>
@@ -2236,137 +2284,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="230"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="232"/>
         <source>Updating</source>
         <translation>Updating</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="124"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="184"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="104"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>Warning</source>
         <translation>Warning</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>The device will be unavailable after the driver uninstallation</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="126"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Uninstall</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="130"/>
         <source>Uninstalling</source>
         <translation>Uninstalling</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Update successful</source>
         <translation>Update successful</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Uninstallation successful</source>
         <translation>Uninstallation successful</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Update failed</source>
         <translation>Update failed</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Uninstallation failed</source>
         <translation>Uninstallation failed</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="163"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="164"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="182"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="203"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="204"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>The selected folder does not exist, please select again</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="208"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="210"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="242"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="244"/>
         <source>Broken package</source>
         <translation>Broken package</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="248"/>
         <source>Unmatched package architecture</source>
         <translation>Unmatched package architecture</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="251"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="253"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
         <source>The selected file does not exist, please select again</source>
         <translation>The selected file does not exist, please select again</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
         <source>It is not a driver</source>
         <translation>It is not a driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
         <source>Unable to install - no digital signature</source>
         <translation>Unable to install - no digital signature</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="330"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
         <source>Unknown error</source>
         <translation>Unknown error</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="331"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
         <source>The driver module was not found</source>
         <translation>The driver module was not found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
         <source>Invalid module format</source>
         <translation>Invalid module format</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
         <source>The driver module has dependencies</source>
         <translation>The driver module has dependencies</translation>
     </message>
@@ -2537,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Storage</source>
         <translation type="unfinished">Storage</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Memory</source>
         <translation type="unfinished">Memory</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Monitor</source>
         <translation type="unfinished">Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
         <source>Failed to enable the device</source>
         <translation>Failed to enable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
         <source>Failed to disable the device</source>
         <translation>Failed to disable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="184"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Failed to disable it: unable to get the device SN</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="206"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
         <source>Update Drivers</source>
         <translation>Update Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="224"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
         <source>Uninstall Drivers</source>
         <translation>Uninstall Drivers</translation>
     </message>
@@ -2880,7 +2928,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1598"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1626"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1662"/>
-        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="55"/>
         <source>Keyboard</source>
         <translation>Keyboard</translation>
     </message>
@@ -2897,7 +2945,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1627"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1663"/>
-        <location filename="../src/Tool/commontools.cpp" line="55"/>
+        <location filename="../src/Tool/commontools.cpp" line="57"/>
         <source>Mouse</source>
         <translation>Mouse</translation>
     </message>
@@ -2914,7 +2962,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1600"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1664"/>
-        <location filename="../src/Tool/commontools.cpp" line="57"/>
+        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <source>Printer</source>
         <translation>Printer</translation>
     </message>
@@ -2963,8 +3011,8 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1603"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1667"/>
-        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <location filename="../src/Tool/commontools.cpp" line="61"/>
+        <location filename="../src/Tool/commontools.cpp" line="63"/>
         <source>Other Devices</source>
         <translation>Other Devices</translation>
     </message>
@@ -2977,7 +3025,7 @@
         <translation>No other devices found</translation>
     </message>
     <message>
-        <location filename="../src/Tool/EDIDParser.cpp" line="221"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="215"/>
         <source>inch</source>
         <translation>inch</translation>
     </message>
@@ -2993,12 +3041,12 @@
         <translation>Device Manager is a handy tool for viewing hardware information and managing the devices.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
+        <location filename="../src/main.cpp" line="170"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>New drivers available! Install or update them now.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="169"/>
+        <location filename="../src/main.cpp" line="171"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3251,113 +3299,113 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="50"/>
+        <location filename="../src/Tool/commontools.cpp" line="52"/>
         <source>Bluetooth adapter</source>
         <translation>Bluetooth adapter</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="51"/>
-        <location filename="../src/Tool/commontools.cpp" line="58"/>
+        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="60"/>
         <source>Imaging device</source>
         <translation>Imaging device</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="52"/>
+        <location filename="../src/Tool/commontools.cpp" line="54"/>
         <source>Display adapter</source>
         <translation>Display adapter</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="54"/>
+        <location filename="../src/Tool/commontools.cpp" line="56"/>
         <source>Sound card</source>
         <translation>Sound card</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="56"/>
+        <location filename="../src/Tool/commontools.cpp" line="58"/>
         <source>Network adapter</source>
         <translation>Network adapter</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="60"/>
+        <location filename="../src/Tool/commontools.cpp" line="62"/>
         <source>Wireless network adapter</source>
         <translation>Wireless network adapter</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="80"/>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Installation successful</source>
         <translation>Installation successful</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Installation failed</source>
         <translation>Installation failed</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Downloading</source>
         <translation>Downloading</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>Installing</source>
         <translation>Installing</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>Not installed</source>
         <translation>Not installed</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>Out-of-date</source>
         <translation>Out-of-date</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <location filename="../src/Tool/commontools.cpp" line="88"/>
         <source>Waiting</source>
         <translation>Waiting</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <location filename="../src/Tool/commontools.cpp" line="89"/>
         <source>Not backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="88"/>
+        <location filename="../src/Tool/commontools.cpp" line="90"/>
         <source>Backing up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="89"/>
+        <location filename="../src/Tool/commontools.cpp" line="91"/>
         <source>Backup failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="90"/>
+        <location filename="../src/Tool/commontools.cpp" line="92"/>
         <source>Backup successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="91"/>
+        <location filename="../src/Tool/commontools.cpp" line="93"/>
         <source>Restoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="95"/>
+        <location filename="../src/Tool/commontools.cpp" line="97"/>
         <source>Unknown error</source>
         <translation>Unknown error</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="96"/>
+        <location filename="../src/Tool/commontools.cpp" line="98"/>
         <source>Network error</source>
         <translation>Network error</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="97"/>
+        <location filename="../src/Tool/commontools.cpp" line="99"/>
         <source>Canceled</source>
         <translation>Canceled</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="98"/>
+        <location filename="../src/Tool/commontools.cpp" line="100"/>
         <source>Failed to get driver files</source>
         <translation>Failed to get driver files</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
@@ -31,17 +31,17 @@
 <context>
     <name>CommonTools</name>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="99"/>
+        <location filename="../src/Tool/commontools.cpp" line="101"/>
         <source>EC_NOTIFY_NETWORK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="100"/>
+        <location filename="../src/Tool/commontools.cpp" line="102"/>
         <source>EC_REINSTALL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="101"/>
+        <location filename="../src/Tool/commontools.cpp" line="103"/>
         <source>EC_6</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1504,13 +1504,13 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="200"/>
         <source>Processor</source>
         <translation>གཏན་ཚིགས་ཐག་གཅོད་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="198"/>
         <source>Core(s)</source>
         <translation>ལྟེ་བ།</translation>
     </message>
@@ -1852,6 +1852,54 @@
     </message>
 </context>
 <context>
+    <name>DeviceGenerator</name>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <source>Model Name</source>
+        <translation>མིང་།</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <source>Vendor ID</source>
+        <translation>བཟོ་བྱེད་མཁན།</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <source>Architecture</source>
+        <translation>གཞི་སྒྲོམ།</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
+        <source>Core(s)</source>
+        <translation>རིག་རྟགས་འཕྲུལ་འཁོར།</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <source>Thread(s)</source>
+        <translation>སྙིང་རྫས་རེའི་ཐིག་སྒྲོན་གྲངས།</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <source>L1d cache</source>
+        <translation>L1 གཏོགས་ཁང་ (གཞི་གྲངས)</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <source>L1i cache</source>
+        <translation>L1 གཏོགས་ཁང་ (བཀའ་རིན)</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <source>L2 cache</source>
+        <translation>L2 གཏོགས་ཁང་</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <source>L3 cache</source>
+        <translation>L3 གཏོགས་ཁང་</translation>
+    </message>
+</context>
+<context>
     <name>DeviceManager</name>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="142"/>
@@ -1995,8 +2043,8 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="562"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="565"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="573"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="576"/>
         <source>%1@%2Hz</source>
         <translation>%1@%2Hz</translation>
     </message>
@@ -2188,7 +2236,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="310"/>
         <source>More</source>
         <translation>དེ་བས་མང་།</translation>
     </message>
@@ -2237,137 +2285,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="230"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="232"/>
         <source>Updating</source>
         <translation>གསར་སྒྱུར་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="124"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="184"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="104"/>
         <source>Next</source>
         <translation>རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>Warning</source>
         <translation>དོ་སྣང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>མ་ལག་ཁྲོད་ནས་སྐུལ་བྱེད་བྱ་རིམ་འདི་བཤིག་རྒྱུ། བཤིག་རྗེས་སྒྲིག་ཆས་འདི་སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="126"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>བཤིག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="130"/>
         <source>Uninstalling</source>
         <translation>བཤིག་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Update successful</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Uninstallation successful</source>
         <translation>སྐུལ་བྱེད་བཤིག་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Update failed</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར་ཐུབ་མ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Uninstallation failed</source>
         <translation>སྐུལ་བྱེད་བཤིག་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="163"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="164"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="182"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="203"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="204"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>བདམས་པའི་ཡིག་ཁུག་མི་འདུག་པས། ཡང་བསྐྱར་འདེམས་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="208"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>གསར་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="210"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>སྔ་མ་དེ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="242"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="244"/>
         <source>Broken package</source>
         <translation>ཁུག་མའི་ཡིག་ཆ་འཕྲོ་བརླག་ཕྱིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="248"/>
         <source>Unmatched package architecture</source>
         <translation>ཁུག་མའི་ཡིག་ཆ་དང་རྒྱུད་ཁོངས་ཀྱི་སྒྲོམ་གཞི་མི་མཐུན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="251"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="253"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
         <source>The selected file does not exist, please select again</source>
         <translation>བདམས་པའི་ཡིག་ཆ་མི་འདུག་པས། ཡང་བསྐྱར་འདེམས་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
         <source>It is not a driver</source>
         <translation>ཡིག་ཆ་འདི་ནི་སྐུལ་བྱེད་ཡིག་ཆ་མ་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
         <source>Unable to install - no digital signature</source>
         <translation>སྒྲིག་སྦྱོར་བྱེད་ཐབས་མེད། སྒྲིག་སྦྱོར་ཐུམ་ལ་ཨང་ཀིའི་མཚན་རྟགས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="330"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
         <source>Unknown error</source>
         <translation>མ་ཤེས་པའི་ནོར་འཁྲུལ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="331"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
         <source>The driver module was not found</source>
         <translation>སྒུལ་བྱེད་མ་དཔེ་དེ་ཉིད་མ་རྙེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
         <source>Invalid module format</source>
         <translation>དཔེ་དུམ་རྣམ་གཞག་གོ་མི་ཆོད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
         <source>The driver module has dependencies</source>
         <translation>སྒུལ་བྱེད་མ་དཔེ་དེ་ཉིད་གཞན་གྱིས་བརྟེན་འདུག</translation>
     </message>
@@ -2538,48 +2586,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Storage</source>
         <translation>གསོག་འཇོག་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Memory</source>
         <translation>ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Monitor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
         <source>Failed to enable the device</source>
         <translation>འགོ་སློང་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
         <source>Failed to disable the device</source>
         <translation>སྤྱོད་མི་ཆོག་པ་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="184"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>སྒྲིག་ཆས་ཀྱི་རིམ་ཨང་ཐོབ་ཐབས་མི་འདུག་པས་སྤྱོད་མི་རུང་བ་ཐུབ་མ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="206"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
         <source>Update Drivers</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="224"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
         <source>Uninstall Drivers</source>
         <translation>སྐུལ་བྱེད་བཤིག་པ།</translation>
     </message>
@@ -2881,7 +2929,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1598"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1626"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1662"/>
-        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="55"/>
         <source>Keyboard</source>
         <translation>མཐེབ་གཞོང་།</translation>
     </message>
@@ -2898,7 +2946,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1627"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1663"/>
-        <location filename="../src/Tool/commontools.cpp" line="55"/>
+        <location filename="../src/Tool/commontools.cpp" line="57"/>
         <source>Mouse</source>
         <translation>ཙི་གུ།</translation>
     </message>
@@ -2915,7 +2963,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1600"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1664"/>
-        <location filename="../src/Tool/commontools.cpp" line="57"/>
+        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <source>Printer</source>
         <translation>པར་འདེབས་ཆས།</translation>
     </message>
@@ -2964,8 +3012,8 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1603"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1667"/>
-        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <location filename="../src/Tool/commontools.cpp" line="61"/>
+        <location filename="../src/Tool/commontools.cpp" line="63"/>
         <source>Other Devices</source>
         <translation>སྒྲིག་ཆས་གཞན་དག</translation>
     </message>
@@ -2978,7 +3026,7 @@
         <translation>སྒྲིག་ཆས་གཞན་དག་རྙེད་མ་བྱུང་།</translation>
     </message>
     <message>
-        <location filename="../src/Tool/EDIDParser.cpp" line="221"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="215"/>
         <source>inch</source>
         <translation>དབྱིན་ཚུན།</translation>
     </message>
@@ -2994,12 +3042,12 @@
         <translation>སྒྲིག་ཆས་དོ་དམ་ཆས་ནི་མཁྲེགས་ཆས་ལྟ་བ་དང་དོ་དམ་བྱེད་པའི་ཡོ་བྱད་ཅིག་རེད།.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
+        <location filename="../src/main.cpp" line="170"/>
         <source>New drivers available! Install or update them now.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="169"/>
+        <location filename="../src/main.cpp" line="171"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3252,113 +3300,113 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="50"/>
+        <location filename="../src/Tool/commontools.cpp" line="52"/>
         <source>Bluetooth adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="51"/>
-        <location filename="../src/Tool/commontools.cpp" line="58"/>
+        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="60"/>
         <source>Imaging device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="52"/>
+        <location filename="../src/Tool/commontools.cpp" line="54"/>
         <source>Display adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="54"/>
+        <location filename="../src/Tool/commontools.cpp" line="56"/>
         <source>Sound card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="56"/>
+        <location filename="../src/Tool/commontools.cpp" line="58"/>
         <source>Network adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="60"/>
+        <location filename="../src/Tool/commontools.cpp" line="62"/>
         <source>Wireless network adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="80"/>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Installation successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Installation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>Installing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>Not installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>Out-of-date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <location filename="../src/Tool/commontools.cpp" line="88"/>
         <source>Waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <location filename="../src/Tool/commontools.cpp" line="89"/>
         <source>Not backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="88"/>
+        <location filename="../src/Tool/commontools.cpp" line="90"/>
         <source>Backing up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="89"/>
+        <location filename="../src/Tool/commontools.cpp" line="91"/>
         <source>Backup failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="90"/>
+        <location filename="../src/Tool/commontools.cpp" line="92"/>
         <source>Backup successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="91"/>
+        <location filename="../src/Tool/commontools.cpp" line="93"/>
         <source>Restoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="95"/>
+        <location filename="../src/Tool/commontools.cpp" line="97"/>
         <source>Unknown error</source>
         <translation>མ་ཤེས་པའི་ནོར་འཁྲུལ།</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="96"/>
+        <location filename="../src/Tool/commontools.cpp" line="98"/>
         <source>Network error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="97"/>
+        <location filename="../src/Tool/commontools.cpp" line="99"/>
         <source>Canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="98"/>
+        <location filename="../src/Tool/commontools.cpp" line="100"/>
         <source>Failed to get driver files</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
@@ -31,17 +31,17 @@
 <context>
     <name>CommonTools</name>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="99"/>
+        <location filename="../src/Tool/commontools.cpp" line="101"/>
         <source>EC_NOTIFY_NETWORK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="100"/>
+        <location filename="../src/Tool/commontools.cpp" line="102"/>
         <source>EC_REINSTALL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="101"/>
+        <location filename="../src/Tool/commontools.cpp" line="103"/>
         <source>EC_6</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1504,13 +1504,13 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="200"/>
         <source>Processor</source>
         <translation>بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="198"/>
         <source>Core(s)</source>
         <translation>يادرو</translation>
     </message>
@@ -1851,6 +1851,54 @@
     </message>
 </context>
 <context>
+    <name>DeviceGenerator</name>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <source>Model Name</source>
+        <translation>نامى</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <source>Vendor ID</source>
+        <translation>ئىشلەپچىقارغۇچى</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <source>Architecture</source>
+        <translation>قۇرۇلما</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
+        <source>Core(s)</source>
+        <translation>مەنتىقىي پىروتسېسسور</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <source>Thread(s)</source>
+        <translation>ھەر يادرو خېتى سانى</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <source>L1d cache</source>
+        <translation>كېش (سانلىق) L1</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <source>L1i cache</source>
+        <translation>كېش (بۇيرۇق) L1</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <source>L2 cache</source>
+        <translation>كېش L2</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <source>L3 cache</source>
+        <translation>كېش L3</translation>
+    </message>
+</context>
+<context>
     <name>DeviceManager</name>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="142"/>
@@ -1994,8 +2042,8 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="562"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="565"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="573"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="576"/>
         <source>%1@%2Hz</source>
         <translation>%1@%2Hz</translation>
     </message>
@@ -2187,7 +2235,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="310"/>
         <source>More</source>
         <translation>تېخىمۇ كۆپ</translation>
     </message>
@@ -2236,137 +2284,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="230"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="232"/>
         <source>Updating</source>
         <translation>يېڭىلاۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="124"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="184"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="104"/>
         <source>Next</source>
         <translation>كىينكى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>Warning</source>
         <translation>دىققەت</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>قوزغاتقۇچ ئۆچۈرۈلگەندىن كىيىن،بۇ ئۈسكىنىنى ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="126"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>چىقىرۋىتىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="130"/>
         <source>Uninstalling</source>
         <translation>ئۆچۈرۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Update successful</source>
         <translation>قوزغاتقۇچ يېڭىلاش تامام</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Uninstallation successful</source>
         <translation>قوزغاتقۇچ ئوڭۇشلۇق ئۆچۈرۈلدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Update failed</source>
         <translation>يېڭىلاش مۇۋەپپەقىيەتسىز بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Uninstallation failed</source>
         <translation>قوزغاتقۇچنى ئۆچۈرەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="163"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="164"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>جەزىملەش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="182"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>كىينكى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="203"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="204"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>ھۆججەت قىسقۇچ مەۋجۇت ئەمەس،قايتا تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="208"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="210"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>كىينكى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="242"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="244"/>
         <source>Broken package</source>
         <translation>بولاق بۇزۇلغان</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="248"/>
         <source>Unmatched package architecture</source>
         <translation>ماس كەلمەيدىغان قۇرۇلما</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="251"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="253"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
         <source>The selected file does not exist, please select again</source>
         <translation>ھۆججەت مەۋجۇت ئەمەس،قايتا تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
         <source>It is not a driver</source>
         <translation>بۇ قوزغىتىش ھۆججىتى ئەمەس</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
         <source>Unable to install - no digital signature</source>
         <translation>قاچىلانمىدى، قاچىلاش بولىقىدا رەقەملىك ئىمزا يوقكەن</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="330"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
         <source>Unknown error</source>
         <translation>نامەلۇم خاتالىق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="331"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
         <source>The driver module was not found</source>
         <translation>بۇ قوزغاتقۇچ مودېلى تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
         <source>Invalid module format</source>
         <translation>مودۇل فورماتى ئۈنۈمسىز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
         <source>The driver module has dependencies</source>
         <translation>بۇ قوزغاتقۇچ مودېلى ئىشلىتىلگەن</translation>
     </message>
@@ -2537,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Storage</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Memory</source>
         <translation>ساقلىغۇ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Monitor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
         <source>Failed to enable the device</source>
         <translation>ئۈسكۈنىنى قوزغىتىش مەغلۇب بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
         <source>Failed to disable the device</source>
         <translation>ئۈسكۈنىنى چەكلىيەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="184"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>ئۈسكۈنە تەرتىپ نومۇرىنى ئئالالمىدى، چەكلەش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="206"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
         <source>Update Drivers</source>
         <translation>يېڭىلاش دىرىۋېرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="224"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
         <source>Uninstall Drivers</source>
         <translation>قوزغاتقۇچنى چىقىرۋىتىش</translation>
     </message>
@@ -2880,7 +2928,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1598"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1626"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1662"/>
-        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="55"/>
         <source>Keyboard</source>
         <translation>كۇنۇپكا تاختىسى</translation>
     </message>
@@ -2897,7 +2945,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1627"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1663"/>
-        <location filename="../src/Tool/commontools.cpp" line="55"/>
+        <location filename="../src/Tool/commontools.cpp" line="57"/>
         <source>Mouse</source>
         <translation>چاشقىنەك</translation>
     </message>
@@ -2914,7 +2962,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1600"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1664"/>
-        <location filename="../src/Tool/commontools.cpp" line="57"/>
+        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <source>Printer</source>
         <translation>پىرىنتېر</translation>
     </message>
@@ -2963,8 +3011,8 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1603"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1667"/>
-        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <location filename="../src/Tool/commontools.cpp" line="61"/>
+        <location filename="../src/Tool/commontools.cpp" line="63"/>
         <source>Other Devices</source>
         <translation>باشقا ئۈسكۈنىلەر</translation>
     </message>
@@ -2977,7 +3025,7 @@
         <translation>باشقا ئۈسكۈنىلەر تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Tool/EDIDParser.cpp" line="221"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="215"/>
         <source>inch</source>
         <translation>ئىنگىلىزچىسى</translation>
     </message>
@@ -2993,12 +3041,12 @@
         <translation>ئۈسكۈنە باشقۇرغۇچى قاتتىق دېتال ئۇچۇرلىرىنى كۆرۈش ۋە ئۈسكۈنىلەرنى باشقۇرۇشتىكى قۇلايلىق قورال.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
+        <location filename="../src/main.cpp" line="170"/>
         <source>New drivers available! Install or update them now.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="169"/>
+        <location filename="../src/main.cpp" line="171"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3251,113 +3299,113 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="50"/>
+        <location filename="../src/Tool/commontools.cpp" line="52"/>
         <source>Bluetooth adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="51"/>
-        <location filename="../src/Tool/commontools.cpp" line="58"/>
+        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="60"/>
         <source>Imaging device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="52"/>
+        <location filename="../src/Tool/commontools.cpp" line="54"/>
         <source>Display adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="54"/>
+        <location filename="../src/Tool/commontools.cpp" line="56"/>
         <source>Sound card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="56"/>
+        <location filename="../src/Tool/commontools.cpp" line="58"/>
         <source>Network adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="60"/>
+        <location filename="../src/Tool/commontools.cpp" line="62"/>
         <source>Wireless network adapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="80"/>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Installation successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Installation failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>Installing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>Not installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>Out-of-date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <location filename="../src/Tool/commontools.cpp" line="88"/>
         <source>Waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <location filename="../src/Tool/commontools.cpp" line="89"/>
         <source>Not backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="88"/>
+        <location filename="../src/Tool/commontools.cpp" line="90"/>
         <source>Backing up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="89"/>
+        <location filename="../src/Tool/commontools.cpp" line="91"/>
         <source>Backup failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="90"/>
+        <location filename="../src/Tool/commontools.cpp" line="92"/>
         <source>Backup successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="91"/>
+        <location filename="../src/Tool/commontools.cpp" line="93"/>
         <source>Restoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="95"/>
+        <location filename="../src/Tool/commontools.cpp" line="97"/>
         <source>Unknown error</source>
         <translation>نامەلۇم خاتالىق</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="96"/>
+        <location filename="../src/Tool/commontools.cpp" line="98"/>
         <source>Network error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="97"/>
+        <location filename="../src/Tool/commontools.cpp" line="99"/>
         <source>Canceled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="98"/>
+        <location filename="../src/Tool/commontools.cpp" line="100"/>
         <source>Failed to get driver files</source>
         <translation type="unfinished"></translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
@@ -31,17 +31,17 @@
 <context>
     <name>CommonTools</name>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="99"/>
+        <location filename="../src/Tool/commontools.cpp" line="101"/>
         <source>EC_NOTIFY_NETWORK</source>
         <translation>EC_NOTIFY_NETWORK</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="100"/>
+        <location filename="../src/Tool/commontools.cpp" line="102"/>
         <source>EC_REINSTALL</source>
         <translation>EC_REINSTALL</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="101"/>
+        <location filename="../src/Tool/commontools.cpp" line="103"/>
         <source>EC_6</source>
         <translation>EC_6</translation>
     </message>
@@ -1504,13 +1504,13 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="200"/>
         <source>Processor</source>
         <translation>逻辑处理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="198"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
@@ -1851,6 +1851,54 @@
     </message>
 </context>
 <context>
+    <name>DeviceGenerator</name>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <source>Model Name</source>
+        <translation>名称</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <source>Vendor ID</source>
+        <translation>制造商</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <source>Architecture</source>
+        <translation>架构</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
+        <source>Core(s)</source>
+        <translation>逻辑处理器</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <source>Thread(s)</source>
+        <translation>每核线程数</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <source>L1d cache</source>
+        <translation>L1缓存（数据）</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <source>L1i cache</source>
+        <translation>L1缓存（指令）</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <source>L2 cache</source>
+        <translation>L2缓存</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <source>L3 cache</source>
+        <translation>L3缓存</translation>
+    </message>
+</context>
+<context>
     <name>DeviceManager</name>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="142"/>
@@ -1994,8 +2042,8 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="562"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="565"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="573"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="576"/>
         <source>%1@%2Hz</source>
         <translation>%1@%2Hz</translation>
     </message>
@@ -2187,7 +2235,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="310"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
@@ -2236,137 +2284,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="230"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="232"/>
         <source>Updating</source>
         <translation>正在更新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="124"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="184"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="104"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>Warning</source>
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>将从系统中卸载此驱动程序，卸载后该设备不可用</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="126"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>卸 载</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="130"/>
         <source>Uninstalling</source>
         <translation>正在卸载</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Update successful</source>
         <translation>驱动更新成功</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Uninstallation successful</source>
         <translation>驱动卸载成功</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Update failed</source>
         <translation>驱动更新失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Uninstallation failed</source>
         <translation>驱动卸载失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="163"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="164"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="182"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="203"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="204"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>所选文件夹不存在，请重新选择</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="208"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="210"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>上一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="242"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="244"/>
         <source>Broken package</source>
         <translation>包文件损坏</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="248"/>
         <source>Unmatched package architecture</source>
         <translation>包文件与系统架构不匹配</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="251"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="253"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
         <source>The selected file does not exist, please select again</source>
         <translation>所选文件不存在，请重新选择</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
         <source>It is not a driver</source>
         <translation>该文件不是驱动文件</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
         <source>Unable to install - no digital signature</source>
         <translation>无法安装，安装包无数字签名</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="330"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
         <source>Unknown error</source>
         <translation>未知错误</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="331"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
         <source>The driver module was not found</source>
         <translation>未发现该驱动模块</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
         <source>Invalid module format</source>
         <translation>模块格式无效</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
         <source>The driver module has dependencies</source>
         <translation>驱动模块被依赖</translation>
     </message>
@@ -2537,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Storage</source>
         <translation>存储设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Monitor</source>
         <translation>显示设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
         <source>Failed to enable the device</source>
         <translation>启用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
         <source>Failed to disable the device</source>
         <translation>禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="184"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>无法获取设备序列号，禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="206"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
         <source>Update Drivers</source>
         <translation>更新驱动</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="224"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
         <source>Uninstall Drivers</source>
         <translation>卸载驱动</translation>
     </message>
@@ -2880,7 +2928,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1598"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1626"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1662"/>
-        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="55"/>
         <source>Keyboard</source>
         <translation>键盘</translation>
     </message>
@@ -2897,7 +2945,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1627"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1663"/>
-        <location filename="../src/Tool/commontools.cpp" line="55"/>
+        <location filename="../src/Tool/commontools.cpp" line="57"/>
         <source>Mouse</source>
         <translation>鼠标</translation>
     </message>
@@ -2914,7 +2962,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1600"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1664"/>
-        <location filename="../src/Tool/commontools.cpp" line="57"/>
+        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <source>Printer</source>
         <translation>打印机</translation>
     </message>
@@ -2963,8 +3011,8 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1603"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1667"/>
-        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <location filename="../src/Tool/commontools.cpp" line="61"/>
+        <location filename="../src/Tool/commontools.cpp" line="63"/>
         <source>Other Devices</source>
         <translation>其他设备</translation>
     </message>
@@ -2988,12 +3036,12 @@
         <translation>设备管理器是查看、管理硬件设备的工具软件。</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
+        <location filename="../src/main.cpp" line="170"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>您有驱动可进行安装/更新</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="169"/>
+        <location filename="../src/main.cpp" line="171"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
@@ -3246,113 +3294,113 @@
         <translation>当前正在还原驱动，退出应用后任务将会中断</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="50"/>
+        <location filename="../src/Tool/commontools.cpp" line="52"/>
         <source>Bluetooth adapter</source>
         <translation>蓝牙适配器</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="51"/>
-        <location filename="../src/Tool/commontools.cpp" line="58"/>
+        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="60"/>
         <source>Imaging device</source>
         <translation>图像设备</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="52"/>
+        <location filename="../src/Tool/commontools.cpp" line="54"/>
         <source>Display adapter</source>
         <translation>显卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="54"/>
+        <location filename="../src/Tool/commontools.cpp" line="56"/>
         <source>Sound card</source>
         <translation>声卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="56"/>
+        <location filename="../src/Tool/commontools.cpp" line="58"/>
         <source>Network adapter</source>
         <translation>网卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="60"/>
+        <location filename="../src/Tool/commontools.cpp" line="62"/>
         <source>Wireless network adapter</source>
         <translation>无线网卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="80"/>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Installation successful</source>
         <translation>安装成功</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Installation failed</source>
         <translation>安装失败</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Downloading</source>
         <translation>下载中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>Installing</source>
         <translation>安装中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>Not installed</source>
         <translation>驱动未安装</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>Out-of-date</source>
         <translation>驱动可更新</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <location filename="../src/Tool/commontools.cpp" line="88"/>
         <source>Waiting</source>
         <translation>等待中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <location filename="../src/Tool/commontools.cpp" line="89"/>
         <source>Not backed up</source>
         <translation>驱动未备份</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="88"/>
+        <location filename="../src/Tool/commontools.cpp" line="90"/>
         <source>Backing up</source>
         <translation>正在备份</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="89"/>
+        <location filename="../src/Tool/commontools.cpp" line="91"/>
         <source>Backup failed</source>
         <translation>备份失败</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="90"/>
+        <location filename="../src/Tool/commontools.cpp" line="92"/>
         <source>Backup successful</source>
         <translation>备份成功</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="91"/>
+        <location filename="../src/Tool/commontools.cpp" line="93"/>
         <source>Restoring</source>
         <translation>还原中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="95"/>
+        <location filename="../src/Tool/commontools.cpp" line="97"/>
         <source>Unknown error</source>
         <translation>未知错误</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="96"/>
+        <location filename="../src/Tool/commontools.cpp" line="98"/>
         <source>Network error</source>
         <translation>网络异常</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="97"/>
+        <location filename="../src/Tool/commontools.cpp" line="99"/>
         <source>Canceled</source>
         <translation>已取消</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="98"/>
+        <location filename="../src/Tool/commontools.cpp" line="100"/>
         <source>Failed to get driver files</source>
         <translation>驱动文件获取异常</translation>
     </message>
@@ -3377,7 +3425,7 @@
         <translation>安装</translation>
     </message>
     <message>
-        <location filename="../src/Tool/EDIDParser.cpp" line="221"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="215"/>
         <source>inch</source>
         <translation>英寸</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
@@ -31,17 +31,17 @@
 <context>
     <name>CommonTools</name>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="99"/>
+        <location filename="../src/Tool/commontools.cpp" line="101"/>
         <source>EC_NOTIFY_NETWORK</source>
         <translation>EC_NOTIFY_NETWORK</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="100"/>
+        <location filename="../src/Tool/commontools.cpp" line="102"/>
         <source>EC_REINSTALL</source>
         <translation>EC_REINSTALL</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="101"/>
+        <location filename="../src/Tool/commontools.cpp" line="103"/>
         <source>EC_6</source>
         <translation>EC_6</translation>
     </message>
@@ -1504,13 +1504,13 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="200"/>
         <source>Processor</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="198"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
@@ -1851,6 +1851,54 @@
     </message>
 </context>
 <context>
+    <name>DeviceGenerator</name>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <source>Model Name</source>
+        <translation>名稱</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <source>Vendor ID</source>
+        <translation>製造商</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <source>Architecture</source>
+        <translation>架構</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
+        <source>Core(s)</source>
+        <translation>邏輯處理器</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <source>Thread(s)</source>
+        <translation>每核心線程數</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <source>L1d cache</source>
+        <translation>一級緩存（數據）</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <source>L1i cache</source>
+        <translation>一級緩存（指令）</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <source>L2 cache</source>
+        <translation>二級緩存</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <source>L3 cache</source>
+        <translation>三級緩存</translation>
+    </message>
+</context>
+<context>
     <name>DeviceManager</name>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="142"/>
@@ -1994,8 +2042,8 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="562"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="565"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="573"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="576"/>
         <source>%1@%2Hz</source>
         <translation>%1@%2Hz</translation>
     </message>
@@ -2187,7 +2235,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="310"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
@@ -2236,137 +2284,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="230"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="232"/>
         <source>Updating</source>
         <translation>正在更新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="124"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="184"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="104"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>Warning</source>
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>將從系統中卸載此驅動程序，卸載後該設備不可用</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="126"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>卸 載</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="130"/>
         <source>Uninstalling</source>
         <translation>正在卸載</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Update successful</source>
         <translation>驅動更新成功</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Uninstallation successful</source>
         <translation>驅動卸載成功</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Update failed</source>
         <translation>驅動更新失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Uninstallation failed</source>
         <translation>驅動卸載失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="163"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="164"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="182"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="203"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="204"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>所選文件夾不存在，請重新選擇</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="208"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="210"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>上一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="242"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="244"/>
         <source>Broken package</source>
         <translation>包文件損壞</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="248"/>
         <source>Unmatched package architecture</source>
         <translation>包文件與系統架構不匹配</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="251"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="253"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
         <source>The selected file does not exist, please select again</source>
         <translation>所選文件不存在，請重新選擇</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
         <source>It is not a driver</source>
         <translation>該文件不是驅動文件</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
         <source>Unable to install - no digital signature</source>
         <translation>無法安裝，安裝包無數字簽名</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="330"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
         <source>Unknown error</source>
         <translation>未知錯誤</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="331"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
         <source>The driver module was not found</source>
         <translation>未發現該驅動模塊</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
         <source>Invalid module format</source>
         <translation>模塊格式無效</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
         <source>The driver module has dependencies</source>
         <translation>驅動模塊被依賴</translation>
     </message>
@@ -2537,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Storage</source>
         <translation>存儲設備</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Memory</source>
         <translation>內存</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Monitor</source>
         <translation>顯示設備</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
         <source>Failed to enable the device</source>
         <translation>啟用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
         <source>Failed to disable the device</source>
         <translation>禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="184"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>無法獲取設備序列號，禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="206"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
         <source>Update Drivers</source>
         <translation>更新驅動</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="224"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
         <source>Uninstall Drivers</source>
         <translation>卸載驅動</translation>
     </message>
@@ -2880,7 +2928,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1598"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1626"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1662"/>
-        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="55"/>
         <source>Keyboard</source>
         <translation>鍵盤</translation>
     </message>
@@ -2897,7 +2945,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1627"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1663"/>
-        <location filename="../src/Tool/commontools.cpp" line="55"/>
+        <location filename="../src/Tool/commontools.cpp" line="57"/>
         <source>Mouse</source>
         <translation>鼠標</translation>
     </message>
@@ -2914,7 +2962,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1600"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1664"/>
-        <location filename="../src/Tool/commontools.cpp" line="57"/>
+        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <source>Printer</source>
         <translation>打印機</translation>
     </message>
@@ -2963,8 +3011,8 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1603"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1667"/>
-        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <location filename="../src/Tool/commontools.cpp" line="61"/>
+        <location filename="../src/Tool/commontools.cpp" line="63"/>
         <source>Other Devices</source>
         <translation>其他設備</translation>
     </message>
@@ -2977,7 +3025,7 @@
         <translation>未發現其他設備</translation>
     </message>
     <message>
-        <location filename="../src/Tool/EDIDParser.cpp" line="221"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="215"/>
         <source>inch</source>
         <translation>英吋</translation>
     </message>
@@ -2993,12 +3041,12 @@
         <translation>設備管理器是查看、管理硬件設備的工具軟件。</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
+        <location filename="../src/main.cpp" line="170"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>您有驅動可進行安裝/更新。</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="169"/>
+        <location filename="../src/main.cpp" line="171"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3251,113 +3299,113 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="50"/>
+        <location filename="../src/Tool/commontools.cpp" line="52"/>
         <source>Bluetooth adapter</source>
         <translation>藍牙適配器</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="51"/>
-        <location filename="../src/Tool/commontools.cpp" line="58"/>
+        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="60"/>
         <source>Imaging device</source>
         <translation>圖像設備</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="52"/>
+        <location filename="../src/Tool/commontools.cpp" line="54"/>
         <source>Display adapter</source>
         <translation>顯卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="54"/>
+        <location filename="../src/Tool/commontools.cpp" line="56"/>
         <source>Sound card</source>
         <translation>聲卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="56"/>
+        <location filename="../src/Tool/commontools.cpp" line="58"/>
         <source>Network adapter</source>
         <translation>網卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="60"/>
+        <location filename="../src/Tool/commontools.cpp" line="62"/>
         <source>Wireless network adapter</source>
         <translation>無線網卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="80"/>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Installation successful</source>
         <translation>安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Installation failed</source>
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Downloading</source>
         <translation>下載中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>Installing</source>
         <translation>安裝中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>Not installed</source>
         <translation>驅動未安裝</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>Out-of-date</source>
         <translation>驅動可更新</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <location filename="../src/Tool/commontools.cpp" line="88"/>
         <source>Waiting</source>
         <translation>等待中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <location filename="../src/Tool/commontools.cpp" line="89"/>
         <source>Not backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="88"/>
+        <location filename="../src/Tool/commontools.cpp" line="90"/>
         <source>Backing up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="89"/>
+        <location filename="../src/Tool/commontools.cpp" line="91"/>
         <source>Backup failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="90"/>
+        <location filename="../src/Tool/commontools.cpp" line="92"/>
         <source>Backup successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="91"/>
+        <location filename="../src/Tool/commontools.cpp" line="93"/>
         <source>Restoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="95"/>
+        <location filename="../src/Tool/commontools.cpp" line="97"/>
         <source>Unknown error</source>
         <translation>未知錯誤</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="96"/>
+        <location filename="../src/Tool/commontools.cpp" line="98"/>
         <source>Network error</source>
         <translation>網絡異常</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="97"/>
+        <location filename="../src/Tool/commontools.cpp" line="99"/>
         <source>Canceled</source>
         <translation>已取消</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="98"/>
+        <location filename="../src/Tool/commontools.cpp" line="100"/>
         <source>Failed to get driver files</source>
         <translation>驅動文件獲取異常</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
@@ -31,17 +31,17 @@
 <context>
     <name>CommonTools</name>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="99"/>
+        <location filename="../src/Tool/commontools.cpp" line="101"/>
         <source>EC_NOTIFY_NETWORK</source>
         <translation>EC_NOTIFY_NETWORK</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="100"/>
+        <location filename="../src/Tool/commontools.cpp" line="102"/>
         <source>EC_REINSTALL</source>
         <translation>EC_REINSTALL</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="101"/>
+        <location filename="../src/Tool/commontools.cpp" line="103"/>
         <source>EC_6</source>
         <translation>EC_6</translation>
     </message>
@@ -1504,13 +1504,13 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="200"/>
         <source>Processor</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="198"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
@@ -1851,6 +1851,54 @@
     </message>
 </context>
 <context>
+    <name>DeviceGenerator</name>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <source>Model Name</source>
+        <translation>名稱</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <source>Vendor ID</source>
+        <translation>製造商</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <source>Architecture</source>
+        <translation>架構</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
+        <source>Core(s)</source>
+        <translation>邏輯處理器</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <source>Thread(s)</source>
+        <translation>每核心執行緒數</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <source>L1d cache</source>
+        <translation>第一級快取（資料）</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <source>L1i cache</source>
+        <translation>第一級快取（指令）</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <source>L2 cache</source>
+        <translation>第二級快取</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <source>L3 cache</source>
+        <translation>第三級快取</translation>
+    </message>
+</context>
+<context>
     <name>DeviceManager</name>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="142"/>
@@ -1994,8 +2042,8 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="562"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="565"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="573"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="576"/>
         <source>%1@%2Hz</source>
         <translation>%1@%2Hz</translation>
     </message>
@@ -2187,7 +2235,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="310"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
@@ -2236,137 +2284,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="97"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="230"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="98"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="232"/>
         <source>Updating</source>
         <translation>正在更新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="124"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="184"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="104"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>Warning</source>
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="121"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="122"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>將從系統中移除此驅動程式，移除後該裝置不可用</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="126"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>卸 載</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="130"/>
         <source>Uninstalling</source>
         <translation>正在移除</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Update successful</source>
         <translation>驅動更新成功</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="155"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
         <source>Uninstallation successful</source>
         <translation>驅動移除成功</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Update failed</source>
         <translation>驅動更新失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="156"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="157"/>
         <source>Uninstallation failed</source>
         <translation>驅動移除失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="163"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="164"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>確 定</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="182"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="183"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="203"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="204"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>所選資料夾不存在，請重新選擇</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="208"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="209"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="210"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>上一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="242"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="244"/>
         <source>Broken package</source>
         <translation>包文件損壞</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="248"/>
         <source>Unmatched package architecture</source>
         <translation>包文件與系統架構不匹配</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="251"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="253"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
         <source>The selected file does not exist, please select again</source>
         <translation>所選文件不存在，請重新選擇</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
         <source>It is not a driver</source>
         <translation>該文件不是驅動文件</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
         <source>Unable to install - no digital signature</source>
         <translation>無法安裝，安裝包無數位簽章</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="330"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
         <source>Unknown error</source>
         <translation>未知錯誤</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="331"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
         <source>The driver module was not found</source>
         <translation>未發現該驅動模組</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="332"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
         <source>Invalid module format</source>
         <translation>模塊格式無效</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="333"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
         <source>The driver module has dependencies</source>
         <translation>驅動模組被依賴</translation>
     </message>
@@ -2537,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Storage</source>
         <translation>儲存裝置</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="95"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="134"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="142"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
         <source>Monitor</source>
         <translation>顯示裝置</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
         <source>Failed to enable the device</source>
         <translation>啟用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
         <source>Failed to disable the device</source>
         <translation>禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="184"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>無法獲取裝置序號，禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="206"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
         <source>Update Drivers</source>
         <translation>更新驅動</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="224"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
         <source>Uninstall Drivers</source>
         <translation>移除驅動</translation>
     </message>
@@ -2880,7 +2928,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1598"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1626"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1662"/>
-        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="55"/>
         <source>Keyboard</source>
         <translation>鍵盤</translation>
     </message>
@@ -2897,7 +2945,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1627"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1663"/>
-        <location filename="../src/Tool/commontools.cpp" line="55"/>
+        <location filename="../src/Tool/commontools.cpp" line="57"/>
         <source>Mouse</source>
         <translation>滑鼠</translation>
     </message>
@@ -2914,7 +2962,7 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1600"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1628"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1664"/>
-        <location filename="../src/Tool/commontools.cpp" line="57"/>
+        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <source>Printer</source>
         <translation>印表機</translation>
     </message>
@@ -2963,8 +3011,8 @@
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1603"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1631"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1667"/>
-        <location filename="../src/Tool/commontools.cpp" line="59"/>
         <location filename="../src/Tool/commontools.cpp" line="61"/>
+        <location filename="../src/Tool/commontools.cpp" line="63"/>
         <source>Other Devices</source>
         <translation>其他裝置</translation>
     </message>
@@ -2977,7 +3025,7 @@
         <translation>未發現其他裝置</translation>
     </message>
     <message>
-        <location filename="../src/Tool/EDIDParser.cpp" line="221"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="215"/>
         <source>inch</source>
         <translation>英寸</translation>
     </message>
@@ -2993,12 +3041,12 @@
         <translation>裝置管理器是查看、管理硬體裝置的工具軟體。</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="168"/>
+        <location filename="../src/main.cpp" line="170"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>您有驅動可進行安裝/更新。</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="169"/>
+        <location filename="../src/main.cpp" line="171"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3251,113 +3299,113 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="50"/>
+        <location filename="../src/Tool/commontools.cpp" line="52"/>
         <source>Bluetooth adapter</source>
         <translation>藍牙適配器</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="51"/>
-        <location filename="../src/Tool/commontools.cpp" line="58"/>
+        <location filename="../src/Tool/commontools.cpp" line="53"/>
+        <location filename="../src/Tool/commontools.cpp" line="60"/>
         <source>Imaging device</source>
         <translation>圖像裝置</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="52"/>
+        <location filename="../src/Tool/commontools.cpp" line="54"/>
         <source>Display adapter</source>
         <translation>顯示卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="54"/>
+        <location filename="../src/Tool/commontools.cpp" line="56"/>
         <source>Sound card</source>
         <translation>音效卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="56"/>
+        <location filename="../src/Tool/commontools.cpp" line="58"/>
         <source>Network adapter</source>
         <translation>網卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="60"/>
+        <location filename="../src/Tool/commontools.cpp" line="62"/>
         <source>Wireless network adapter</source>
         <translation>無線網卡</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="80"/>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Installation successful</source>
         <translation>安裝成功</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Installation failed</source>
         <translation>安裝失敗</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Downloading</source>
         <translation>下載中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>Installing</source>
         <translation>安裝中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>Not installed</source>
         <translation>驅動未安裝</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>Out-of-date</source>
         <translation>驅動可更新</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <location filename="../src/Tool/commontools.cpp" line="88"/>
         <source>Waiting</source>
         <translation>等待中</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <location filename="../src/Tool/commontools.cpp" line="89"/>
         <source>Not backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="88"/>
+        <location filename="../src/Tool/commontools.cpp" line="90"/>
         <source>Backing up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="89"/>
+        <location filename="../src/Tool/commontools.cpp" line="91"/>
         <source>Backup failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="90"/>
+        <location filename="../src/Tool/commontools.cpp" line="92"/>
         <source>Backup successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="91"/>
+        <location filename="../src/Tool/commontools.cpp" line="93"/>
         <source>Restoring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="95"/>
+        <location filename="../src/Tool/commontools.cpp" line="97"/>
         <source>Unknown error</source>
         <translation>未知錯誤</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="96"/>
+        <location filename="../src/Tool/commontools.cpp" line="98"/>
         <source>Network error</source>
         <translation>網路異常</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="97"/>
+        <location filename="../src/Tool/commontools.cpp" line="99"/>
         <source>Canceled</source>
         <translation>已取消</translation>
     </message>
     <message>
-        <location filename="../src/Tool/commontools.cpp" line="98"/>
+        <location filename="../src/Tool/commontools.cpp" line="100"/>
         <source>Failed to get driver files</source>
         <translation>驅動文件獲取異常</translation>
     </message>


### PR DESCRIPTION
--Add translate for cpu info.

Log: add feature for cpu info show.
Task: https://pms.uniontech.com/task-view-387697.html

## Summary by Sourcery

Add CPU information translations and related labels across multiple locales.

New Features:
- Introduce localized labels for CPU model, vendor, architecture, cores, threads, and cache levels in DeviceGenerator views across supported languages.

Enhancements:
- Update translation contexts and locations for existing device manager strings to align with recent source code changes.