### PR TITLE
chore: update version to 6.0.62

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-devicemanager (6.0.62) unstable; urgency=medium
+
+  * fix(security): VPLUS-2026-34718 - fix DBus permission configuration
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Thu, 07 May 2026 20:50:31 +0800
+
 deepin-devicemanager (6.0.61) unstable; urgency=medium
 
   * chore: Update version to 6.0.61


### PR DESCRIPTION
- bump version to 6.0.62

Log : bump version to 6.0.62

## Summary by Sourcery

Chores:
- Update Debian changelog entry to reflect version 6.0.62.