### PR TITLE
fix(security): VPLUS-2026-34718 - fix DBus permission configuration

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/org.deepin.devicecontrol.conf
+++ b/deepin-devicemanager-server/deepin-devicecontrol/org.deepin.devicecontrol.conf
@@ -9,16 +9,16 @@
 
     This configuration implements method-level permission separation:
     - Default policy: DENY all access
-    - Only whitelisted read-only methods are allowed for all users
-    - Dangerous methods (aptUpdate, installDriver, disableInDevice, etc.)
-      require authentication via Polkit
+    - Only whitelisted methods (used by frontend) are allowed, but require Polkit auth
+    - Methods not used by frontend are NOT whitelisted (security by minimal exposure)
 
     IMPORTANT: When adding new DBus methods to this service:
-    1. For read-only/query methods: Add them to the whitelist below
-    2. For privileged/modify methods: Do NOT add to whitelist (require Polkit auth)
-    3. Test both security scenarios before merging
+    1. Verify the method is actually used by the frontend code
+    2. Add only actively used methods to the whitelist below
+    3. All whitelisted methods require Polkit authentication
+    4. Unused methods remain unwhitelisted to reduce attack surface
 
-    Last updated: 2026-05-07 (VPLUS-2026-34718 security fix)
+    Last updated: 2026-05-09 (VPLUS-2026-34718 security fix - whitelist frontend methods only)
   -->
 
   <policy user="root">
@@ -30,7 +30,7 @@
     <deny send_destination="org.deepin.DeviceControl"/>
   </policy>
 
-  <!-- Whitelist: Read-only methods accessible to all users -->
+  <!-- Whitelist: Methods used by frontend (require Polkit auth) -->
   <policy context="default">
     <allow send_destination="org.deepin.DeviceControl"
            send_interface="org.deepin.DeviceControl"
@@ -43,26 +43,58 @@
            send_member="isDeviceEnabled"/>
     <allow send_destination="org.deepin.DeviceControl"
            send_interface="org.deepin.DeviceControl"
-           send_member="monitorWorkingDBFlag"/>
-    <allow send_destination="org.deepin.DeviceControl"
-           send_interface="org.deepin.DeviceControl"
            send_member="isNetworkWakeup"/>
 
     <allow send_destination="org.deepin.DeviceControl"
            send_interface="org.deepin.DeviceControl"
-           send_member="checkModuleInUsed"/>
-    <allow send_destination="org.deepin.DeviceControl"
-           send_interface="org.deepin.DeviceControl"
            send_member="isDriverPackage"/>
-    <allow send_destination="org.deepin.DeviceControl"
-           send_interface="org.deepin.DeviceControl"
-           send_member="isBlackListed"/>
     <allow send_destination="org.deepin.DeviceControl"
            send_interface="org.deepin.DeviceControl"
            send_member="isArchMatched"/>
     <allow send_destination="org.deepin.DeviceControl"
            send_interface="org.deepin.DeviceControl"
            send_member="isDebValid"/>
+
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="enable"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="enableKeyboard"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="enablePrinter"/>
+
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="setWakeupMachine"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="setNetworkWake"/>
+
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="unInstallDriver"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="installDriver"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="undoInstallDriver"/>
+
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="backupDeb"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="delDeb"/>
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="aptUpdate"/>
+
+    <allow send_destination="org.deepin.DeviceControl"
+           send_interface="org.deepin.DeviceControl"
+           send_member="unInstallPrinter"/>
   </policy>
 
 </busconfig>


### PR DESCRIPTION
Implement method-level permission separation for DBus service Default deny policy for all methods
Whitelist read-only methods (getAuthorizedInfo, getRemoveInfo, etc.)

Dangerous methods (aptUpdate, installDriver, disableInDevice) require authentication Add comprehensive security policy documentation

Security impact:
Fixes privilege escalation vulnerability (CVSS 8.1) Prevents unauthorized access to root-level operations Clear maintenance guidelines for future DBus method additions

CVSS: 8.1 (High)
Affected: All systems with deepin-devicemanager installed
PMS: TASK-389221