### PR TITLE
Fix(battery): get battery info error.

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -1316,12 +1316,10 @@ QMap<QString, QMap<QString, QString>> CmdTool::getCurPowerInfo()
     qCDebug(appLog) << "Getting current power info from upower.";
     QString powerInfo;
     QMap<QString, QMap<QString, QString>> map;
-    QProcess process;
 
     //执行"upower --dump"命令获取电池相关信息
-    QString cmd = "upower --dump";
-    process.start(cmd);
-
+    QProcess process;
+    process.start("upower", QStringList() << "--dump");
     // 获取命令执行结果
     process.waitForFinished(-1);
     powerInfo = process.readAllStandardOutput();


### PR DESCRIPTION
-- In Qt 6, when using QProcess::start(), you must separate the program name from the argument list for the command to execute correctly.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-361071.html

## Summary by Sourcery

Bug Fixes:
- Resolve failure to obtain battery information by correctly separating the upower program name and its arguments when starting the QProcess in Qt 6.