### PR TITLE
Fix(battery): get battery info error.

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1316,14 +1316,12 @@ QMap<QString, QMap<QString, QString>> CmdTool::getCurPowerInfo()
     qCDebug(appLog) << "Getting current power info from upower.";
     QString powerInfo;
     QMap<QString, QMap<QString, QString>> map;
-    QProcess process;
 
     //执行"upower --dump"命令获取电池相关信息
-    QString cmd = "upower --dump";
-    process.start(cmd);
-
+    QProcess process;
+    process.start("upower", QStringList() << "--dump");
     // 获取命令执行结果
-    process.waitForFinished(-1);
+    process.waitForFinished(5000);
     powerInfo = process.readAllStandardOutput();
     qCDebug(appLog) << "upower --dump output:" << powerInfo;
     QStringList items = powerInfo.split("\n\n");


### PR DESCRIPTION
-- In Qt 6, when using QProcess::start(), you must separate the program name from the argument list for the command to execute correctly.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-361071.html

## Summary by Sourcery

Fix battery information retrieval by correctly invoking the upower command with separated program and arguments and adding a timeout for the process execution.

Bug Fixes:
- Resolve failure to obtain current power information caused by improper QProcess usage when running the upower command.

Enhancements:
- Add a finite timeout when waiting for the upower process to finish to avoid potential indefinite hangs.
- Update the source file copyright years to include 2026.