### PR TITLE
fix(cpu): fix CPU cache size calculation with shared list

### DIFF
--- a/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/cpu/corecpu.cpp
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/cpu/corecpu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -63,6 +63,11 @@ void CoreCpu::getInfo(QString &info)
         appendKeyValue(info, "L2 cache", logical.l2Cache());
         appendKeyValue(info, "L3 cache", logical.l3Cache());
         appendKeyValue(info, "L4 cache", logical.l4Cache());
+        appendKeyValue(info, "L1d shared cpu list", logical.l1dSharedCpuList());
+        appendKeyValue(info, "L1i shared cpu list", logical.l1iSharedCpuList());
+        appendKeyValue(info, "L2 shared cpu list", logical.l2SharedCpuList());
+        appendKeyValue(info, "L3 shared cpu list", logical.l3SharedCpuList());
+        appendKeyValue(info, "L4 shared cpu list", logical.l4SharedCpuList());
         appendKeyValue(info, "CPU MHz", logical.curFreq());
         appendKeyValue(info, "CPU max MHz", logical.maxFreq());
         appendKeyValue(info, "CPU min MHz", logical.minFreq());

--- a/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/cpu/cpuinfo.cpp
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/cpu/cpuinfo.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -341,7 +341,7 @@ void CpuInfo::readCpuCache(const QString &path, LogicalCpu &lcpu)
 void CpuInfo::readCpuCacheIndex(const QString &path, LogicalCpu &lcpu)
 {
     int level = -1;
-    QString type, value;
+    QString type, value, sharedCpuList;
 
     // get level
     QString levelPath = path + "/level";
@@ -368,17 +368,31 @@ void CpuInfo::readCpuCacheIndex(const QString &path, LogicalCpu &lcpu)
     }
     fileV.close();
 
+    // get shared_cpu_list
+    QString sharedPath = path + "/shared_cpu_list";
+    QFile fileS(sharedPath);
+    if (fileS.open(QIODevice::ReadOnly)) {
+        sharedCpuList = fileS.readAll();
+    }
+    fileS.close();
+
     if (level == 2) {
         lcpu.setL2Cache(value);
+        lcpu.setL2SharedCpuList(sharedCpuList);
     } else if (level == 3) {
         lcpu.setL3Cache(value);
+        lcpu.setL3SharedCpuList(sharedCpuList);
     } else if (level == 4) {
         lcpu.setL4Cache(value);
+        lcpu.setL4SharedCpuList(sharedCpuList);
     } else if (level == 1) {
-        if (type.contains("Data", Qt::CaseInsensitive))
+        if (type.contains("Data", Qt::CaseInsensitive)) {
             lcpu.setL1dCache(value);
-        else
+            lcpu.setL1dSharedCpuList(sharedCpuList);
+        } else {
             lcpu.setL1iCache(value);
+            lcpu.setL1iSharedCpuList(sharedCpuList);
+        }
     }
 }
 

--- a/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/cpu/logicalcpu.cpp
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/cpu/logicalcpu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -53,6 +53,31 @@ void LogicalCpu::setL4Cache(const QString &value)
 {
     Q_D(LogicalCpu);
     d->l4_cache = value;
+}
+void LogicalCpu::setL1dSharedCpuList(const QString &value)
+{
+    Q_D(LogicalCpu);
+    d->l1d_shared_cpu_list = value;
+}
+void LogicalCpu::setL1iSharedCpuList(const QString &value)
+{
+    Q_D(LogicalCpu);
+    d->l1i_shared_cpu_list = value;
+}
+void LogicalCpu::setL2SharedCpuList(const QString &value)
+{
+    Q_D(LogicalCpu);
+    d->l2_shared_cpu_list = value;
+}
+void LogicalCpu::setL3SharedCpuList(const QString &value)
+{
+    Q_D(LogicalCpu);
+    d->l3_shared_cpu_list = value;
+}
+void LogicalCpu::setL4SharedCpuList(const QString &value)
+{
+    Q_D(LogicalCpu);
+    d->l4_shared_cpu_list = value;
 }
 void LogicalCpu::setMinFreq(const QString &value)
 {
@@ -151,6 +176,31 @@ const QString &LogicalCpu::l4Cache()
     Q_D(LogicalCpu);
     return d->l4_cache;
 }
+const QString &LogicalCpu::l1dSharedCpuList()
+{
+    Q_D(LogicalCpu);
+    return d->l1d_shared_cpu_list;
+}
+const QString &LogicalCpu::l1iSharedCpuList()
+{
+    Q_D(LogicalCpu);
+    return d->l1i_shared_cpu_list;
+}
+const QString &LogicalCpu::l2SharedCpuList()
+{
+    Q_D(LogicalCpu);
+    return d->l2_shared_cpu_list;
+}
+const QString &LogicalCpu::l3SharedCpuList()
+{
+    Q_D(LogicalCpu);
+    return d->l3_shared_cpu_list;
+}
+const QString &LogicalCpu::l4SharedCpuList()
+{
+    Q_D(LogicalCpu);
+    return d->l4_shared_cpu_list;
+}
 const QString &LogicalCpu::minFreq()
 {
     Q_D(LogicalCpu);
@@ -219,6 +269,11 @@ void LogicalCpu::diagPrintInfo()
     qCInfo(appLog) << "l2_cache   : " << d->l2_cache;
     qCInfo(appLog) << "l3_cache   : " << d->l3_cache;
     qCInfo(appLog) << "l4_cache   : " << d->l4_cache;
+    qCInfo(appLog) << "l1d_shared : " << d->l1d_shared_cpu_list;
+    qCInfo(appLog) << "l1i_shared : " << d->l1i_shared_cpu_list;
+    qCInfo(appLog) << "l2_shared  : " << d->l2_shared_cpu_list;
+    qCInfo(appLog) << "l3_shared  : " << d->l3_shared_cpu_list;
+    qCInfo(appLog) << "l4_shared  : " << d->l4_shared_cpu_list;
     qCInfo(appLog) << "max_freq   : " << d->max_freq;
     qCInfo(appLog) << "min_freq   : " << d->min_freq;
     qCInfo(appLog) << "cur_freq   : " << d->cur_freq;

--- a/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/cpu/logicalcpu.h
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/cpu/logicalcpu.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -60,6 +60,12 @@ public:
      * @param value cache
      */
     void setL4Cache(const QString &value);
+
+    void setL1dSharedCpuList(const QString &value);
+    void setL1iSharedCpuList(const QString &value);
+    void setL2SharedCpuList(const QString &value);
+    void setL3SharedCpuList(const QString &value);
+    void setL4SharedCpuList(const QString &value);
 
     /**
      * @brief setMinFreq : set min freq
@@ -180,6 +186,12 @@ public:
      */
     const QString &l4Cache();
 
+    const QString &l1dSharedCpuList();
+    const QString &l1iSharedCpuList();
+    const QString &l2SharedCpuList();
+    const QString &l3SharedCpuList();
+    const QString &l4SharedCpuList();
+
     /**
      * @brief minFreq
      * @return : value
@@ -266,6 +278,11 @@ public:
         , l2_cache("")
         , l3_cache("")
         , l4_cache("")
+        , l1d_shared_cpu_list("")
+        , l1i_shared_cpu_list("")
+        , l2_shared_cpu_list("")
+        , l3_shared_cpu_list("")
+        , l4_shared_cpu_list("")
         , max_freq("")
         , min_freq("")
         , cur_freq("")
@@ -289,6 +306,11 @@ public:
     QString     l2_cache;              // l2 cache
     QString     l3_cache;              // l3 cache
     QString     l4_cache;              // l4 cache
+    QString     l1d_shared_cpu_list;   // l1d shared cpu list
+    QString     l1i_shared_cpu_list;   // l1i shared cpu list
+    QString     l2_shared_cpu_list;    // l2 shared cpu list
+    QString     l3_shared_cpu_list;    // l3 shared cpu list
+    QString     l4_shared_cpu_list;    // l4 shared cpu list
     QString     max_freq;              // max freq
     QString     min_freq;              // min freq
     QString     cur_freq;              // cur freq

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -1547,7 +1547,9 @@ void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &first
     }
     if (firstProcessorInfo.contains("L1d cache")) {
         QString strL1dCache = firstProcessorInfo.value("L1d cache");
-        QString strTotalL1dCache = Common::formatTotalCache(strL1dCache, coreNum);
+        int sharedCount = Common::parseSharedCpuCount(firstProcessorInfo.value("L1d shared cpu list"));
+        int groupCount = (sharedCount > 0 && logicalNum > 0) ? logicalNum / sharedCount : coreNum;
+        QString strTotalL1dCache = Common::formatTotalCache(strL1dCache, groupCount);
         if (!strTotalL1dCache.isEmpty()) {
             QPair<QString, QString> totalL1dCache(tr("L1d cache"), strTotalL1dCache);
             singleCpuHeaderInfo.push_back(totalL1dCache);
@@ -1555,7 +1557,9 @@ void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &first
     }
     if (firstProcessorInfo.contains("L1i cache")) {
         QString strL1iCache = firstProcessorInfo.value("L1i cache");
-        QString strTotalL1iCache = Common::formatTotalCache(strL1iCache, coreNum);
+        int sharedCount = Common::parseSharedCpuCount(firstProcessorInfo.value("L1i shared cpu list"));
+        int groupCount = (sharedCount > 0 && logicalNum > 0) ? logicalNum / sharedCount : coreNum;
+        QString strTotalL1iCache = Common::formatTotalCache(strL1iCache, groupCount);
         if (!strTotalL1iCache.isEmpty()) {
             QPair<QString, QString> totalL1iCache(tr("L1i cache"), strTotalL1iCache);
             singleCpuHeaderInfo.push_back(totalL1iCache);
@@ -1563,7 +1567,9 @@ void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &first
     }
     if (firstProcessorInfo.contains("L2 cache")) {
         QString strL2Cache = firstProcessorInfo.value("L2 cache");
-        QString strTotalL2Cache = Common::formatTotalCache(strL2Cache, coreNum);
+        int sharedCount = Common::parseSharedCpuCount(firstProcessorInfo.value("L2 shared cpu list"));
+        int groupCount = (sharedCount > 0 && logicalNum > 0) ? logicalNum / sharedCount : coreNum;
+        QString strTotalL2Cache = Common::formatTotalCache(strL2Cache, groupCount);
         if (!strTotalL2Cache.isEmpty()) {
             QPair<QString, QString> totalL2Cache(tr("L2 cache"), strTotalL2Cache);
             singleCpuHeaderInfo.push_back(totalL2Cache);
@@ -1571,7 +1577,9 @@ void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &first
     }
     if (firstProcessorInfo.contains("L3 cache")) {
         QString strL3Cache = firstProcessorInfo.value("L3 cache");
-        QString strTotalL3Cache = Common::formatTotalCache(strL3Cache, 1);
+        int sharedCount = Common::parseSharedCpuCount(firstProcessorInfo.value("L3 shared cpu list"));
+        int groupCount = (sharedCount > 0 && logicalNum > 0) ? logicalNum / sharedCount : 1;
+        QString strTotalL3Cache = Common::formatTotalCache(strL3Cache, groupCount);
         if (!strTotalL3Cache.isEmpty()) {
             QPair<QString, QString> totalL3Cache(tr("L3 cache"), strTotalL3Cache);
             singleCpuHeaderInfo.push_back(totalL3Cache);

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,8 @@
 #include "commondefine.h"
 #include "DBusInterface.h"
 #include "DDLog.h"
+
+#include <QRegularExpression>
 
 // 其它头文件
 #include <QString>
@@ -372,4 +374,34 @@ QString Common::formatTotalCache(const QString &perThreadCache, int coreCount)
     } else {
         return QString::number(value, 'f', 1) + " " + unit;
     }
+}
+
+int Common::parseSharedCpuCount(const QString &sharedCpuList)
+{
+    QString s = sharedCpuList.trimmed();
+    if (s.isEmpty())
+        return 0;
+
+    int count = 0;
+    QStringList parts = s.split(',', Qt::SkipEmptyParts);
+    for (const QString &part : parts) {
+        QString trimmed = part.trimmed();
+        if (trimmed.contains('-')) {
+            QStringList range = trimmed.split('-');
+            if (range.size() == 2) {
+                bool ok1 = false, ok2 = false;
+                int start = range[0].trimmed().toInt(&ok1);
+                int end = range[1].trimmed().toInt(&ok2);
+                if (ok1 && ok2 && end >= start) {
+                    count += end - start + 1;
+                }
+            }
+        } else {
+            bool ok = false;
+            if (trimmed.toInt(&ok) || ok) {
+                count += 1;
+            }
+        }
+    }
+    return count;
 }

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -51,5 +51,7 @@ public:
     static bool isShowScreenSize();
 
     static QString formatTotalCache(const QString& perThreadCache, int coreCount);
+
+    static int parseSharedCpuCount(const QString &sharedCpuList);
 };
 #endif // COMMONFUNCTION_H


### PR DESCRIPTION
Add support for reading CPU cache shared_cpu_list from sysfs and use it to calculate total cache size accurately for each cache level.

添加对CPU缓存shared_cpu_list的支持，从sysfs读取并用于准确
计算各级缓存总大小。

Log: 修复CPU缓存大小计算错误
PMS: BUG-361631
Influence: 修复后CPU各级缓存总大小计算准确，系统监视器显示的缓存信息更准确。