### PR TITLE
chore: Update version to 6.0.65

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-devicemanager (6.0.65) unstable; urgency=medium
+
+  * chore: Update version to 6.0.65
+  * fix(cpu): fix CPU cache size calculation with shared list
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Wed, 20 May 2026 13:07:35 +0800
+
 deepin-devicemanager (6.0.64) unstable; urgency=medium
 
   * Chore: Code optimization


### PR DESCRIPTION
- update version to 6.0.65

log: update version to 6.0.65

## Summary by Sourcery

Chores:
- Update Debian packaging changelog entry for version 6.0.65.