### PR TITLE
fix(enable): use sysfs to detect wireless NIC instead of name prefix

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enableutils.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enableutils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,6 +12,8 @@
 #include <QCryptographicHash>
 #include <QRegularExpression>
 #include <QDebug>
+#include <QFileInfo>
+#include <QDir>
 
 #include <net/if.h>
 #include <sys/ioctl.h>
@@ -140,7 +142,7 @@ void EnableUtils::disableInDevice()
 
 bool EnableUtils::ioctlOperateNetworkLogicalName(const QString &logicalName, bool enable)
 {
-    if (logicalName.startsWith("wlan") || logicalName.startsWith("wlp")) {  // Wireless LAN
+    if (isWireless(logicalName)) {  // Wireless LAN
         // 第一步：获取 wiphy 编号
         QProcess iwProcess;
         iwProcess.start("iw", QStringList() << "dev" << logicalName << "info");
@@ -157,17 +159,30 @@ bool EnableUtils::ioctlOperateNetworkLogicalName(const QString &logicalName, boo
         QString phyNum = wiphyMatch.captured(1);
 
         // 第二步：获取 rfkill 设备编号
-        QProcess rfkillListProcess;
-        rfkillListProcess.start("rfkill", QStringList() << "list");
-        rfkillListProcess.waitForFinished();
-        QString rfkillOutput = QString::fromUtf8(rfkillListProcess.readAllStandardOutput());
-
-        // 查找对应的 rfkill 编号
-        QRegularExpression rfkillRe("^(\\d+):.*\\n.*\\n.*phy" + phyNum);
-        QRegularExpressionMatch rfkillMatch = rfkillRe.match(rfkillOutput);
         QString rfkillId;
-        if (rfkillMatch.hasMatch()) {
-            rfkillId = rfkillMatch.captured(1);
+        QString phyPath = QString("/sys/class/ieee80211/phy%1").arg(phyNum);
+        QDir phyDir(phyPath);
+        if (!phyDir.exists()) {
+            qCritical() << "Phy path does not exist:" << phyPath;
+            return false;
+        }
+
+        // 查找 rfkill 目录
+        QStringList rfkillDirs = phyDir.entryList(QStringList() << "rfkill*", QDir::Dirs);
+        if (rfkillDirs.isEmpty()) {
+            qCritical() << "No rfkill directory found unbder" << phyPath;
+            return false;
+        }
+
+        // 读取 index 文件
+        QString rfkillIndexPath = phyPath + "/" + rfkillDirs.first() + "/index";
+        QFile indexFile(rfkillIndexPath);
+        if (indexFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            rfkillId = indexFile.readLine().trimmed();
+            indexFile.close();
+        } else {
+            qCritical() << "Failded to read rfkill index from" << rfkillIndexPath;
+            return false;
         }
 
         // 第三步：执行 rfkill block/unblock
@@ -179,6 +194,8 @@ bool EnableUtils::ioctlOperateNetworkLogicalName(const QString &logicalName, boo
             if (ret != 0) {
                 qCritical() << "Failed to block/unblock wifi: error code: " << ret;
             }
+        } else {
+            qCritical() << "Empty rfkill ID";
         }
 
         // 第四步：执行 ifconfig up/down
@@ -251,4 +268,14 @@ bool EnableUtils::getMapInfo(const QString &item, QMap<QString, QString> &mapInf
     }
 
     return true;
+}
+
+bool EnableUtils::isWireless(const QString &logicalName)
+{
+    QFileInfo wirelessInfo(QString("/sys/class/net/%1/wireless").arg(logicalName));
+    QFileInfo phyInfo(QString("/sys/class/net/%1/phy80211").arg(logicalName));
+    if (wirelessInfo.exists() || phyInfo.exists())
+        return true;
+    else
+        return false;
 }

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enableutils.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/enablecontrol/enableutils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -39,6 +39,9 @@ public:
      * @return
      */
     static bool getMapInfo(const QString &item, QMap<QString, QString> &mapInfo);
+
+private:
+    static bool isWireless(const QString &logicalName);
 };
 
 #endif // ENABLEUTILS_H


### PR DESCRIPTION
Replace hardcoded name prefix matching (wlan/wlp) with sysfs path checking (/sys/class/net/<name>/wireless and phy80211) for more reliable wireless NIC detection.

使用 sysfs 路径检测替代硬编码名称前缀匹配来判断无线网卡，提升检测准确性。

Log: 修复无线网卡检测逻辑，使用sysfs替代名称前缀匹配
PMS: https://pms.uniontech.com/bug-view-362409.html
Influence: 无线网卡启用/禁用操作不再依赖接口名称前缀，支持所有符合内核规范的无线网卡接口名称。

## Summary by Sourcery

Detect wireless network interfaces via sysfs paths instead of hardcoded name prefixes when enabling or disabling devices.

Bug Fixes:
- Fix wireless NIC detection so it no longer relies on interface name prefixes like wlan/wlp but uses kernel-provided sysfs indicators instead.

Enhancements:
- Add a reusable helper to classify network interfaces as wireless based on /sys/class/net entries.
- Update file copyright years to cover up to 2026.