### PR TITLE
fix(cpu-header): use CPU(s) label for core count and refresh translat…

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -1291,7 +1291,7 @@ void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &first
         singleCpuHeaderInfo.push_back(arch);
     }
     if (coreNum > 0) {
-        QPair<QString, QString> coreCount(tr("Core(s)"), QString::number(coreNum));
+        QPair<QString, QString> coreCount(tr("CPU(s)"), QString::number(logicalNum));
         singleCpuHeaderInfo.push_back(coreCount);
         QPair<QString, QString> threadPerCore(tr("Thread(s)"), QString::number(logicalNum / coreNum));
         singleCpuHeaderInfo.push_back(threadPerCore);

--- a/deepin-devicemanager/translations/deepin-devicemanager.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager.ts
@@ -92,1411 +92,1411 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="964"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
         <source>Core(s)</source>
         <translation type="unfinished">Core(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="965"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Processor</source>
         <translation type="unfinished">Processor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="966"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
         <source>ACL MTU</source>
         <translation type="unfinished">ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
         <source>Address</source>
         <translation type="unfinished">Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
         <source>Alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
         <source>ansiversion</source>
         <translation type="unfinished">ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
         <source>Application</source>
         <translation type="unfinished">Application</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Architecture</source>
         <translation type="unfinished">Architecture</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
         <source>Array Handle</source>
         <translation type="unfinished">Array Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
         <source>Asset Tag</source>
         <translation type="unfinished">Asset Tag</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
         <source>Auto Negotiation</source>
         <translation type="unfinished">Auto Negotiation</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
         <source>Bank Locator</source>
         <translation type="unfinished">Bank Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
         <source>Base Board Information</source>
         <translation type="unfinished">Base Board Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
         <source>BD Address</source>
         <translation type="unfinished">BD Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
         <source>BIOS Information</source>
         <translation type="unfinished">BIOS Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
         <source>BIOS Revision</source>
         <translation type="unfinished">BIOS Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
         <source>BIOS ROMSIZE</source>
         <translation type="unfinished">BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
         <source>Board name</source>
         <translation type="unfinished">Board name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
         <source>BogoMIPS</source>
         <translation type="unfinished">BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
         <source>Boot-up State</source>
         <translation type="unfinished">Boot-up State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
         <source>Broadcast</source>
         <translation type="unfinished">Broadcast</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
         <source>Bus</source>
         <translation type="unfinished">Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
         <source>bus info</source>
         <translation type="unfinished">bus info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
         <source>Bus Info</source>
         <translation type="unfinished">Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
         <source>Cache Size</source>
         <translation type="unfinished">Cache Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
         <source>Capabilities</source>
         <translation type="unfinished">Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
         <source>Capacity</source>
         <translation type="unfinished">Capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
         <source>Characteristics</source>
         <translation type="unfinished">Characteristics</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
         <source>Chassis Handle</source>
         <translation type="unfinished">Chassis Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
         <source>Chassis Information</source>
         <translation type="unfinished">Chassis Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
         <source>Chip</source>
         <translation type="unfinished">Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
         <source>Chipset</source>
         <translation type="unfinished">Chipset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
         <source>Class</source>
         <translation type="unfinished">Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
         <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
         <source>Config Status</source>
         <translation type="unfinished">Config Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
         <source>Configured Speed</source>
         <translation type="unfinished">Configured Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
         <source>Configured Voltage</source>
         <translation type="unfinished">Configured Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
         <source>Contained Elements</source>
         <translation type="unfinished">Contained Elements</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
         <source>Contained Object Handles</source>
         <translation type="unfinished">Contained Object Handles</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
         <source>copies</source>
         <translation type="unfinished">copies</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
         <source>Core ID</source>
         <translation type="unfinished">Core ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
         <source>CPU architecture</source>
         <translation type="unfinished">CPU architecture</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
         <source>CPU Family</source>
         <translation type="unfinished">CPU Family</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
         <source>CPU ID</source>
         <translation type="unfinished">CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
         <source>CPU implementer</source>
         <translation type="unfinished">CPU implementer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
         <source>CPU part</source>
         <translation type="unfinished">CPU part</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
         <source>CPU revision</source>
         <translation type="unfinished">CPU revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
         <source>CPU variant</source>
         <translation type="unfinished">CPU variant</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
         <source>critical-action</source>
         <translation type="unfinished">critical-action</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
         <source>Currently Installed Language</source>
         <translation type="unfinished">Currently Installed Language</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
         <source>Current Resolution</source>
         <translation type="unfinished">Current Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
         <source>daemon-version</source>
         <translation type="unfinished">daemon-version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
         <source>Data Width</source>
         <translation type="unfinished">Data Width</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
         <source>description</source>
         <translation type="unfinished">description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
         <source>Design Capacity</source>
         <translation type="unfinished">Design Capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
         <source>Design Voltage</source>
         <translation type="unfinished">Design Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
         <source>Device</source>
         <translation type="unfinished">Device</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
         <source>Device Class</source>
         <translation type="unfinished">Device Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
         <source>Device File</source>
         <translation type="unfinished">Device File</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
         <source>Device Files</source>
         <translation type="unfinished">Device Files</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
         <source>Device Name</source>
         <translation type="unfinished">Device Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
         <source>Device Number</source>
         <translation type="unfinished">Device Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
         <source>DigitalOutput</source>
         <translation type="unfinished">DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
         <source>Disable</source>
         <translation type="unfinished">Disable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
         <source>Discoverable</source>
         <translation type="unfinished">Discoverable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
         <source>Discovering</source>
         <translation type="unfinished">Discovering</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
         <source>Display Input</source>
         <translation type="unfinished">Display Input</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
         <source>Display Output</source>
         <translation type="unfinished">Display Output</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
         <source>Display Ratio</source>
         <translation type="unfinished">Display Ratio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
         <source>DP</source>
         <translation type="unfinished">DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
         <source>Driver</source>
         <translation type="unfinished">Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
         <source>Driver Activation Cmd</source>
         <translation type="unfinished">Driver Activation Cmd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
         <source>Driver Modules</source>
         <translation type="unfinished">Driver Modules</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
         <source>Driver Status</source>
         <translation type="unfinished">Driver Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
         <source>Driver Version</source>
         <translation type="unfinished">Driver Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
         <source>Duplex</source>
         <translation type="unfinished">Duplex</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
         <source>DVI</source>
         <translation type="unfinished">DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
         <source>eDP</source>
         <translation type="unfinished">eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
         <source>EGL client APIs</source>
         <translation type="unfinished">EGL client APIs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
         <source>EGL version</source>
         <translation type="unfinished">EGL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
         <source>energy</source>
         <translation type="unfinished">energy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
         <source>energy-empty</source>
         <translation type="unfinished">energy-empty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
         <source>energy-full</source>
         <translation type="unfinished">energy-full</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
         <source>energy-full-design</source>
         <translation type="unfinished">energy-full-design</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
         <source>energy-rate</source>
         <translation type="unfinished">energy-rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
         <source>Error Correction Type</source>
         <translation type="unfinished">Error Correction Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
         <source>Error Information Handle</source>
         <translation type="unfinished">Error Information Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
         <source>EV</source>
         <translation type="unfinished">EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
         <source>Extensions</source>
         <translation type="unfinished">Extensions</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
         <source>Family</source>
         <translation type="unfinished">Family</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
         <source>Features</source>
         <translation type="unfinished">Features</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
         <source>Firmware</source>
         <translation type="unfinished">Firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
         <source>Firmware Revision</source>
         <translation type="unfinished">Firmware Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
         <source>Firmware Version</source>
         <translation type="unfinished">Firmware Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
         <source>Flags</source>
         <translation type="unfinished">Flags</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
         <source>Form Factor</source>
         <translation type="unfinished">Form Factor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
         <source>GDDR capacity</source>
         <translation type="unfinished">GDDR capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
         <source>Geometry (Logical)</source>
         <translation type="unfinished">Geometry (Logical)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
         <source>GLSL version</source>
         <translation type="unfinished">GLSL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
         <source>GL version</source>
         <translation type="unfinished">GL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
         <source>GPU type</source>
         <translation type="unfinished">GPU type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
         <source>GPU vendor</source>
         <translation type="unfinished">GPU vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
         <source>Graphics Memory</source>
         <translation type="unfinished">Graphics Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
         <source>guid</source>
         <translation type="unfinished">guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
         <source>Handlers</source>
         <translation type="unfinished">Handlers</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
         <source>Hardware Class</source>
         <translation type="unfinished">Hardware Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
         <source>has history</source>
         <translation type="unfinished">has history</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
         <source>has statistics</source>
         <translation type="unfinished">has statistics</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
         <source>HCI Version</source>
         <translation type="unfinished">HCI Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
         <source>HDMI</source>
         <translation type="unfinished">HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
         <source>icon-name</source>
         <translation type="unfinished">icon-name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
         <source>Input/Output</source>
         <translation type="unfinished">Input/Output</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
         <source>Installable Languages</source>
         <translation type="unfinished">Installable Languages</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
         <source>Interface</source>
         <translation type="unfinished">Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
         <source>Interface Type</source>
         <translation type="unfinished">Interface Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
         <source>ioport</source>
         <translation type="unfinished">ioport</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
         <source>IO Port</source>
         <translation type="unfinished">IO Port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
         <source>IP</source>
         <translation type="unfinished">IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
         <source>IRQ</source>
         <translation type="unfinished">IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
         <source>job-cancel-after</source>
         <translation type="unfinished">job-cancel-after</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
         <source>job-hold-until</source>
         <translation type="unfinished">job-hold-until</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
         <source>job-priority</source>
         <translation type="unfinished">job-priority</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
         <source>KernelModeDriver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
         <source>KEY</source>
         <translation type="unfinished">KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
         <source>L1d Cache</source>
         <translation type="unfinished">L1d Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
         <source>L1i Cache</source>
         <translation type="unfinished">L1i Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
         <source>L2 Cache</source>
         <translation type="unfinished">L2 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
         <source>L3 Cache</source>
         <translation type="unfinished">L3 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
         <source>L4 Cache</source>
         <translation type="unfinished">L2 Cache {4 ?}</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
         <source>Language Description Format</source>
         <translation type="unfinished">Language Description Format</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
         <source>latency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
         <source>Latency</source>
         <translation type="unfinished">Latency</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
         <source>lid-is-closed</source>
         <translation type="unfinished">lid-is-closed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
         <source>lid-is-present</source>
         <translation type="unfinished">lid-is-present</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
         <source>Link</source>
         <translation type="unfinished">Link</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
         <source>Link mode</source>
         <translation type="unfinished">Link mode</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
         <source>Link policy</source>
         <translation type="unfinished">Link policy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
         <source>LMP Version</source>
         <translation type="unfinished">LMP Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
         <source>Location</source>
         <translation type="unfinished">Location</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
         <source>Location In Chassis</source>
         <translation type="unfinished">Location In Chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
         <source>Locator</source>
         <translation type="unfinished">Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
         <source>Lock</source>
         <translation type="unfinished">Lock</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
         <source>logical name</source>
         <translation type="unfinished">logical name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
         <source>Logical Name</source>
         <translation type="unfinished">Logical Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
         <source>logicalsectorsize</source>
         <translation type="unfinished">logicalsectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
         <source>Logical Size</source>
         <translation type="unfinished">Logical Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
         <source>MAC Address</source>
         <translation type="unfinished">MAC Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
         <source>marker-change-time</source>
         <translation type="unfinished">marker-change-time</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Max Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
         <source>Maximum Capacity</source>
         <translation type="unfinished">Maximum Capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
         <source>Maximum Current</source>
         <translation type="unfinished">Maximum Current</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
         <source>Maximum Power</source>
         <translation type="unfinished">Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
         <source>Maximum Rate</source>
         <translation type="unfinished">Maximum Rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
         <source>Maximum Resolution</source>
         <translation type="unfinished">Maximum Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
         <source>Maximum Voltage</source>
         <translation type="unfinished">Maximum Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Media Type</source>
         <translation type="unfinished">Media Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
         <source>Memory</source>
         <translation type="unfinished">Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
         <source>Memory Address</source>
         <translation type="unfinished">Memory Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
         <source>Memory Operating Mode Capability</source>
         <translation type="unfinished">Memory Operating Mode Capability</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation type="unfinished">Memory Subsystem Controller Manufacturer ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation type="unfinished">Memory Subsystem Controller Product ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
         <source>Memory Technology</source>
         <translation type="unfinished">Memory Technology</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
         <source>Minimum Resolution</source>
         <translation type="unfinished">Minimum Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
         <source>Minimum Voltage</source>
         <translation type="unfinished">Minimum Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
         <source>Modalias</source>
         <translation type="unfinished">Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
         <source>Module Alias</source>
         <translation type="unfinished">Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
         <source>Module Manufacturer ID</source>
         <translation type="unfinished">Module Manufacturer ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
         <source>Module Product ID</source>
         <translation type="unfinished">Module Product ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
         <source>MSC</source>
         <translation type="unfinished">MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
         <source>Multicast</source>
         <translation type="unfinished">Multicast</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
         <source>native-path</source>
         <translation type="unfinished">native-path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
         <source>Negotiation Rate</source>
         <translation type="unfinished">Negotiation Rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
         <source>network</source>
         <translation type="unfinished">network</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
         <source>Non-Volatile Size</source>
         <translation type="unfinished">Non-Volatile Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
         <source>Number Of Devices</source>
         <translation type="unfinished">Number Of Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
         <source>Number Of Power Cords</source>
         <translation type="unfinished">Number Of Power Cords</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
         <source>number-up</source>
         <translation type="unfinished">number-up</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
         <source>OEM Information</source>
         <translation type="unfinished">OEM Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
         <source>on-battery</source>
         <translation type="unfinished">on-battery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
         <source>online</source>
         <translation type="unfinished">online</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
         <source>orientation-requested</source>
         <translation type="unfinished">orientation-requested</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
         <source>Packet type</source>
         <translation type="unfinished">Packet type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
         <source>Pairable</source>
         <translation type="unfinished">Pairable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
         <source>Part Number</source>
         <translation type="unfinished">Part Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
         <source>percentage</source>
         <translation type="unfinished">percentage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
         <source>Phys</source>
         <translation type="unfinished">Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
         <source>physical id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
         <source>Physical ID</source>
         <translation type="unfinished">Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
         <source>Physical Memory Array</source>
         <translation type="unfinished">Physical Memory Array</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
         <source>Port</source>
         <translation type="unfinished">Port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
         <source>Powered</source>
         <translation type="unfinished">Powered</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
         <source>power supply</source>
         <translation type="unfinished">power supply</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
         <source>Power Supply State</source>
         <translation type="unfinished">Power Supply State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
         <source>Primary Monitor</source>
         <translation type="unfinished">Primary Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
         <source>print-color-mode</source>
         <translation type="unfinished">print-color-mode</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
         <source>printer-is-accepting-jobs</source>
         <translation type="unfinished">printer-is-accepting-jobs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
         <source>printer-is-shared</source>
         <translation type="unfinished">printer-is-shared</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
         <source>printer-is-temporary</source>
         <translation type="unfinished">printer-is-temporary</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
         <source>printer-make-and-model</source>
         <translation type="unfinished">printer-make-and-model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
         <source>printer-state-change-time</source>
         <translation type="unfinished">printer-state-change-time</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
         <source>printer-state-reasons</source>
         <translation type="unfinished">printer-state-reasons</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
         <source>printer-type</source>
         <translation type="unfinished">printer-type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
         <source>printer-uri-supported</source>
         <translation type="unfinished">printer-uri-supported</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
         <source>product</source>
         <translation type="unfinished">product</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
         <source>Product Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
         <source>Product Name</source>
         <translation type="unfinished">Product Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
         <source>PROP</source>
         <translation type="unfinished">PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
         <source>Rank</source>
         <translation type="unfinished">Rank</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
         <source>rechargeable</source>
         <translation type="unfinished">rechargeable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Refresh Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
         <source>Release date</source>
         <translation type="unfinished">Release date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>Release Date</source>
         <translation type="unfinished">Release Date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Revision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>ROM Size</source>
         <translation type="unfinished">ROM Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>Rotation Rate</source>
         <translation type="unfinished">Rotation Rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Runtime Size</source>
         <translation type="unfinished">Runtime Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
         <source>SBDS Chemistry</source>
         <translation type="unfinished">SBDS Chemistry</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>SBDS Manufacture Date</source>
         <translation type="unfinished">SBDS Manufacture Date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>SBDS Serial Number</source>
         <translation type="unfinished">SBDS Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>SBDS Version</source>
         <translation type="unfinished">SBDS Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>SCO MTU</source>
         <translation type="unfinished">SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>sectorsize</source>
         <translation type="unfinished">sectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>Security Status</source>
         <translation type="unfinished">Security Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>Serial ID</source>
         <translation type="unfinished">Serial ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>Serial Number</source>
         <translation type="unfinished">Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>Service Classes</source>
         <translation type="unfinished">Service Classes</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Set</source>
         <translation type="unfinished">Set</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>Shared</source>
         <translation type="unfinished">Shared</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>sides</source>
         <translation type="unfinished">sides</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Size</source>
         <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>SKU Number</source>
         <translation type="unfinished">SKU Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>Slot</source>
         <translation type="unfinished">Slot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>SMBIOS Version</source>
         <translation type="unfinished">SMBIOS Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>state</source>
         <translation type="unfinished">state</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>status</source>
         <translation type="unfinished">status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Status</source>
         <translation type="unfinished">Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Stepping</source>
         <translation type="unfinished">Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>SubDevice</source>
         <translation type="unfinished">SubDevice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>SubVendor</source>
         <translation type="unfinished">SubVendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Subversion</source>
         <translation type="unfinished">Subversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Support Resolution</source>
         <translation type="unfinished">Support Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Sysfs</source>
         <translation type="unfinished">Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>SysFS_Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>System Information</source>
         <translation type="unfinished">System Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>technology</source>
         <translation type="unfinished">technology</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Temperature</source>
         <translation type="unfinished">Temperature</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Thermal State</source>
         <translation type="unfinished">Thermal State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>Threads</source>
         <translation type="unfinished">Threads</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Total Width</source>
         <translation type="unfinished">Total Width</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>Type Detail</source>
         <translation type="unfinished">Type Detail</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>Unavailable</source>
         <translation type="unfinished">Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>Uniq</source>
         <translation type="unfinished">Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>updated</source>
         <translation type="unfinished">updated</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>URI</source>
         <translation type="unfinished">URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>UUID</source>
         <translation type="unfinished">UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Version</source>
         <translation type="unfinished">Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>VGA</source>
         <translation type="unfinished">VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>Virtualization</source>
         <translation type="unfinished">Virtualization</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Volatile Size</source>
         <translation type="unfinished">Volatile Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>voltage</source>
         <translation type="unfinished">voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>Voltage</source>
         <translation type="unfinished">Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Wake-up Type</source>
         <translation type="unfinished">Wake-up Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>warning-level</source>
         <translation type="unfinished">warning-level</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>battery</source>
         <translation type="unfinished">battery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>inch</source>
         <translation type="unfinished">inch</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Speed</source>
         <translation type="unfinished">Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Max Boost Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>SSD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>HDD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
@@ -1853,47 +1853,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1282"/>
         <source>Model Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1286"/>
         <source>Vendor ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
         <source>Architecture</source>
         <translation type="unfinished">Architecture</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
-        <source>Core(s)</source>
-        <translation type="unfinished">Core(s)</translation>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1294"/>
+        <source>CPU(s)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1296"/>
         <source>Thread(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1305"/>
         <source>L1d cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1315"/>
         <source>L1i cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1325"/>
         <source>L2 cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1335"/>
         <source>L3 cache</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2585,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Storage</source>
         <translation type="unfinished">Storage</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Memory</source>
         <translation type="unfinished">Memory</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Monitor</source>
         <translation type="unfinished">Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="211"/>
         <source>Failed to enable the device</source>
         <translation>Failed to enable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="214"/>
         <source>Failed to disable the device</source>
         <translation>Failed to disable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="219"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Failed to disable it: unable to get the device SN</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="241"/>
         <source>Update Drivers</source>
         <translation>Update Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="259"/>
         <source>Uninstall Drivers</source>
         <translation>Uninstall Drivers</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
@@ -92,1411 +92,1411 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="964"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
         <source>Core(s)</source>
         <translation>ལྟེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="965"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Processor</source>
         <translation>གཏན་ཚིགས་ཐག་གཅོད་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="966"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
         <source>Address</source>
         <translation>གནས་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
         <source>Alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
         <source>ansiversion</source>
         <translation>ANSIཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
         <source>Application</source>
         <translation>ཉེར་སྤྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Architecture</source>
         <translation>གཞི་སྒྲོམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
         <source>Array Handle</source>
         <translation>གྲངས་ཚོ་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
         <source>Asset Tag</source>
         <translation>རྒྱུ་ནོར་སྒྲིག་ཨང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
         <source>Auto Negotiation</source>
         <translation>རང་འགུལ་གྲོས་དོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
         <source>Bank Locator</source>
         <translation>ནང་གསོག་རྒྱུ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
         <source>Base Board Information</source>
         <translation>མ་པང་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
         <source>BD Address</source>
         <translation>སོ་སྔོན་སྒྲིག་ཆས་སྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
         <source>BIOS Information</source>
         <translation>BIOSཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
         <source>BIOS Revision</source>
         <translation>BIOSབཟོ་བཅོས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROMཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
         <source>Board name</source>
         <translation>མ་པང་གི་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
         <source>Boot-up State</source>
         <translation>འཕྲུལ་སྒོ་ཕྱེ་བའི་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
         <source>Broadcast</source>
         <translation>རྒྱང་བསྒྲགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
         <source>Bus</source>
         <translation>མ་སྐུད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
         <source>bus info</source>
         <translation>ཆ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
         <source>Bus Info</source>
         <translation>མ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
         <source>Cache Size</source>
         <translation>ཤོང་གསོག་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
         <source>Capabilities</source>
         <translation>བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
         <source>Capacity</source>
         <translation>ཤོང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
         <source>Characteristics</source>
         <translation>ཁྱད་གཤིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
         <source>Chassis Handle</source>
         <translation>འཁོར་སྒམ་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
         <source>Chassis Information</source>
         <translation>འཁོར་སྒམ་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
         <source>Chip</source>
         <translation>ཉིང་ལྷེབ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
         <source>Chipset</source>
         <translation>ཉིང་ལྷེབ་ཙུའུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
         <source>Class</source>
         <translation>རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
         <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
         <source>Config Status</source>
         <translation>སྒྲིག་སྦྱོར་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
         <source>Configured Speed</source>
         <translation>སྒྲིག་སྦྱོར་ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
         <source>Configured Voltage</source>
         <translation>སྒྲིག་སྦྱོར་གློག་གནོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
         <source>Contained Elements</source>
         <translation>ཡོད་པའི་སྒྲིག་ཆས་གྲངས་ཀ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
         <source>Contained Object Handles</source>
         <translation>བྱ་ཡུལ་བྱ་རིམ་ཚུད་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
         <source>copies</source>
         <translation>བསྐྱར་པར་གྲངས་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
         <source>Core ID</source>
         <translation>ལྟེ་བ། ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
         <source>CPU architecture</source>
         <translation>CPUགཞི་སྒྲོམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
         <source>CPU Family</source>
         <translation>ཁྱིམ་རྒྱུད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
         <source>CPU ID</source>
         <translation>སྒྲིག་གཅོད་ཆས།  ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
         <source>CPU implementer</source>
         <translation>CPUབྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
         <source>CPU part</source>
         <translation>CPUལྷུ་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
         <source>CPU revision</source>
         <translation>CPUཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
         <source>CPU variant</source>
         <translation>CPUའགྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
         <source>critical-action</source>
         <translation>གློག་ཚད་ཆེས་ཉུང་བའི་སྐབས་ལག་བསྟར་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
         <source>Currently Installed Language</source>
         <translation>མིག་སྔའི་སྒྲིག་སྦྱོར་སྐད་བརྡ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
         <source>Current Resolution</source>
         <translation>མིག་སྔའི་འབྱེད་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
         <source>daemon-version</source>
         <translation>Daemonཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
         <source>Data Width</source>
         <translation>གཞི་གྲངས་ཞེང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
         <source>Date</source>
         <translation>དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
         <source>description</source>
         <translation>ཞིབ་བརྗོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
         <source>Description</source>
         <translation>ཞིབ་བརྗོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
         <source>Design Capacity</source>
         <translation>ཤོང་ཚད་ཇུས་འགོད་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
         <source>Design Voltage</source>
         <translation>གློག་གནོན་ཇུས་འགོད་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
         <source>Device</source>
         <translation>སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
         <source>Device Class</source>
         <translation>སྒྲིག་ཆས་རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
         <source>Device File</source>
         <translation>སྒྲིག་ཆས་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
         <source>Device Files</source>
         <translation>སྒྲིག་ཆས་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
         <source>Device Name</source>
         <translation>སྒྲིག་ཆས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
         <source>Device Number</source>
         <translation>སྒྲིག་ཆས་ཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
         <source>Discoverable</source>
         <translation>ཤེས་རྟོགས་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
         <source>Discovering</source>
         <translation>འཚོལ་ཞིབ་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
         <source>Display Input</source>
         <translation>ནང་འཇུག་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
         <source>Display Output</source>
         <translation>ཕྱིར་འདྲེན་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
         <source>Display Ratio</source>
         <translation>འཆར་བའི་བསྡུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
         <source>Driver</source>
         <translation>སྒུལ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
         <source>Driver Activation Cmd</source>
         <translation>སྒུལ་བྱེད་སྐུལ་སློང་བཀའ་རྒྱ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
         <source>Driver Modules</source>
         <translation>སྒུལ་བྱེད་དཔེ་དུམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
         <source>Driver Status</source>
         <translation>སྒུལ་བྱེད་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
         <source>Driver Version</source>
         <translation>སྒུལ་བྱེད་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
         <source>Duplex</source>
         <translation>གོ་ཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
         <source>EGL client APIs</source>
         <translation>EGLམཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
         <source>EGL version</source>
         <translation>EGLཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
         <source>energy</source>
         <translation>ཤོང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
         <source>energy-empty</source>
         <translation>ཤོང་ཚད་ཆུང་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
         <source>energy-full</source>
         <translation>ཤོང་ཚད་ཡོངས་རྫོགས་གསོག་ཟིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
         <source>energy-full-design</source>
         <translation>ཤོང་ཚད་ཇུས་འགོད་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
         <source>energy-rate</source>
         <translation>ནུས་ཚད་སྟུག་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
         <source>Error Correction Type</source>
         <translation>ནོར་བཅོས་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
         <source>Error Information Handle</source>
         <translation>ནོར་འཁྲུལ་ཆ་འཕྲིན་གྱི་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
         <source>Extensions</source>
         <translation>རྒྱ་སྐྱེད་བཀའ་འདུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
         <source>Family</source>
         <translation>ཁྱིམ་རྒྱུད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
         <source>Features</source>
         <translation>ཁྱད་ཆོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
         <source>Firmware</source>
         <translation>བརྟན་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
         <source>Firmware Revision</source>
         <translation>བརྟན་ཆས་བཟོ་བཅོས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
         <source>Firmware Version</source>
         <translation>བརྟན་ཆས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
         <source>Flags</source>
         <translation>ཁྱད་གཤིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
         <source>Form Factor</source>
         <translation>ཚད་གཞི་བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
         <source>GDDR capacity</source>
         <translation>GDDRཤོང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
         <source>Geometry (Logical)</source>
         <translation>དབྱིབས་རྩིས་གཞི་གྲངས།（གཏན་ཚིགས།）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
         <source>GLSL version</source>
         <translation>GLSLཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
         <source>GL version</source>
         <translation>GLཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
         <source>GPU type</source>
         <translation>GPUརིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
         <source>GPU vendor</source>
         <translation>GPUའདོན་སྤྲོད་བྱེད་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
         <source>Graphics Memory</source>
         <translation>འཆར་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
         <source>guid</source>
         <translation>ཁྱོན་ཡོངས་ཀྱི་མཚོན་རྟགས་གཅིག་པུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
         <source>Handlers</source>
         <translation>ཐག་གཅོད་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
         <source>Hardware Class</source>
         <translation>བརྟན་ཆས་རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
         <source>has history</source>
         <translation>ལོ་རྒྱུས་ཟིན་ཐོ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
         <source>has statistics</source>
         <translation>གློག་སྤྱོད་སྡོམ་རྩིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
         <source>HCI Version</source>
         <translation>HCIཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
         <source>Height</source>
         <translation>མཐོ་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
         <source>icon-name</source>
         <translation>རྟགས་རིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
         <source>Input/Output</source>
         <translation>ནང་འཇུག/ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
         <source>Installable Languages</source>
         <translation>སྒྲིག་སྦྱོར་བྱ་རུང་བའི་སྐད་བརྡའི་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
         <source>Interface</source>
         <translation>མཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
         <source>Interface Type</source>
         <translation>མཐུད་སྣེའི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
         <source>ioport</source>
         <translation>I/Oམཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
         <source>IO Port</source>
         <translation>I/Oམཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
         <source>IP</source>
         <translation>IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
         <source>IRQ</source>
         <translation>ཆད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
         <source>job-cancel-after</source>
         <translation>དེའི་སྐབས་སུ་པར་འདེབས་ལས་འགན་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
         <source>job-hold-until</source>
         <translation>བར་པར་འདེབས་ལས་འགན་སོར་བཞག་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
         <source>job-priority</source>
         <translation>ལས་འགན་གྱི་སྔོན་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
         <source>KernelModeDriver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
         <source>L1d Cache</source>
         <translation>L1ཤོང་གསོག（གཞི་གྲངས།）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
         <source>L1i Cache</source>
         <translation>L1ཤོང་གསོག（བཀའ།）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
         <source>L2 Cache</source>
         <translation>L2ཤོང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
         <source>L3 Cache</source>
         <translation>L3ཤོང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
         <source>L4 Cache</source>
         <translation>L2ཤོང་གསོག {4 ?}</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
         <source>Language Description Format</source>
         <translation>སྐད་བརྡ་ཞིབ་བརྗོད་རྣམ་བཞག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
         <source>latency</source>
         <translation>ནར་འགྱངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
         <source>Latency</source>
         <translation>ནར་འགྱངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
         <source>lid-is-closed</source>
         <translation>ལག་ཁྱེར་གློག་ཀླད་ཁ་རྒྱག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
         <source>lid-is-present</source>
         <translation>ལག་ཁྱེར་གློག་ཀླད་ཁ་ཕྱེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
         <source>Link</source>
         <translation>སྦྲེལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
         <source>Link mode</source>
         <translation>སྦྲེལ་མཐུད་དཔེ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
         <source>Link policy</source>
         <translation>སྦྲེལ་མཐུད་དྲིད་ཇུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
         <source>LMP Version</source>
         <translation>LMPཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
         <source>Location</source>
         <translation>གནས་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
         <source>Location In Chassis</source>
         <translation>འཁོར་སྒམ་ནང་གི་སྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
         <source>Locator</source>
         <translation>འཇུག་ཤུར།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
         <source>Lock</source>
         <translation>སྒོ་ལྕག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
         <source>logical name</source>
         <translation>གཏན་ཚིགས་སྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
         <source>Logical Name</source>
         <translation>གཏན་ཚིགས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
         <source>logicalsectorsize</source>
         <translation>གཏན་ཚིགས་ཁུལ་དབྱེའི་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
         <source>Logical Size</source>
         <translation>གཏན་ཚིགས་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
         <source>MAC Address</source>
         <translation>MACསྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
         <source>marker-change-time</source>
         <translation>མཚོན་རྟགས་བཅོས་པའི་ཐེངས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Max Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
         <source>Maximum Capacity</source>
         <translation>ཤོང་ཚད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
         <source>Maximum Current</source>
         <translation>གློག་རྒྱུན་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
         <source>Maximum Power</source>
         <translation>ནུས་ཆོད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
         <source>Maximum Rate</source>
         <translation>མྱུར་ཚད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
         <source>Maximum Resolution</source>
         <translation>འབྱེད་ཕྱོད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
         <source>Maximum Voltage</source>
         <translation>གློག་གནོན་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Media Type</source>
         <translation>བར་རྫས་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
         <source>Memory</source>
         <translation>ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
         <source>Memory Address</source>
         <translation>ནང་གསོག་བྱེད་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
         <source>Memory Operating Mode Capability</source>
         <translation>ནང་གསོག་བཀོལ་སྤྱོད་དཔེ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ནང་གསོག་མ་ལག་ཡན་ལག་གྱི་ཚོད་འཛིན་ཆས་བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ནང་གསོག་མ་ལག་ཡན་ལག་གྱི་ཚོད་འཛིན་ཆས་ཐོན་རྫས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
         <source>Memory Technology</source>
         <translation>ནང་གསོག་ལག་རྩལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
         <source>Minimum Resolution</source>
         <translation>འབྱེད་ཕྱོད་ཆུང་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
         <source>Minimum Voltage</source>
         <translation>གློག་གནོན་ཆུང་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
         <source>Modalias</source>
         <translation>བཀའི་མིང་གཞན་སྒྲིག་བཀོད་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
         <source>Module Alias</source>
         <translation>དཔེ་དུམ་གྱི་མིང་གཞན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
         <source>Module Manufacturer ID</source>
         <translation>ལྷུ་ཆས་བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
         <source>Module Product ID</source>
         <translation>ལྷུ་ཆས་ཐོན་རྫས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
         <source>Multicast</source>
         <translation>མང་བསྒྲགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
         <source>native-path</source>
         <translation>སྒྲིག་སྦྱོར་ཐབས་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
         <source>Negotiation Rate</source>
         <translation>གྲོས་མཐུན་མྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
         <source>network</source>
         <translation>དྲ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
         <source>Non-Volatile Size</source>
         <translation>བོར་མི་སླ་བའི་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
         <source>Number Of Devices</source>
         <translation>གཱ་འཇུག་སའི་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
         <source>Number Of Power Cords</source>
         <translation>གློག་ཁུངས་སྐུད་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
         <source>number-up</source>
         <translation>སྒྲིག་ཨང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
         <source>OEM Information</source>
         <translation>OEMཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
         <source>on-battery</source>
         <translation>གློག་རྫས་སྤྱོད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
         <source>online</source>
         <translation>སྐུད་ཐོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
         <source>orientation-requested</source>
         <translation>པར་འདེབས་ཕྱོགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
         <source>Packet type</source>
         <translation>གཞི་གྲངས་ཁུག་གི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
         <source>Pairable</source>
         <translation>ཆ་འགྲིག་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
         <source>Part Number</source>
         <translation>ལྷུ་ཆས་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
         <source>percentage</source>
         <translation>གློག་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
         <source>physical id</source>
         <translation>དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
         <source>Physical ID</source>
         <translation>དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
         <source>Physical Memory Array</source>
         <translation>ནང་གསོག་འཇུག་ཤུར་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
         <source>Port</source>
         <translation>མཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
         <source>Powered</source>
         <translation>གློག་འདོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
         <source>power supply</source>
         <translation>གློག་འདོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
         <source>Power Supply State</source>
         <translation>གློག་འདོན་པའི་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
         <source>Primary Monitor</source>
         <translation>འཆར་ཆས་གཙོ་བོ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
         <source>print-color-mode</source>
         <translation>ཚོས་གཞི་དཔེ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
         <source>printer-is-accepting-jobs</source>
         <translation>མིག་སྔར་པར་འདེབས་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
         <source>printer-is-shared</source>
         <translation>པར་འདེབས་ཆས་མཉམ་སྤྱོད་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
         <source>printer-is-temporary</source>
         <translation>གནས་སྐབས་པར་འདེབས་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
         <source>printer-make-and-model</source>
         <translation>བཟོ་མཁན་དང་བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
         <source>printer-state-change-time</source>
         <translation>པར་འདེབས་ཆས་ཀྱི་ངང་ཚུལ་བཅོས་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
         <source>printer-state-reasons</source>
         <translation>པར་འདེབས་ཆས་ཀྱི་ངང་ཚུལ་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
         <source>printer-type</source>
         <translation>པར་འདེབས་ཆས་ཀྱི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
         <source>printer-uri-supported</source>
         <translation>རྒྱབ་སྐྱོར་བྱེད་པའི་URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
         <source>product</source>
         <translation>ཐོན་རྫས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
         <source>Product Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
         <source>Product Name</source>
         <translation>ཐོན་རྫས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
         <source>Rank</source>
         <translation>གནས་སྟར།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
         <source>rechargeable</source>
         <translation>གློག་བསྐྱར་གསོག་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Refresh Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
         <source>Release date</source>
         <translation>ཁྱབ་བསྒྲགས་བྱས་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>Release Date</source>
         <translation>ཡོངས་བསྒྲགས་བྱེད་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Revision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>ROM Size</source>
         <translation>ROMཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>Rotation Rate</source>
         <translation>སྐོར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Runtime Size</source>
         <translation>འཁོར་རྒྱུག་ནང་གསོག་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
         <source>SBDS Chemistry</source>
         <translation>SBDSརྒྱུ་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>SBDS Manufacture Date</source>
         <translation>SBDSབཟོ་བའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>SBDS Serial Number</source>
         <translation>SBDSརིམ་སྟར་ཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>SBDS Version</source>
         <translation>SBDSཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>sectorsize</source>
         <translation>གཡབ་ཁུལ་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>Security Status</source>
         <translation>བདེ་འཇགས་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>Serial ID</source>
         <translation>རིམ་སྟར་ཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>Serial Number</source>
         <translation>རིམ་སྟར་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>Service Classes</source>
         <translation>ཞབས་ཞུའི་རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Set</source>
         <translation>སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>Shared</source>
         <translation>མཉམ་སྤྱོད་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>sides</source>
         <translation>པར་འདེབས་ངོས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Size</source>
         <translation>ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>SKU Number</source>
         <translation>SKUཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>Slot</source>
         <translation>འཇུག་ཤུར།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOSཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>state</source>
         <translation>ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>status</source>
         <translation>ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Status</source>
         <translation>ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Stepping</source>
         <translation>གོམ་བགྲོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>SubDevice</source>
         <translation>སྒྲིག་ཆས་ཡན་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>SubVendor</source>
         <translation>བཟོ་མཁན་ཡན་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Subversion</source>
         <translation>པར་གཞི་ཡན་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Support Resolution</source>
         <translation>རྒྱབ་སྐྱོར་ཐུབ་པའི་འབྱེད་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>SysFS_Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>System Information</source>
         <translation>མ་ལག་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>technology</source>
         <translation>གློག་རྫས་ལག་རྩལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Temperature</source>
         <translation>དྲོད་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Thermal State</source>
         <translation>དྲོད་འཐོར་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>Threads</source>
         <translation>སྐུད་རིམ་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Total Width</source>
         <translation>སྤྱིའི་ཞེང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Type</source>
         <translation>རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>Type Detail</source>
         <translation>རིགས་གྲས་ཞིབ་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>updated</source>
         <translation>གསར་སྒྱུར་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>Virtualization</source>
         <translation>རྟོག་བཟོ་ཅན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Volatile Size</source>
         <translation>བོར་སླ་བའི་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>voltage</source>
         <translation>གློག་གནོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>Voltage</source>
         <translation>གློག་གནོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Wake-up Type</source>
         <translation>གཉིད་སད་པའི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>warning-level</source>
         <translation>ཉེན་བརྡའི་བང་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>battery</source>
         <translation>གློག་རྫས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>inch</source>
         <translation>དབྱིན་ཚུན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Speed</source>
         <translation>ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Max Boost Clock</source>
         <translation>མཐོ་ཤོག་མགྱོགས་སྐྱེད་ཀླད་ཀོར</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>Unknown</source>
         <translation>མི་ཤེས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>SSD</source>
         <translation>འཇགས་གཟུགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>HDD</source>
         <translation>འཕྲུལ་འཁོར།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
@@ -1854,47 +1854,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1282"/>
         <source>Model Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1286"/>
         <source>Vendor ID</source>
         <translation>བཟོ་བྱེད་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
         <source>Architecture</source>
         <translation>གཞི་སྒྲོམ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
-        <source>Core(s)</source>
-        <translation>རིག་རྟགས་འཕྲུལ་འཁོར།</translation>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1294"/>
+        <source>CPU(s)</source>
+        <translation>འཚར་ལོན་སྒྲིག་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1296"/>
         <source>Thread(s)</source>
         <translation>སྙིང་རྫས་རེའི་ཐིག་སྒྲོན་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1305"/>
         <source>L1d cache</source>
         <translation>L1 གཏོགས་ཁང་ (གཞི་གྲངས)</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1315"/>
         <source>L1i cache</source>
         <translation>L1 གཏོགས་ཁང་ (བཀའ་རིན)</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1325"/>
         <source>L2 cache</source>
         <translation>L2 གཏོགས་ཁང་</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1335"/>
         <source>L3 cache</source>
         <translation>L3 གཏོགས་ཁང་</translation>
     </message>
@@ -2586,48 +2586,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Storage</source>
         <translation>གསོག་འཇོག་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Memory</source>
         <translation>ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Monitor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="211"/>
         <source>Failed to enable the device</source>
         <translation>འགོ་སློང་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="214"/>
         <source>Failed to disable the device</source>
         <translation>སྤྱོད་མི་ཆོག་པ་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="219"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>སྒྲིག་ཆས་ཀྱི་རིམ་ཨང་ཐོབ་ཐབས་མི་འདུག་པས་སྤྱོད་མི་རུང་བ་ཐུབ་མ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="241"/>
         <source>Update Drivers</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="259"/>
         <source>Uninstall Drivers</source>
         <translation>སྐུལ་བྱེད་བཤིག་པ།</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
@@ -92,1411 +92,1411 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="964"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
         <source>Core(s)</source>
         <translation>يادرو</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="965"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Processor</source>
         <translation>بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="966"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
         <source>Address</source>
         <translation>ئادرېس</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
         <source>Alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
         <source>ansiversion</source>
         <translation>ANSI نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
         <source>Application</source>
         <translation>ئىلتىماس</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Architecture</source>
         <translation>قۇرۇلما</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
         <source>Array Handle</source>
         <translation>گورۇپپا پىروگرامما</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
         <source>Asset Tag</source>
         <translation>مۈلۈك بەلگىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
         <source>Auto Negotiation</source>
         <translation>ئاپتوماتىك سۆھبەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
         <source>Bank Locator</source>
         <translation>سىغم بەلگىلىگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
         <source>Base Board Information</source>
         <translation>ئانا تاختا ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
         <source>BD Address</source>
         <translation>BD ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
         <source>BIOS Information</source>
         <translation>BIOS ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
         <source>BIOS Revision</source>
         <translation>BIOS تۈزىتىلگەن نۇسخىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
         <source>Board name</source>
         <translation>مۇدىرىيەت ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
         <source>Boot-up State</source>
         <translation>قوزغىتىش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
         <source>Broadcast</source>
         <translation>رادىيو</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
         <source>Bus</source>
         <translation>ئومۇمىي لىنىيە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
         <source>bus info</source>
         <translation>باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
         <source>Bus Info</source>
         <translation>باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
         <source>Cache Size</source>
         <translation>ساقلانما سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
         <source>Capabilities</source>
         <translation>ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
         <source>Capacity</source>
         <translation>سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
         <source>Characteristics</source>
         <translation>ئالاھىدىلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
         <source>Chassis Handle</source>
         <translation>ئاساسىي ماشىنا ساندۇقى پىروگراممىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
         <source>Chassis Information</source>
         <translation>تەگلىك ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
         <source>Chip</source>
         <translation>ئۆزەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
         <source>Chipset</source>
         <translation>ئۆزەك گورۇپىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
         <source>Class</source>
         <translation>تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
         <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
         <source>Config Status</source>
         <translation>ھالەتنى تەڭشەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
         <source>Configured Speed</source>
         <translation>تەڭشەلگەن سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
         <source>Configured Voltage</source>
         <translation>تەڭشەلگەن توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
         <source>Contained Elements</source>
         <translation>ئۆز ئىچىگە ئېلىنغان ئېلمىنىتلار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
         <source>Contained Object Handles</source>
         <translation>مەزمۇننى ئۆز ئىچىگە ئالغان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
         <source>copies</source>
         <translation>نۇسخىلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
         <source>Core ID</source>
         <translation>يادرولۇق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
         <source>CPU architecture</source>
         <translation>بىر تەرەپ قىلغۇچ قۇرۇلمىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
         <source>CPU Family</source>
         <translation>بىر تەرەپ قىلغۇچ ئائىلىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
         <source>CPU ID</source>
         <translation>بىر تەرەپ قىلغۇچ كىملىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
         <source>CPU implementer</source>
         <translation>بىر تەرەپ قىلغۇچ پىروگراممىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
         <source>CPU part</source>
         <translation>بىر تەرەپ قىلغۇچ قىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
         <source>CPU revision</source>
         <translation>بىر تەرەپ قىلغۇچ تۈزىتىلگەن نۇسخىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
         <source>CPU variant</source>
         <translation>مەركىزى بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
         <source>critical-action</source>
         <translation>توك بەك ئاز قالغاندا ئىجرا بولسۇن</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
         <source>Currently Installed Language</source>
         <translation>ھازىر قاچىلانغان تىل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
         <source>Current Resolution</source>
         <translation>نۆۋەتتىكى قارار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
         <source>daemon-version</source>
         <translation>Daemon نەشىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
         <source>Data Width</source>
         <translation>سان-سىپېر چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
         <source>Date</source>
         <translation>چېسلا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
         <source>description</source>
         <translation>چۈشەندۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
         <source>Description</source>
         <translation>چۈشەندۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
         <source>Design Capacity</source>
         <translation>لايىھەلەنگەن ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
         <source>Design Voltage</source>
         <translation>لايىھەنگەن بېسىم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
         <source>Device</source>
         <translation>ئۈسكۈنە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
         <source>Device Class</source>
         <translation>ئۈسكۈنە سىنىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
         <source>Device File</source>
         <translation>ئۈسكۈنە ھۆججىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
         <source>Device Files</source>
         <translation>ئۈسكۈنە ھۆججەتلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
         <source>Device Name</source>
         <translation>ئۈسكۈنىنىڭ ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
         <source>Device Number</source>
         <translation>ئۈسكۈنە نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
         <source>Discoverable</source>
         <translation>بايقاشقا بولىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
         <source>Discovering</source>
         <translation>ئىزدەۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
         <source>Display Input</source>
         <translation>كىرگۈزۈشنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
         <source>Display Output</source>
         <translation>چىقىرىشنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
         <source>Display Ratio</source>
         <translation>كۆرسىتىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
         <source>Driver</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
         <source>Driver Activation Cmd</source>
         <translation>قوزغاتقۇچ ئاكتىپلاش بۇيرۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
         <source>Driver Modules</source>
         <translation>قوزغاتقۇچ مودۇلى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
         <source>Driver Status</source>
         <translation>قوزغاتقۇ ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
         <source>Driver Version</source>
         <translation>قوزغاتقۇچ نەشىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
         <source>Duplex</source>
         <translation>قوش ئىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
         <source>EGL client APIs</source>
         <translation>EGL خېرىدار API لىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
         <source>EGL version</source>
         <translation>EGL نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
         <source>energy</source>
         <translation>ئېنېرگىيە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
         <source>energy-empty</source>
         <translation>ئېنېرگىيەسىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
         <source>energy-full</source>
         <translation>ئېنېرگىيە تولۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
         <source>energy-full-design</source>
         <translation>ئېنېرگىيە تولۇق لايىھىلەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
         <source>energy-rate</source>
         <translation>ئېنېرگىيە نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
         <source>Error Correction Type</source>
         <translation>خاتالىق تۈزىتىش تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
         <source>Error Information Handle</source>
         <translation>خاتالىق ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
         <source>Extensions</source>
         <translation>كېڭەيتىلمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
         <source>Family</source>
         <translation>ئائىلە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
         <source>Features</source>
         <translation>خاسلىقلار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
         <source>Firmware</source>
         <translation>قۇيما ماتېرىيال</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
         <source>Firmware Revision</source>
         <translation>زاپچاس يامىقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
         <source>Firmware Version</source>
         <translation>يۇمشاق دېتال نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
         <source>Flags</source>
         <translation>بايراق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
         <source>Form Factor</source>
         <translation>سىغىم شەكلى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
         <source>GDDR capacity</source>
         <translation>GDDR سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
         <source>Geometry (Logical)</source>
         <translation>گېئومېتىرىيە (لوگىكىلىق)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
         <source>GLSL version</source>
         <translation>GLSL نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
         <source>GL version</source>
         <translation>GL نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
         <source>GPU type</source>
         <translation>GPU تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
         <source>GPU vendor</source>
         <translation>GPU ساتقۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
         <source>Graphics Memory</source>
         <translation>گرافىك ئەستە ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
         <source>guid</source>
         <translation>كۆرسەتمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
         <source>Handlers</source>
         <translation>بېجىرگۈچىلەر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
         <source>Hardware Class</source>
         <translation>قاتتىق دېتال سىنىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
         <source>has history</source>
         <translation>خاتىرە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
         <source>has statistics</source>
         <translation>ئىستاتىستىكا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
         <source>HCI Version</source>
         <translation>HCI نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
         <source>Height</source>
         <translation>ئېگىزلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
         <source>icon-name</source>
         <translation>سىنبەلگە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
         <source>Input/Output</source>
         <translation>كىرگۈزۈش / چىقىرىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
         <source>Installable Languages</source>
         <translation>قاچىلىغىلى بولىدىغان تىللار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
         <source>Interface</source>
         <translation>كۆرۈنمە يۈزى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
         <source>Interface Type</source>
         <translation>كۆرۈنمە يۈزى تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
         <source>ioport</source>
         <translation>I/O ئېغىزى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
         <source>IO Port</source>
         <translation>I/O ئېغىزى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
         <source>IP</source>
         <translation>IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
         <source>IRQ</source>
         <translation>ئۈزۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
         <source>job-cancel-after</source>
         <translation>خىزمەتنى ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
         <source>job-hold-until</source>
         <translation>خىزمەتنى تۇتۇش بۆلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
         <source>job-priority</source>
         <translation>خىزمەت تەرتىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
         <source>KernelModeDriver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
         <source>L1d Cache</source>
         <translation>L1d غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
         <source>L1i Cache</source>
         <translation>L1i غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
         <source>L2 Cache</source>
         <translation>L2 غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
         <source>L3 Cache</source>
         <translation>L3 غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
         <source>L4 Cache</source>
         <translation>L2 غەملەك {4 ?}</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
         <source>Language Description Format</source>
         <translation>تىل چۈشەندۈرۈش فورماتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
         <source>latency</source>
         <translation>كېچىكىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
         <source>Latency</source>
         <translation>كېچىكتۈرمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
         <source>lid-is-closed</source>
         <translation>قاپاق تاقالغان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
         <source>lid-is-present</source>
         <translation>لەپتوپنى ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
         <source>Link</source>
         <translation>ئۇلىنىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
         <source>Link mode</source>
         <translation>ئۇلىنىش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
         <source>Link policy</source>
         <translation>ئۇلىنىش سىياسىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
         <source>LMP Version</source>
         <translation>LMP نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
         <source>Location</source>
         <translation>ئورنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
         <source>Location In Chassis</source>
         <translation>تەگلىك ئورنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
         <source>Locator</source>
         <translation>ئورۇن بەلگىلىگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
         <source>Lock</source>
         <translation>قۇلۇپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
         <source>logical name</source>
         <translation>لوگىكىلىق ئىسىم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
         <source>Logical Name</source>
         <translation>لوگىكىلىق ئىسىم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
         <source>logicalsectorsize</source>
         <translation>لوگىكىلىق سېكتور چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
         <source>Logical Size</source>
         <translation>لوگىكىلىق چوڭلۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
         <source>MAC Address</source>
         <translation>MAC ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
         <source>marker-change-time</source>
         <translation>ئۆزگەرتىش سانىغا بەلگە سېلىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Max Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
         <source>Maximum Capacity</source>
         <translation>ئەڭ چوڭ سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
         <source>Maximum Current</source>
         <translation>ئەڭ چوڭ توك ئېقىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
         <source>Maximum Power</source>
         <translation>ئەڭ چوڭ قۇۋۋەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
         <source>Maximum Rate</source>
         <translation>ئەڭ چوڭ تېزلىنىشى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
         <source>Maximum Resolution</source>
         <translation>ئەڭ چوڭ ئېنىقلىق دەرىجىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
         <source>Maximum Voltage</source>
         <translation>ئەڭ چوڭ توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Media Type</source>
         <translation>مېدىيا تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
         <source>Memory</source>
         <translation>ساقلىغۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
         <source>Memory Address</source>
         <translation>ئىچكى ساقلىغۇچ ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
         <source>Memory Operating Mode Capability</source>
         <translation>ئىچكى ساقلىغۇچ مەشغۇلات ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ئىچكى ساقلىغۇچ سىستېمىسى كونتروللىغۇچ ئىشلەپچىقارغۇچى كىملىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ئىچكى ساقلىغۇچ سىستېمىسى كونتروللىغۇچ مەھسۇلات IDسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
         <source>Memory Technology</source>
         <translation>ئىچكى ساقلىغۇچ تېخنىكىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
         <source>Minimum Resolution</source>
         <translation>ئەڭ تۆۋەن ئېنىقلىق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
         <source>Minimum Voltage</source>
         <translation>ئەڭ تۆۋەن توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
         <source>Modalias</source>
         <translation>بۇيرۇققا باشقا نام بەلگىلەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
         <source>Module Alias</source>
         <translation>مودېلنىڭ باشقا نامى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
         <source>Module Manufacturer ID</source>
         <translation>مودېل ئىشلەپچىقارغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
         <source>Module Product ID</source>
         <translation>IDمودۇل مەھسۇلات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
         <source>Multicast</source>
         <translation>قويغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
         <source>native-path</source>
         <translation>قاچىلاش ئورنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
         <source>Negotiation Rate</source>
         <translation>كېڭىشىش تېزلىك نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
         <source>network</source>
         <translation>تور</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
         <source>Non-Volatile Size</source>
         <translation>تۇراقسىز چوڭلۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
         <source>Number Of Devices</source>
         <translation>ئۈسكۈنىلەرنىڭ سانى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
         <source>Number Of Power Cords</source>
         <translation>توك سىمىنىڭ سانى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
         <source>number-up</source>
         <translation>تەريىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
         <source>OEM Information</source>
         <translation>OEM ئۇچۇرلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
         <source>on-battery</source>
         <translation>باتارېيەدە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
         <source>online</source>
         <translation>توردا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
         <source>orientation-requested</source>
         <translation>يۆنىلىش تەلەپ قىلىنغان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
         <source>Packet type</source>
         <translation>بولاق تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
         <source>Pairable</source>
         <translation>مۇۋاپىق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
         <source>Part Number</source>
         <translation>بۆلەك نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
         <source>percentage</source>
         <translation>پىرسەنت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
         <source>physical id</source>
         <translation>فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
         <source>Physical ID</source>
         <translation>فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
         <source>Physical Memory Array</source>
         <translation>فىزىكىلىق ساقلىغۇچ گورۇپىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
         <source>Port</source>
         <translation>پورت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
         <source>Powered</source>
         <translation>تۆھپىكار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
         <source>power supply</source>
         <translation>توك بىلەن تەمىنلەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
         <source>Power Supply State</source>
         <translation>توك بىلەن تەمىنلەش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
         <source>Primary Monitor</source>
         <translation>دەسلەپكى كۆزەتكۈ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
         <source>print-color-mode</source>
         <translation>رەڭلىك بىسىش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
         <source>printer-is-accepting-jobs</source>
         <translation>نۆۋەتتە باسقىلى بولىدىغىنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
         <source>printer-is-shared</source>
         <translation>پىرىنتېر ئورتاقلاندى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
         <source>printer-is-temporary</source>
         <translation>ۋاقىتلىق پىرىنتېر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
         <source>printer-make-and-model</source>
         <translation>پىرىنتېر ياسىغۇچى ۋە تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
         <source>printer-state-change-time</source>
         <translation>بېسىش ھالىتىنى ئۆزگەرتكەن ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
         <source>printer-state-reasons</source>
         <translation>بېسىش ھالىتى ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
         <source>printer-type</source>
         <translation>پرىنتېر تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
         <source>printer-uri-supported</source>
         <translation>URI نى قوللايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
         <source>product</source>
         <translation>مەھسۇلات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
         <source>Product Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
         <source>Product Name</source>
         <translation>مەھسۇلات ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
         <source>Rank</source>
         <translation>رەت تەرتىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
         <source>rechargeable</source>
         <translation>توك قاچىلىغىلى بولىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Refresh Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
         <source>Release date</source>
         <translation>ئېلان قىلىنغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>Release Date</source>
         <translation>ئېلان قىلىنغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Revision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>ROM Size</source>
         <translation>ROM سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>Rotation Rate</source>
         <translation>ئايلىنىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Runtime Size</source>
         <translation>ئىجرا ۋاقتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
         <source>SBDS Chemistry</source>
         <translation>SBDS ماتېرىيالى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>SBDS Manufacture Date</source>
         <translation>SBDS ئىشلەپچىقىرىش ۋاقتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>SBDS Serial Number</source>
         <translation>SBDS تەرتىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>SBDS Version</source>
         <translation>SBDS نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>sectorsize</source>
         <translation>ساھە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>Security Status</source>
         <translation>بىخەتەرلىك ھالەتلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>Serial ID</source>
         <translation>تەرتىپ نومۇر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>Serial Number</source>
         <translation>تەرتىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>Service Classes</source>
         <translation>مۇلازىمەت دەرسلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Set</source>
         <translation>بېكىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>Shared</source>
         <translation>ئورتاقلاشقان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>sides</source>
         <translation>يان تەرەپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Size</source>
         <translation>چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>SKU Number</source>
         <translation>SKU نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>Slot</source>
         <translation>ئوقۇر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>state</source>
         <translation>ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>status</source>
         <translation>ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Status</source>
         <translation>ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Stepping</source>
         <translation>قەدەم بېسىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>SubDevice</source>
         <translation>قوشۇمچى ئۈسكىنە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>SubVendor</source>
         <translation>قوشۇمچە ساتقۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Subversion</source>
         <translation>قوشۇمچە نەشىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Support Resolution</source>
         <translation>قوللاش قارارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>SysFS_Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>System Information</source>
         <translation>سىستېما ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>technology</source>
         <translation>باتارىيە تېخنىكىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Temperature</source>
         <translation>تېمپېراتۇرا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Thermal State</source>
         <translation>قىززىق ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>Threads</source>
         <translation>تېما</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Total Width</source>
         <translation>ئومۇمىي كەڭلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Type</source>
         <translation>تىپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>Type Detail</source>
         <translation>تەپسىلات تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>updated</source>
         <translation>يېڭىلاندى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Vendor</source>
         <translation>ساتقۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>Virtualization</source>
         <translation>مەۋھۇملاشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Volatile Size</source>
         <translation>ئۆزگىرىشچان چوڭلۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>voltage</source>
         <translation>توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>Voltage</source>
         <translation>توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Wake-up Type</source>
         <translation>ئويغىنىش تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>warning-level</source>
         <translation>ئاگاھلاندۇرۇش دەرىجىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>battery</source>
         <translation>باتارېيە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>inch</source>
         <translation>ئىنگىلىزچىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Speed</source>
         <translation>سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Max Boost Clock</source>
         <translation>ماكسىمۇل تېزلەشتىش ۋاقىت چاستوتىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>Unknown</source>
         <translation>نامەلۇم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>SSD</source>
         <translation>قاسقا ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>HDD</source>
         <translation>ماشىنا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
         <source>Model</source>
         <translation>مودىل</translation>
     </message>
@@ -1853,47 +1853,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1282"/>
         <source>Model Name</source>
         <translation>نامى</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1286"/>
         <source>Vendor ID</source>
         <translation>ئىشلەپچىقارغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
         <source>Architecture</source>
         <translation>قۇرۇلما</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
-        <source>Core(s)</source>
-        <translation>مەنتىقىي پىروتسېسسور</translation>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1294"/>
+        <source>CPU(s)</source>
+        <translation>مەنتىقىي پىروتسېسور</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1296"/>
         <source>Thread(s)</source>
         <translation>ھەر يادرو خېتى سانى</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1305"/>
         <source>L1d cache</source>
         <translation>كېش (سانلىق) L1</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1315"/>
         <source>L1i cache</source>
         <translation>كېش (بۇيرۇق) L1</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1325"/>
         <source>L2 cache</source>
         <translation>كېش L2</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1335"/>
         <source>L3 cache</source>
         <translation>كېش L3</translation>
     </message>
@@ -2585,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Storage</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Memory</source>
         <translation>ساقلىغۇ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Monitor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="211"/>
         <source>Failed to enable the device</source>
         <translation>ئۈسكۈنىنى قوزغىتىش مەغلۇب بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="214"/>
         <source>Failed to disable the device</source>
         <translation>ئۈسكۈنىنى چەكلىيەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="219"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>ئۈسكۈنە تەرتىپ نومۇرىنى ئئالالمىدى، چەكلەش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="241"/>
         <source>Update Drivers</source>
         <translation>يېڭىلاش دىرىۋېرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="259"/>
         <source>Uninstall Drivers</source>
         <translation>قوزغاتقۇچنى چىقىرۋىتىش</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
@@ -92,1411 +92,1411 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
         <source>Device Name</source>
         <translation>设备名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
         <source>Chip</source>
         <translation>芯片</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>SysFS_Path</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Revision</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
         <source>KernelModeDriver</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
         <source>IRQ</source>
         <translation>中断</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
         <source>Chipset</source>
         <translation>芯片组</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
         <source>Module Alias</source>
         <translation>模块别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
         <source>Driver</source>
         <translation>驱动</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
         <source>Driver Version</source>
         <translation>驱动版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
         <source>logical name</source>
         <translation>逻辑名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
         <source>Logical Name</source>
         <translation>逻辑名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
         <source>MAC Address</source>
         <translation>物理地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
         <source>CPU ID</source>
         <translation>处理器ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
         <source>Core ID</source>
         <translation>核心ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>Threads</source>
         <translation>线程数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
         <source>BogoMIPS</source>
         <translation>运行速度（Bogomips）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Architecture</source>
         <translation>架构</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
         <source>CPU Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="965"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Processor</source>
         <translation>逻辑处理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="964"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>Virtualization</source>
         <translation>虚拟化</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
         <source>Flags</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
         <source>Extensions</source>
         <translation>扩展指令集</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
         <source>L3 Cache</source>
         <translation>L3缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
         <source>L4 Cache</source>
         <translation>L4缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
         <source>L2 Cache</source>
         <translation>L2缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
         <source>L1i Cache</source>
         <translation>L1缓存（指令）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
         <source>L1d Cache</source>
         <translation>L1缓存（数据）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Stepping</source>
         <translation>步进</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Frequency</source>
         <translation>频率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Max Frequency</source>
         <translation>最大频率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
         <source>Graphics Memory</source>
         <translation>显存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
         <source>Memory Address</source>
         <translation>内存地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
         <source>IO Port</source>
         <translation>I/O端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
         <source>Maximum Resolution</source>
         <translation>最大分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
         <source>Minimum Resolution</source>
         <translation>最小分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>Type Detail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
         <source>Display Output</source>
         <translation>显示输出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
         <source>Interface</source>
         <translation>接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
         <source>Bus Info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
         <source>bus info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
         <source>Maximum Current</source>
         <translation>最大电流</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Total Width</source>
         <translation>总位宽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
         <source>Locator</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
         <source>Configured Voltage</source>
         <translation>配置电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
         <source>Maximum Voltage</source>
         <translation>最高电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
         <source>Minimum Voltage</source>
         <translation>最低电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
         <source>Configured Speed</source>
         <translation>配置速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
         <source>Data Width</source>
         <translation>数据位宽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
         <source>Display Input</source>
         <translation>显示输入</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
         <source>Interface Type</source>
         <translation>接口类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Support Resolution</source>
         <translation>支持分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
         <source>Current Resolution</source>
         <translation>当前分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Refresh Rate</source>
         <translation>刷新率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
         <source>Display Ratio</source>
         <translation>显示比例</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
         <source>Primary Monitor</source>
         <translation>主显示器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
         <source>Maximum Rate</source>
         <translation>最大速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
         <source>Negotiation Rate</source>
         <translation>协商速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
         <source>Port</source>
         <translation>端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
         <source>Multicast</source>
         <translation>组播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
         <source>Link</source>
         <translation>连接</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
         <source>Latency</source>
         <translation>延迟</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
         <source>IP</source>
         <translation>IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
         <source>Firmware</source>
         <translation>固件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
         <source>Duplex</source>
         <translation>双工</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
         <source>Broadcast</source>
         <translation>广播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
         <source>Auto Negotiation</source>
         <translation>自动协商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
         <source>Input/Output</source>
         <translation>输入/输出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
         <source>Capacity</source>
         <translation>最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>Voltage</source>
         <translation>电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>Slot</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
         <source>Design Capacity</source>
         <translation>设计容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
         <source>Design Voltage</source>
         <translation>设计电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>SBDS Version</source>
         <translation>SBDS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>SBDS Serial Number</source>
         <translation>SBDS序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>SBDS Manufacture Date</source>
         <translation>SBDS制造日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
         <source>SBDS Chemistry</source>
         <translation>SBDS材料</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Temperature</source>
         <translation>温度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>Shared</source>
         <translation>已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Media Type</source>
         <translation>介质类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
         <source>Firmware Version</source>
         <translation>固件版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>Serial Number</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>Rotation Rate</source>
         <translation>转速</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>SubVendor</source>
         <translation>子制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>SubDevice</source>
         <translation>子设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
         <source>Driver Status</source>
         <translation>驱动状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
         <source>Config Status</source>
         <translation>配置状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
         <source>Handlers</source>
         <translation>处理程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
         <source>Bus</source>
         <translation>总线</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
         <source>BIOS Information</source>
         <translation>BIOS信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
         <source>Base Board Information</source>
         <translation>主板信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>System Information</source>
         <translation>系统信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
         <source>Chassis Information</source>
         <translation>机箱信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
         <source>Physical Memory Array</source>
         <translation>内存插槽信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>Release Date</source>
         <translation>发布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Runtime Size</source>
         <translation>运行内存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>ROM Size</source>
         <translation>ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
         <source>Characteristics</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
         <source>BIOS Revision</source>
         <translation>BIOS修订版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
         <source>Firmware Revision</source>
         <translation>固件修订版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
         <source>Product Name</source>
         <translation>产品名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
         <source>Asset Tag</source>
         <translation>资产编号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
         <source>Features</source>
         <translation>特征</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
         <source>Location In Chassis</source>
         <translation>机箱内位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
         <source>Chassis Handle</source>
         <translation>机箱程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
         <source>Contained Object Handles</source>
         <translation>包含对象程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Wake-up Type</source>
         <translation>唤醒类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>SKU Number</source>
         <translation>SKU号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
         <source>Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
         <source>Lock</source>
         <translation>锁</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
         <source>Boot-up State</source>
         <translation>开机状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
         <source>Power Supply State</source>
         <translation>供电状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Thermal State</source>
         <translation>散热状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>Security Status</source>
         <translation>安全状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
         <source>OEM Information</source>
         <translation>OEM信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
         <source>Height</source>
         <translation>高度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
         <source>Number Of Power Cords</source>
         <translation>电源线数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
         <source>Contained Elements</source>
         <translation>包含组件数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
         <source>Error Correction Type</source>
         <translation>纠错类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
         <source>Maximum Capacity</source>
         <translation>最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
         <source>Error Information Handle</source>
         <translation>错误信息程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
         <source>Number Of Devices</source>
         <translation>卡槽数量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
         <source>Release date</source>
         <translation>发布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
         <source>Board name</source>
         <translation>主板名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
         <source>Language Description Format</source>
         <translation>语言描述格式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
         <source>Installable Languages</source>
         <translation>可安装语言数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
         <source>Currently Installed Language</source>
         <translation>当前安装语言</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
         <source>BD Address</source>
         <translation>蓝牙设备地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="966"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
         <source>Packet type</source>
         <translation>数据包类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
         <source>Link policy</source>
         <translation>连接策略</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
         <source>Link mode</source>
         <translation>连接模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
         <source>Class</source>
         <translation>类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>Service Classes</source>
         <translation>服务类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
         <source>Device Class</source>
         <translation>设备类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
         <source>HCI Version</source>
         <translation>HCI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
         <source>LMP Version</source>
         <translation>LMP版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Subversion</source>
         <translation>子版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
         <source>Device</source>
         <translation>设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>Serial ID</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
         <source>product</source>
         <translation>产品</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
         <source>Powered</source>
         <translation>供电</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
         <source>Discoverable</source>
         <translation>可发现</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
         <source>Pairable</source>
         <translation>可配对</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
         <source>Modalias</source>
         <translation>设置命令别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
         <source>Discovering</source>
         <translation>搜索中</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
         <source>Device File</source>
         <translation>设备文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
         <source>Device Files</source>
         <translation>设备文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
         <source>Device Number</source>
         <translation>设备编号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
         <source>Application</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
         <source>ansiversion</source>
         <translation>ANSI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
         <source>CPU implementer</source>
         <translation>CPU程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
         <source>CPU architecture</source>
         <translation>CPU架构</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
         <source>CPU variant</source>
         <translation>CPU变量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
         <source>CPU part</source>
         <translation>CPU部件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
         <source>CPU revision</source>
         <translation>CPU版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
         <source>GDDR capacity</source>
         <translation>GDDR容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
         <source>GPU vendor</source>
         <translation>GPU供应商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
         <source>GPU type</source>
         <translation>GPU类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
         <source>EGL version</source>
         <translation>EGL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
         <source>EGL client APIs</source>
         <translation>EGL接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
         <source>GL version</source>
         <translation>GL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
         <source>GLSL version</source>
         <translation>GLSL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
         <source>Hardware Class</source>
         <translation>硬件类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
         <source>Array Handle</source>
         <translation>数组程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
         <source>Form Factor</source>
         <translation>尺寸型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Set</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
         <source>Bank Locator</source>
         <translation>内存通道</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
         <source>Part Number</source>
         <translation>部件号码</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
         <source>Rank</source>
         <translation>位列</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
         <source>Memory Technology</source>
         <translation>内存技术</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
         <source>Memory Operating Mode Capability</source>
         <translation>内存操作模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
         <source>Module Manufacturer ID</source>
         <translation>组件制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
         <source>Module Product ID</source>
         <translation>组件产品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>内存子系统控制器制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>内存子系统控制器产品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
         <source>Non-Volatile Size</source>
         <translation>不易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Volatile Size</source>
         <translation>易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
         <source>Cache Size</source>
         <translation>缓存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
         <source>Logical Size</source>
         <translation>逻辑大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>inch</source>
         <translation>英寸</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
         <source>ioport</source>
         <translation>I/O端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
         <source>network</source>
         <translation>网络</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>battery</source>
         <translation>电池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
         <source>native-path</source>
         <translation>安装路径</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
         <source>power supply</source>
         <translation>供电</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>updated</source>
         <translation>更新时间</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
         <source>has history</source>
         <translation>历史记录</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
         <source>has statistics</source>
         <translation>用电统计</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
         <source>rechargeable</source>
         <translation>可再充电</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>state</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>voltage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>warning-level</source>
         <translation>警告等级</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
         <source>energy</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
         <source>energy-empty</source>
         <translation>最低容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
         <source>energy-full</source>
         <translation>完全充满容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
         <source>energy-full-design</source>
         <translation>设计容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
         <source>energy-rate</source>
         <translation>能量密度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
         <source>percentage</source>
         <translation>电量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>technology</source>
         <translation>电池技术</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
         <source>icon-name</source>
         <translation>图标</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
         <source>online</source>
         <translation>在线</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
         <source>daemon-version</source>
         <translation>Daemon版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
         <source>on-battery</source>
         <translation>使用电池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
         <source>lid-is-closed</source>
         <translation>笔记本合盖</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
         <source>lid-is-present</source>
         <translation>打开笔记本盖子</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
         <source>critical-action</source>
         <translation>电量极低时执行</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
         <source>Alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
         <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
         <source>copies</source>
         <translation>复印数量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
         <source>description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
         <source>Driver Activation Cmd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
         <source>Driver Modules</source>
         <translation>驱动模块</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
         <source>job-cancel-after</source>
         <translation>此时取消打印任务</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
         <source>job-hold-until</source>
         <translation>保留打印任务直至</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
         <source>job-priority</source>
         <translation>任务优先级</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
         <source>latency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
         <source>marker-change-time</source>
         <translation>标记修改次数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
         <source>number-up</source>
         <translation>编号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
         <source>orientation-requested</source>
         <translation>打印方向</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
         <source>physical id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
         <source>print-color-mode</source>
         <translation>颜色模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
         <source>printer-is-accepting-jobs</source>
         <translation>当前可打印</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
         <source>printer-is-shared</source>
         <translation>打印机已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
         <source>printer-is-temporary</source>
         <translation>临时打印机</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
         <source>printer-make-and-model</source>
         <translation>制造商和型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
         <source>printer-state-change-time</source>
         <translation>打印机状态修改时间</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
         <source>printer-state-reasons</source>
         <translation>打印机状态信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
         <source>printer-type</source>
         <translation>打印机类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
         <source>printer-uri-supported</source>
         <translation>支持的URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
         <source>Product Date</source>
         <translation>产品日子</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>sides</source>
         <translation>打印面数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Max Boost Clock</source>
         <translation>最大加速频率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>SSD</source>
         <translation>固态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>HDD</source>
         <translation>机械</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
         <source>logicalsectorsize</source>
         <translation>逻辑分区大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>sectorsize</source>
         <translation>扇区大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
         <source>guid</source>
         <translation>全局唯一标识符</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
         <source>Geometry (Logical)</source>
         <translation>几何数据（逻辑）</translation>
     </message>
@@ -1853,47 +1853,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1282"/>
         <source>Model Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1286"/>
         <source>Vendor ID</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
         <source>Architecture</source>
         <translation>架构</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
-        <source>Core(s)</source>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1294"/>
+        <source>CPU(s)</source>
         <translation>逻辑处理器</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1296"/>
         <source>Thread(s)</source>
         <translation>每核线程数</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1305"/>
         <source>L1d cache</source>
         <translation>L1缓存（数据）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1315"/>
         <source>L1i cache</source>
         <translation>L1缓存（指令）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1325"/>
         <source>L2 cache</source>
         <translation>L2缓存</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1335"/>
         <source>L3 cache</source>
         <translation>L3缓存</translation>
     </message>
@@ -2585,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Storage</source>
         <translation>存储设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Monitor</source>
         <translation>显示设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="211"/>
         <source>Failed to enable the device</source>
         <translation>启用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="214"/>
         <source>Failed to disable the device</source>
         <translation>禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="219"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>无法获取设备序列号，禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="241"/>
         <source>Update Drivers</source>
         <translation>更新驱动</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="259"/>
         <source>Uninstall Drivers</source>
         <translation>卸载驱动</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
@@ -92,1411 +92,1411 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="964"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="965"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Processor</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="966"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
         <source>Alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
         <source>ansiversion</source>
         <translation>ANSI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
         <source>Application</source>
         <translation>應用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Architecture</source>
         <translation>架構</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
         <source>Array Handle</source>
         <translation>數組程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
         <source>Asset Tag</source>
         <translation>資產編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
         <source>Auto Negotiation</source>
         <translation>自動協商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
         <source>Bank Locator</source>
         <translation>內存通道</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
         <source>Base Board Information</source>
         <translation>主板訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
         <source>BD Address</source>
         <translation>藍牙設備地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
         <source>BIOS Information</source>
         <translation>BIOS訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
         <source>BIOS Revision</source>
         <translation>BIOS修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
         <source>Board name</source>
         <translation>主板名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
         <source>Boot-up State</source>
         <translation>開機狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
         <source>Broadcast</source>
         <translation>廣播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
         <source>Bus</source>
         <translation>總線</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
         <source>bus info</source>
         <translation>總線訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
         <source>Bus Info</source>
         <translation>總線訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
         <source>Cache Size</source>
         <translation>緩存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
         <source>Capacity</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
         <source>Characteristics</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
         <source>Chassis Handle</source>
         <translation>機箱程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
         <source>Chassis Information</source>
         <translation>機箱訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
         <source>Chip</source>
         <translation>晶片</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
         <source>Chipset</source>
         <translation>晶片組</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
         <source>Class</source>
         <translation>類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
         <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
         <source>Config Status</source>
         <translation>配置狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
         <source>Configured Speed</source>
         <translation>配置頻率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
         <source>Configured Voltage</source>
         <translation>配置電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
         <source>Contained Elements</source>
         <translation>包含組件數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
         <source>Contained Object Handles</source>
         <translation>包含對象程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
         <source>copies</source>
         <translation>複印數量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
         <source>Core ID</source>
         <translation>核心ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
         <source>CPU architecture</source>
         <translation>CPU架構</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
         <source>CPU Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
         <source>CPU ID</source>
         <translation>處理器ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
         <source>CPU implementer</source>
         <translation>CPU程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
         <source>CPU part</source>
         <translation>CPU部件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
         <source>CPU revision</source>
         <translation>CPU版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
         <source>CPU variant</source>
         <translation>CPU變量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
         <source>critical-action</source>
         <translation>電量極低時執行</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
         <source>Currently Installed Language</source>
         <translation>當前安裝語言</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
         <source>Current Resolution</source>
         <translation>當前解像度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
         <source>daemon-version</source>
         <translation>Daemon版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
         <source>Data Width</source>
         <translation>數據位寬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
         <source>description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
         <source>Design Capacity</source>
         <translation>設計容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
         <source>Design Voltage</source>
         <translation>設計電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
         <source>Device</source>
         <translation>設備</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
         <source>Device Class</source>
         <translation>設備類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
         <source>Device File</source>
         <translation>設備文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
         <source>Device Files</source>
         <translation>設備文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
         <source>Device Name</source>
         <translation>設備名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
         <source>Device Number</source>
         <translation>設備編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
         <source>Discoverable</source>
         <translation>可發現</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
         <source>Discovering</source>
         <translation>搜索中</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
         <source>Display Input</source>
         <translation>顯示輸入</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
         <source>Display Output</source>
         <translation>顯示輸出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
         <source>Display Ratio</source>
         <translation>顯示比例</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
         <source>Driver</source>
         <translation>驅動</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
         <source>Driver Activation Cmd</source>
         <translation>驅動啟動命令</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
         <source>Driver Modules</source>
         <translation>驅動模塊</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
         <source>Driver Status</source>
         <translation>驅動狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
         <source>Driver Version</source>
         <translation>驅動版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
         <source>Duplex</source>
         <translation>雙工</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
         <source>EGL client APIs</source>
         <translation>EGL接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
         <source>EGL version</source>
         <translation>EGL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
         <source>energy</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
         <source>energy-empty</source>
         <translation>最低容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
         <source>energy-full</source>
         <translation>完全充滿容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
         <source>energy-full-design</source>
         <translation>設計容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
         <source>energy-rate</source>
         <translation>能量密度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
         <source>Error Correction Type</source>
         <translation>糾錯類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
         <source>Error Information Handle</source>
         <translation>錯誤訊息程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
         <source>Extensions</source>
         <translation>擴展指令集</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
         <source>Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
         <source>Features</source>
         <translation>特徵</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
         <source>Firmware</source>
         <translation>固件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
         <source>Firmware Revision</source>
         <translation>固件修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
         <source>Firmware Version</source>
         <translation>固件版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
         <source>Flags</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
         <source>Form Factor</source>
         <translation>尺寸型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
         <source>GDDR capacity</source>
         <translation>GDDR容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
         <source>Geometry (Logical)</source>
         <translation>幾何數據（邏輯）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
         <source>GLSL version</source>
         <translation>GLSL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
         <source>GL version</source>
         <translation>GL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
         <source>GPU type</source>
         <translation>GPU類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
         <source>GPU vendor</source>
         <translation>GPU供應商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
         <source>Graphics Memory</source>
         <translation>顯存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
         <source>guid</source>
         <translation>全局唯一標識符</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
         <source>Handlers</source>
         <translation>進程</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
         <source>Hardware Class</source>
         <translation>硬件類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
         <source>has history</source>
         <translation>歷史記錄</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
         <source>has statistics</source>
         <translation>用電統計</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
         <source>HCI Version</source>
         <translation>HCI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
         <source>Height</source>
         <translation>高度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
         <source>icon-name</source>
         <translation>圖標</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
         <source>Input/Output</source>
         <translation>輸入/輸出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
         <source>Installable Languages</source>
         <translation>可安裝語言數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
         <source>Interface</source>
         <translation>接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
         <source>Interface Type</source>
         <translation>接口類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
         <source>ioport</source>
         <translation>I/O端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
         <source>IO Port</source>
         <translation>I/O端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
         <source>IP</source>
         <translation>IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
         <source>IRQ</source>
         <translation>中斷</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
         <source>job-cancel-after</source>
         <translation>此時取消打印任務</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
         <source>job-hold-until</source>
         <translation>保留打印任務直至</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
         <source>job-priority</source>
         <translation>任務優先級</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
         <source>KernelModeDriver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
         <source>L1d Cache</source>
         <translation>L1緩存（數據）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
         <source>L1i Cache</source>
         <translation>L1緩存（指令）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
         <source>L2 Cache</source>
         <translation>L2緩存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
         <source>L3 Cache</source>
         <translation>L3緩存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
         <source>L4 Cache</source>
         <translation>L2緩存 {4 ?}</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
         <source>Language Description Format</source>
         <translation>語言描述格式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
         <source>latency</source>
         <translation>延遲</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
         <source>Latency</source>
         <translation>延遲</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
         <source>lid-is-closed</source>
         <translation>筆記本合蓋</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
         <source>lid-is-present</source>
         <translation>打開筆記本蓋子</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
         <source>Link</source>
         <translation>連接</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
         <source>Link mode</source>
         <translation>連接模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
         <source>Link policy</source>
         <translation>連接策略</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
         <source>LMP Version</source>
         <translation>LMP版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
         <source>Location In Chassis</source>
         <translation>機箱內位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
         <source>Locator</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
         <source>Lock</source>
         <translation>鎖</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
         <source>logical name</source>
         <translation>邏輯地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
         <source>Logical Name</source>
         <translation>邏輯名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
         <source>logicalsectorsize</source>
         <translation>邏輯分區大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
         <source>Logical Size</source>
         <translation>邏輯大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
         <source>MAC Address</source>
         <translation>物理地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
         <source>marker-change-time</source>
         <translation>標記修改次數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Max Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
         <source>Maximum Capacity</source>
         <translation>最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
         <source>Maximum Current</source>
         <translation>最大電流</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
         <source>Maximum Rate</source>
         <translation>最大速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
         <source>Maximum Resolution</source>
         <translation>最大解像度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
         <source>Maximum Voltage</source>
         <translation>最高電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Media Type</source>
         <translation>介質類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
         <source>Memory</source>
         <translation>內存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
         <source>Memory Address</source>
         <translation>內存地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
         <source>Memory Operating Mode Capability</source>
         <translation>內存操作模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>內存子系統控制器製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>內存子系統控制器產品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
         <source>Memory Technology</source>
         <translation>內存技術</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
         <source>Minimum Resolution</source>
         <translation>最小解像度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
         <source>Minimum Voltage</source>
         <translation>最低電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
         <source>Modalias</source>
         <translation>設置命令別名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
         <source>Module Alias</source>
         <translation>模塊別名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
         <source>Module Manufacturer ID</source>
         <translation>組件製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
         <source>Module Product ID</source>
         <translation>組件產品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
         <source>Multicast</source>
         <translation>組播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
         <source>native-path</source>
         <translation>安裝路徑</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
         <source>Negotiation Rate</source>
         <translation>協商速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
         <source>network</source>
         <translation>網絡</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
         <source>Non-Volatile Size</source>
         <translation>不易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
         <source>Number Of Devices</source>
         <translation>卡槽數量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
         <source>Number Of Power Cords</source>
         <translation>電源線數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
         <source>number-up</source>
         <translation>編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
         <source>OEM Information</source>
         <translation>OEM訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
         <source>on-battery</source>
         <translation>使用電池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
         <source>online</source>
         <translation>在線</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
         <source>orientation-requested</source>
         <translation>打印方向</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
         <source>Packet type</source>
         <translation>數據包類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
         <source>Pairable</source>
         <translation>可配對</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
         <source>Part Number</source>
         <translation>部件號碼</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
         <source>percentage</source>
         <translation>電量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
         <source>physical id</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
         <source>Physical Memory Array</source>
         <translation>物理內存數組</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
         <source>Port</source>
         <translation>端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
         <source>Powered</source>
         <translation>供電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
         <source>power supply</source>
         <translation>供電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
         <source>Power Supply State</source>
         <translation>供電狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
         <source>Primary Monitor</source>
         <translation>主顯示器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
         <source>print-color-mode</source>
         <translation>顏色模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
         <source>printer-is-accepting-jobs</source>
         <translation>當前可打印</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
         <source>printer-is-shared</source>
         <translation>打印機已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
         <source>printer-is-temporary</source>
         <translation>臨時打印機</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
         <source>printer-make-and-model</source>
         <translation>製造商和型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
         <source>printer-state-change-time</source>
         <translation>打印機狀態修改時間</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
         <source>printer-state-reasons</source>
         <translation>打印機狀態訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
         <source>printer-type</source>
         <translation>打印機類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
         <source>printer-uri-supported</source>
         <translation>支持的URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
         <source>product</source>
         <translation>產品</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
         <source>Product Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
         <source>Product Name</source>
         <translation>產品名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
         <source>Rank</source>
         <translation>位列</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
         <source>rechargeable</source>
         <translation>可再充電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Refresh Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
         <source>Release date</source>
         <translation>發佈日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>Release Date</source>
         <translation>發佈日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Revision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>ROM Size</source>
         <translation>ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>Rotation Rate</source>
         <translation>轉速</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Runtime Size</source>
         <translation>運行內存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
         <source>SBDS Chemistry</source>
         <translation>SBDS材料</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>SBDS Manufacture Date</source>
         <translation>SBDS製造日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>SBDS Serial Number</source>
         <translation>SBDS序列號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>SBDS Version</source>
         <translation>SBDS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>sectorsize</source>
         <translation>扇區大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>Security Status</source>
         <translation>安全狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>Serial ID</source>
         <translation>序列號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>Serial Number</source>
         <translation>序列號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>Service Classes</source>
         <translation>服務類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Set</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>Shared</source>
         <translation>已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>sides</source>
         <translation>打印面數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>SKU Number</source>
         <translation>SKU號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>Slot</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>state</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Stepping</source>
         <translation>步進</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>SubDevice</source>
         <translation>子設備</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>SubVendor</source>
         <translation>子製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Subversion</source>
         <translation>子版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Support Resolution</source>
         <translation>支持解像度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>SysFS_Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>System Information</source>
         <translation>系統訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>technology</source>
         <translation>電池技術</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Temperature</source>
         <translation>溫度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Thermal State</source>
         <translation>散熱狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>Threads</source>
         <translation>線程數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Total Width</source>
         <translation>總位寬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>Type Detail</source>
         <translation>類型詳情</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>updated</source>
         <translation>更新時間</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Vendor</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>Virtualization</source>
         <translation>虛擬化</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Volatile Size</source>
         <translation>易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>voltage</source>
         <translation>電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>Voltage</source>
         <translation>電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Wake-up Type</source>
         <translation>喚醒類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>warning-level</source>
         <translation>警告等級</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>battery</source>
         <translation>電池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>inch</source>
         <translation>英吋</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Max Boost Clock</source>
         <translation>最大加速頻率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>SSD</source>
         <translation>固態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>HDD</source>
         <translation>機械</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
         <source>Model</source>
         <translation>型號</translation>
     </message>
@@ -1853,47 +1853,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1282"/>
         <source>Model Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1286"/>
         <source>Vendor ID</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
         <source>Architecture</source>
         <translation>架構</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
-        <source>Core(s)</source>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1294"/>
+        <source>CPU(s)</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1296"/>
         <source>Thread(s)</source>
         <translation>每核心線程數</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1305"/>
         <source>L1d cache</source>
         <translation>一級緩存（數據）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1315"/>
         <source>L1i cache</source>
         <translation>一級緩存（指令）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1325"/>
         <source>L2 cache</source>
         <translation>二級緩存</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1335"/>
         <source>L3 cache</source>
         <translation>三級緩存</translation>
     </message>
@@ -2585,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Storage</source>
         <translation>存儲設備</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Memory</source>
         <translation>內存</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Monitor</source>
         <translation>顯示設備</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="211"/>
         <source>Failed to enable the device</source>
         <translation>啟用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="214"/>
         <source>Failed to disable the device</source>
         <translation>禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="219"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>無法獲取設備序列號，禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="241"/>
         <source>Update Drivers</source>
         <translation>更新驅動</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="259"/>
         <source>Uninstall Drivers</source>
         <translation>卸載驅動</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
@@ -92,1411 +92,1411 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="964"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="965"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Processor</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="966"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="967"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="968"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
         <source>Alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="969"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
         <source>ansiversion</source>
         <translation>ANSI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="970"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
         <source>Application</source>
         <translation>應用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="971"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Architecture</source>
         <translation>架構</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="972"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
         <source>Array Handle</source>
         <translation>數組程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="973"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
         <source>Asset Tag</source>
         <translation>資產編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="974"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
         <source>Auto Negotiation</source>
         <translation>自動協商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="975"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
         <source>Bank Locator</source>
         <translation>記憶體通道</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="976"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
         <source>Base Board Information</source>
         <translation>主機板訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="977"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
         <source>BD Address</source>
         <translation>藍牙裝置地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="978"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
         <source>BIOS Information</source>
         <translation>BIOS訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="979"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
         <source>BIOS Revision</source>
         <translation>BIOS修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="980"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="981"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
         <source>Board name</source>
         <translation>主機板名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="982"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="983"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
         <source>Boot-up State</source>
         <translation>開機狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="984"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
         <source>Broadcast</source>
         <translation>廣播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="985"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
         <source>Bus</source>
         <translation>匯流排</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="986"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
         <source>bus info</source>
         <translation>匯流排訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="987"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
         <source>Bus Info</source>
         <translation>匯流排訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="988"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
         <source>Cache Size</source>
         <translation>快取大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="989"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="990"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
         <source>Capacity</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="991"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
         <source>Characteristics</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="992"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
         <source>Chassis Handle</source>
         <translation>機箱程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="993"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
         <source>Chassis Information</source>
         <translation>機箱訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="994"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
         <source>Chip</source>
         <translation>晶片</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="995"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
         <source>Chipset</source>
         <translation>晶片組</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="996"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
         <source>Class</source>
         <translation>類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="997"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
         <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="998"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
         <source>Config Status</source>
         <translation>配置狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="999"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
         <source>Configured Speed</source>
         <translation>配置頻率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1000"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
         <source>Configured Voltage</source>
         <translation>配置電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1001"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
         <source>Contained Elements</source>
         <translation>包含組件數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1002"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
         <source>Contained Object Handles</source>
         <translation>包含對象程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1003"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
         <source>copies</source>
         <translation>影印數量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1004"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
         <source>Core ID</source>
         <translation>核心ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1005"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
         <source>CPU architecture</source>
         <translation>CPU架構</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1006"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
         <source>CPU Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1007"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
         <source>CPU ID</source>
         <translation>處理器ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1008"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
         <source>CPU implementer</source>
         <translation>CPU程式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1009"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
         <source>CPU part</source>
         <translation>CPU部件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1010"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
         <source>CPU revision</source>
         <translation>CPU版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1011"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
         <source>CPU variant</source>
         <translation>CPU變數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1012"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
         <source>critical-action</source>
         <translation>電量極低時執行</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1013"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
         <source>Currently Installed Language</source>
         <translation>當前安裝語言</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1014"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
         <source>Current Resolution</source>
         <translation>目前解析度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1015"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
         <source>daemon-version</source>
         <translation>Daemon版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1016"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
         <source>Data Width</source>
         <translation>數據位寬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1017"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1018"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
         <source>description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1019"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1020"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
         <source>Design Capacity</source>
         <translation>設計容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1021"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
         <source>Design Voltage</source>
         <translation>設計電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1022"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
         <source>Device</source>
         <translation>裝置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1023"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
         <source>Device Class</source>
         <translation>裝置類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1024"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
         <source>Device File</source>
         <translation>裝置文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1025"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
         <source>Device Files</source>
         <translation>裝置文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1026"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
         <source>Device Name</source>
         <translation>裝置名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1027"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
         <source>Device Number</source>
         <translation>裝置編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1028"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1029"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1030"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
         <source>Discoverable</source>
         <translation>可發現</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1031"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
         <source>Discovering</source>
         <translation>搜索中</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1032"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
         <source>Display Input</source>
         <translation>顯示輸入</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1033"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
         <source>Display Output</source>
         <translation>顯示輸出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1034"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
         <source>Display Ratio</source>
         <translation>顯示比例</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1035"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1036"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
         <source>Driver</source>
         <translation>驅動</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1037"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
         <source>Driver Activation Cmd</source>
         <translation>驅動啟動指令</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1038"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
         <source>Driver Modules</source>
         <translation>驅動模組</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1039"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
         <source>Driver Status</source>
         <translation>驅動狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1040"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
         <source>Driver Version</source>
         <translation>驅動版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1041"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
         <source>Duplex</source>
         <translation>雙工</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1042"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1043"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1044"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
         <source>EGL client APIs</source>
         <translation>EGL介面</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1045"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
         <source>EGL version</source>
         <translation>EGL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1046"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
         <source>energy</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1047"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
         <source>energy-empty</source>
         <translation>最低容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1048"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
         <source>energy-full</source>
         <translation>完全充滿容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1049"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
         <source>energy-full-design</source>
         <translation>設計容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1050"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
         <source>energy-rate</source>
         <translation>能量密度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1051"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
         <source>Error Correction Type</source>
         <translation>糾錯類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1052"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
         <source>Error Information Handle</source>
         <translation>錯誤訊息程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1053"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1054"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
         <source>Extensions</source>
         <translation>擴展指令集</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1055"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
         <source>Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1056"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
         <source>Features</source>
         <translation>特徵</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1057"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
         <source>Firmware</source>
         <translation>韌體</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1058"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
         <source>Firmware Revision</source>
         <translation>韌體修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1059"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
         <source>Firmware Version</source>
         <translation>韌體版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1060"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
         <source>Flags</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1061"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
         <source>Form Factor</source>
         <translation>尺寸型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1062"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
         <source>GDDR capacity</source>
         <translation>GDDR容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1063"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
         <source>Geometry (Logical)</source>
         <translation>幾何資料（邏輯）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1064"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
         <source>GLSL version</source>
         <translation>GLSL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1065"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
         <source>GL version</source>
         <translation>GL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1066"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
         <source>GPU type</source>
         <translation>GPU類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1067"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
         <source>GPU vendor</source>
         <translation>GPU供應商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1068"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
         <source>Graphics Memory</source>
         <translation>視訊記憶體</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1069"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
         <source>guid</source>
         <translation>全局唯一標識符</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1070"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
         <source>Handlers</source>
         <translation>處理程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1071"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
         <source>Hardware Class</source>
         <translation>硬體類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1072"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
         <source>has history</source>
         <translation>歷史記錄</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1073"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
         <source>has statistics</source>
         <translation>用電統計</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1074"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
         <source>HCI Version</source>
         <translation>HCI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1075"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1076"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
         <source>Height</source>
         <translation>高度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1077"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
         <source>icon-name</source>
         <translation>圖示</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1078"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
         <source>Input/Output</source>
         <translation>輸入/輸出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1079"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
         <source>Installable Languages</source>
         <translation>可安裝語言數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1080"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
         <source>Interface</source>
         <translation>介面</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1081"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
         <source>Interface Type</source>
         <translation>介面類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1082"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
         <source>ioport</source>
         <translation>IO埠</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1083"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
         <source>IO Port</source>
         <translation>I/O埠</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1084"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
         <source>IP</source>
         <translation>IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1085"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
         <source>IRQ</source>
         <translation>中斷</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1086"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
         <source>job-cancel-after</source>
         <translation>此時取消列印任務</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1087"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
         <source>job-hold-until</source>
         <translation>保留列印任務直至</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1088"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
         <source>job-priority</source>
         <translation>任務優先度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1089"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
         <source>KernelModeDriver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1090"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1091"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
         <source>L1d Cache</source>
         <translation>L1快取（數據）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1092"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
         <source>L1i Cache</source>
         <translation>L1快取（指令）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1093"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
         <source>L2 Cache</source>
         <translation>L2快取</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1094"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
         <source>L3 Cache</source>
         <translation>L3快取</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1095"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
         <source>L4 Cache</source>
         <translation>L2快取 {4 ?}</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1096"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
         <source>Language Description Format</source>
         <translation>語言描述格式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1097"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
         <source>latency</source>
         <translation>延遲</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1098"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
         <source>Latency</source>
         <translation>延遲</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1099"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
         <source>lid-is-closed</source>
         <translation>筆記本合蓋</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1100"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
         <source>lid-is-present</source>
         <translation>打開筆記本蓋子</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1101"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
         <source>Link</source>
         <translation>連結</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1102"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
         <source>Link mode</source>
         <translation>連接模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1103"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
         <source>Link policy</source>
         <translation>連接策略</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1104"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
         <source>LMP Version</source>
         <translation>LMP版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1105"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1106"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
         <source>Location In Chassis</source>
         <translation>機箱內位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1107"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
         <source>Locator</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1108"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
         <source>Lock</source>
         <translation>鎖</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1109"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
         <source>logical name</source>
         <translation>邏輯地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1110"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
         <source>Logical Name</source>
         <translation>邏輯名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1111"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
         <source>logicalsectorsize</source>
         <translation>邏輯分區大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1112"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
         <source>Logical Size</source>
         <translation>邏輯大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1113"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
         <source>MAC Address</source>
         <translation>物理地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1114"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
         <source>marker-change-time</source>
         <translation>標記修改次數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1115"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Max Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1116"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
         <source>Maximum Capacity</source>
         <translation>最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1117"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
         <source>Maximum Current</source>
         <translation>最大電流</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1118"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1119"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
         <source>Maximum Rate</source>
         <translation>最大速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1120"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
         <source>Maximum Resolution</source>
         <translation>最大解析度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1121"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
         <source>Maximum Voltage</source>
         <translation>最高電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1122"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Media Type</source>
         <translation>介質類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1123"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1124"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
         <source>Memory Address</source>
         <translation>記憶體地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1125"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
         <source>Memory Operating Mode Capability</source>
         <translation>記憶體操作模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1126"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>記憶體子系統控制器製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1127"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>記憶體子系統控制器產品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1128"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
         <source>Memory Technology</source>
         <translation>記憶體技術</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1129"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
         <source>Minimum Resolution</source>
         <translation>最小解析度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1130"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
         <source>Minimum Voltage</source>
         <translation>最低電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1131"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
         <source>Modalias</source>
         <translation>設置命令別名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1133"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1134"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
         <source>Module Alias</source>
         <translation>模組別名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
         <source>Module Manufacturer ID</source>
         <translation>元件製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1136"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
         <source>Module Product ID</source>
         <translation>元件產品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1137"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1138"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
         <source>Multicast</source>
         <translation>組播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1139"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1140"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
         <source>native-path</source>
         <translation>安裝路徑</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1141"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
         <source>Negotiation Rate</source>
         <translation>協商速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1142"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
         <source>network</source>
         <translation>網路</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1143"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
         <source>Non-Volatile Size</source>
         <translation>不易遺失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1144"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
         <source>Number Of Devices</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1145"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
         <source>Number Of Power Cords</source>
         <translation>電源線數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1146"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
         <source>number-up</source>
         <translation>編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1147"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
         <source>OEM Information</source>
         <translation>OEM訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1148"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
         <source>on-battery</source>
         <translation>使用電池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1149"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
         <source>online</source>
         <translation>線上</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1150"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
         <source>orientation-requested</source>
         <translation>列印方向</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1151"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
         <source>Packet type</source>
         <translation>封包類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1152"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
         <source>Pairable</source>
         <translation>可配對</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1153"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
         <source>Part Number</source>
         <translation>部件號碼</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1154"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
         <source>percentage</source>
         <translation>電量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1155"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1156"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
         <source>physical id</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1157"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1158"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
         <source>Physical Memory Array</source>
         <translation>物理記憶體陣列</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1159"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
         <source>Port</source>
         <translation>埠</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1160"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
         <source>Powered</source>
         <translation>供電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1161"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
         <source>power supply</source>
         <translation>供電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1162"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
         <source>Power Supply State</source>
         <translation>供電狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1163"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
         <source>Primary Monitor</source>
         <translation>主顯示器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1164"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
         <source>print-color-mode</source>
         <translation>顏色模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1165"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
         <source>printer-is-accepting-jobs</source>
         <translation>當前可列印</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1166"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
         <source>printer-is-shared</source>
         <translation>印表機已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1167"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
         <source>printer-is-temporary</source>
         <translation>臨時印表機</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1168"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
         <source>printer-make-and-model</source>
         <translation>製造商和型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1169"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
         <source>printer-state-change-time</source>
         <translation>印表機狀態修改時間</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1170"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
         <source>printer-state-reasons</source>
         <translation>印表機狀態訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1171"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
         <source>printer-type</source>
         <translation>印表機類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1172"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
         <source>printer-uri-supported</source>
         <translation>支持的URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1173"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
         <source>product</source>
         <translation>產品</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1174"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
         <source>Product Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1175"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
         <source>Product Name</source>
         <translation>產品名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1176"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1177"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
         <source>Rank</source>
         <translation>位列</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1178"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
         <source>rechargeable</source>
         <translation>可再充電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1179"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Refresh Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1180"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
         <source>Release date</source>
         <translation>發布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1181"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>Release Date</source>
         <translation>發布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Revision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>ROM Size</source>
         <translation>ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>Rotation Rate</source>
         <translation>轉速</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Runtime Size</source>
         <translation>運行內存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
         <source>SBDS Chemistry</source>
         <translation>SBDS材料</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>SBDS Manufacture Date</source>
         <translation>SBDS製造日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>SBDS Serial Number</source>
         <translation>SBDS序號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>SBDS Version</source>
         <translation>SBDS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>sectorsize</source>
         <translation>扇區大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>Security Status</source>
         <translation>安全狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>Serial ID</source>
         <translation>序號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>Serial Number</source>
         <translation>序號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>Service Classes</source>
         <translation>服務類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Set</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>Shared</source>
         <translation>已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>sides</source>
         <translation>列印面數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Size</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>SKU Number</source>
         <translation>SKU號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>Slot</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>state</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Stepping</source>
         <translation>步進</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>SubDevice</source>
         <translation>子裝置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>SubVendor</source>
         <translation>子製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Subversion</source>
         <translation>子版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Support Resolution</source>
         <translation>支持解析度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>SysFS_Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>System Information</source>
         <translation>系統訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>technology</source>
         <translation>電池技術</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Temperature</source>
         <translation>溫度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Thermal State</source>
         <translation>散熱狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>Threads</source>
         <translation>執行緒數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Total Width</source>
         <translation>總位寬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>Type Detail</source>
         <translation>類型詳情</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>updated</source>
         <translation>更新時間</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Vendor</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>Virtualization</source>
         <translation>虛擬化</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Volatile Size</source>
         <translation>易遺失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>voltage</source>
         <translation>電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>Voltage</source>
         <translation>電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Wake-up Type</source>
         <translation>喚醒類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>warning-level</source>
         <translation>警告等級</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>battery</source>
         <translation>電池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>inch</source>
         <translation>英寸</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Max Boost Clock</source>
         <translation>最大加速频率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>SSD</source>
         <translation>固態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>HDD</source>
         <translation>機械</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1132"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1135"/>
         <source>Model</source>
         <translation>型號</translation>
     </message>
@@ -1853,47 +1853,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1269"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1282"/>
         <source>Model Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1273"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1286"/>
         <source>Vendor ID</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1277"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
         <source>Architecture</source>
         <translation>架構</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1281"/>
-        <source>Core(s)</source>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1294"/>
+        <source>CPU(s)</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1283"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1296"/>
         <source>Thread(s)</source>
         <translation>每核心執行緒數</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1290"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1305"/>
         <source>L1d cache</source>
         <translation>第一級快取（資料）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1298"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1315"/>
         <source>L1i cache</source>
         <translation>第一級快取（指令）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1306"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1325"/>
         <source>L2 cache</source>
         <translation>第二級快取</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1314"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1335"/>
         <source>L3 cache</source>
         <translation>第三級快取</translation>
     </message>
@@ -2585,48 +2585,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Storage</source>
         <translation>儲存裝置</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="126"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="173"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="130"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="169"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="177"/>
         <source>Monitor</source>
         <translation>顯示裝置</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="207"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="211"/>
         <source>Failed to enable the device</source>
         <translation>啟用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="214"/>
         <source>Failed to disable the device</source>
         <translation>禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="215"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="219"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>無法獲取裝置序號，禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="237"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="241"/>
         <source>Update Drivers</source>
         <translation>更新驅動</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="255"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="259"/>
         <source>Uninstall Drivers</source>
         <translation>移除驅動</translation>
     </message>


### PR DESCRIPTION
…ions

changed CPU header label from Core(s) to CPU(s) in DeviceGenerator.cpp updated core count to use logicalNum
regenerated translation source files in translations

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-363563.html