### PR TITLE
fix(network): prefer permanent MAC address from hwinfo

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -136,7 +136,10 @@ bool DeviceNetwork::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Device", m_Name);
     setAttribute(mapInfo, "Vendor", m_Vendor);
     setAttribute(mapInfo, "Device File", m_LogicalName);
-    setAttribute(mapInfo, "HW Address", m_MACAddress);
+    setAttribute(mapInfo, "Permanent HW Address", m_MACAddress);
+    if (m_MACAddress == "00:00:00:00:00:00")
+        m_MACAddress.clear();
+    setAttribute(mapInfo, "HW Address", m_MACAddress, false);
     setAttribute(mapInfo, "Permanent HW Address", m_UniqueID);
     setAttribute(mapInfo, "SysFS Device Link", m_SysPath);
     setAttribute(mapInfo, "Driver", m_Driver);

--- a/deepin-devicemanager/tests/src/DeviceManager/ut_devicenetwork.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_devicenetwork.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 UnionTech Software Technology Co.,Ltd
+// Copyright (C) 2019-2026 ~ 2020 UnionTech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -82,6 +82,45 @@ TEST_F(UT_DeviceNetwork, DeviceNetwork_UT_setInfoFromHwinfo_002)
     ut_network_sethwinfomap(mapinfo);
 
     EXPECT_TRUE(m_deviceNetwork->setInfoFromHwinfo(mapinfo));
+}
+
+TEST_F(UT_DeviceNetwork, DeviceNetwork_UT_setInfoFromHwinfo_prefersPermanentHwAddress)
+{
+    QMap<QString, QString> mapinfo;
+    mapinfo.insert("Device", "Ethernet Controller");
+    mapinfo.insert("Device File", "enp2s0");
+    mapinfo.insert("HW Address", "11:22:33:44:55:66");
+    mapinfo.insert("Permanent HW Address", "aa:bb:cc:dd:ee:ff");
+    mapinfo.insert("SysFS ID", "/class/net/enp2s0");
+
+    EXPECT_TRUE(m_deviceNetwork->setInfoFromHwinfo(mapinfo));
+    EXPECT_STREQ("aa:bb:cc:dd:ee:ff", m_deviceNetwork->m_MACAddress.toStdString().c_str());
+    EXPECT_STREQ("aa:bb:cc:dd:ee:ff", m_deviceNetwork->m_UniqueID.toStdString().c_str());
+}
+
+TEST_F(UT_DeviceNetwork, DeviceNetwork_UT_setInfoFromHwinfo_fallsBackToHwAddress)
+{
+    QMap<QString, QString> mapinfo;
+    mapinfo.insert("Device", "Ethernet Controller");
+    mapinfo.insert("Device File", "enp2s0");
+    mapinfo.insert("HW Address", "11:22:33:44:55:66");
+    mapinfo.insert("SysFS ID", "/class/net/enp2s0");
+
+    EXPECT_TRUE(m_deviceNetwork->setInfoFromHwinfo(mapinfo));
+    EXPECT_STREQ("11:22:33:44:55:66", m_deviceNetwork->m_MACAddress.toStdString().c_str());
+}
+
+TEST_F(UT_DeviceNetwork, DeviceNetwork_UT_setInfoFromHwinfo_fallsBackWhenPermanentHwAddressIsZero)
+{
+    QMap<QString, QString> mapinfo;
+    mapinfo.insert("Device", "Ethernet Controller");
+    mapinfo.insert("Device File", "enp2s0");
+    mapinfo.insert("HW Address", "11:22:33:44:55:66");
+    mapinfo.insert("Permanent HW Address", "00:00:00:00:00:00");
+    mapinfo.insert("SysFS ID", "/class/net/enp2s0");
+
+    EXPECT_TRUE(m_deviceNetwork->setInfoFromHwinfo(mapinfo));
+    EXPECT_STREQ("11:22:33:44:55:66", m_deviceNetwork->m_MACAddress.toStdString().c_str());
 }
 
 TEST_F(UT_DeviceNetwork, DeviceNetwork_UT_setInfoFromLshw)


### PR DESCRIPTION
Prefer the permanent hardware address when parsing network device info.

解析网卡信息时优先使用永久硬件地址。

Fall back to the current MAC address when the permanent address is empty or zero.

当永久地址为空或全零时，回退使用当前MAC地址。

Log: 修复网卡MAC地址显示优先级
PMS: Bug: https://pms.uniontech.com/bug-view-363471.html
Influence: 网卡详情页优先显示永久物理地址，永久地址无效时显示当前MAC地址。

## Summary by Sourcery

Prefer permanent hardware MAC addresses from hwinfo when populating network device info, falling back to the current MAC when the permanent address is missing or invalid.

Bug Fixes:
- Ensure network MAC address and unique ID use the permanent hardware address when available and non-zero.
- Fall back to the current hardware MAC address when the permanent address is empty or all zeros to avoid invalid display.

Tests:
- Add unit tests covering preference of permanent MAC address and fallback behavior when it is missing or all zeros.