### PR TITLE
fix(network): prefer permanent MAC address from hwinfo

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -150,7 +150,8 @@ bool DeviceNetwork::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Device", m_Name);
     setAttribute(mapInfo, "Vendor", m_Vendor);
     setAttribute(mapInfo, "Device File", m_LogicalName);
-    setAttribute(mapInfo, "HW Address", m_MACAddress);
+    setAttribute(mapInfo, "Permanent HW Address", m_MACAddress);
+    setAttribute(mapInfo, "HW Address", m_MACAddress, false);
     setAttribute(mapInfo, "Permanent HW Address", m_UniqueID);
     setAttribute(mapInfo, "SysFS Device Link", m_SysPath);
     setAttribute(mapInfo, "Driver", m_Driver);

--- a/deepin-devicemanager/tests/src/DeviceManager/ut_devicenetwork.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_devicenetwork.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 UnionTech Software Technology Co.,Ltd
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019-2026 ~ 2026 UnionTech Software Technology Co.,Ltd
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -82,6 +82,20 @@ TEST_F(UT_DeviceNetwork, DeviceNetwork_UT_setInfoFromHwinfo_002)
     ut_network_sethwinfomap(mapinfo);
 
     EXPECT_TRUE(m_deviceNetwork->setInfoFromHwinfo(mapinfo));
+}
+
+TEST_F(UT_DeviceNetwork, DeviceNetwork_UT_setInfoFromHwinfo_PreferPermanentHwAddress)
+{
+    QMap<QString, QString> mapinfo;
+    mapinfo.insert("Device", "network");
+    mapinfo.insert("Vendor", "vendor");
+    mapinfo.insert("Device File", "enp2s0");
+    mapinfo.insert("HW Address", "66:77:88:99:aa:bb");
+    mapinfo.insert("Permanent HW Address", "00:11:22:33:44:55");
+
+    EXPECT_TRUE(m_deviceNetwork->setInfoFromHwinfo(mapinfo));
+    EXPECT_STREQ("00:11:22:33:44:55", m_deviceNetwork->m_MACAddress.toStdString().c_str());
+    EXPECT_STREQ("00:11:22:33:44:55", m_deviceNetwork->m_UniqueID.toStdString().c_str());
 }
 
 TEST_F(UT_DeviceNetwork, DeviceNetwork_UT_setInfoFromLshw)


### PR DESCRIPTION
Use Permanent HW Address as the displayed network MAC address.

使用 Permanent HW Address 作为网卡展示的 MAC 地址。

Keep Permanent HW Address as the network device unique ID.

同时保留 Permanent HW Address 作为网卡设备唯一标识。

Log: 修复未联网首次进入系统网卡MAC显示错误
Bug: https://pms.uniontech.com/bug-view-363471.html Influence: 未联网首次进入系统时，设备管理器网卡MAC优先显示永久
物理地址，并与控制中心保持一致；同时保留设备唯一标识，避免影响
网卡禁用状态匹配和启停逻辑。