### PR TITLE
Fix(cpu): Improve CPU header fallback and dynamic PageMultiInfo heade…

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -35,6 +35,11 @@
 #include <QRegularExpression>
 #include <QDir>
 
+const QString kModelName { "model name" };
+const QString kVendorId { "vendor_id" };
+const QString kDmiVersion { "Version" };
+const QString kDmiManufacturer { "Manufacturer" };
+
 using namespace DDLog;
 
 DeviceGenerator::DeviceGenerator(QObject *parent)
@@ -244,11 +249,14 @@ void DeviceGenerator::generatorCpuDevice()
 
     // 计算并设置CPU头部信息(当前没有多个物理CPU的环境，所以只能编码单物理CPU的逻辑)
     if (lsCpu.size() > 0) {
-        QMap<QString, QString> baseCPUInfo = lsCpu.at(0);
-        if (dmidecode.contains("Manufacturer")) {
-            baseCPUInfo["vendor_id"] = dmidecode["Manufacturer"];
+        QMap<QString, QString> baseCpuInfo = lsCpu.at(0);
+        if (!baseCpuInfo.contains(kModelName) && dmidecode.contains(kDmiVersion)) {
+            baseCpuInfo.insert(kModelName, dmidecode[kDmiVersion]); // 适配特殊机型CPU
         }
-        calAndSetCpuHeaderInfo(baseCPUInfo, coreNum, logicalNum);
+        if (!baseCpuInfo.contains(kVendorId) && dmidecode.contains(kDmiManufacturer)) {
+            baseCpuInfo.insert(kVendorId, dmidecode[kDmiManufacturer]); // 适配特殊机型CPU
+        }
+        calAndSetCpuHeaderInfo(baseCpuInfo, coreNum, logicalNum);
     }
 }
 
@@ -1527,12 +1535,12 @@ void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &first
     QList<QList<QPair<QString, QString>>> cpuHeaderInfo;
     QList<QPair<QString, QString>> singleCpuHeaderInfo;
 
-    if (firstProcessorInfo.contains("model name")) {
-        QPair<QString, QString> modelName(tr("Model Name"), firstProcessorInfo.value("model name"));
+    if (firstProcessorInfo.contains(kModelName)) {
+        QPair<QString, QString> modelName(tr("Model Name"), firstProcessorInfo.value(kModelName));
         singleCpuHeaderInfo.push_back(modelName);
     }
-    if (firstProcessorInfo.contains("vendor_id")) {
-        QPair<QString, QString> vendorID(tr("Vendor ID"), firstProcessorInfo.value("vendor_id"));
+    if (firstProcessorInfo.contains(kVendorId)) {
+        QPair<QString, QString> vendorID(tr("Vendor ID"), firstProcessorInfo.value(kVendorId));
         singleCpuHeaderInfo.push_back(vendorID);
     }
     if (firstProcessorInfo.contains("Architecture")) {

--- a/deepin-devicemanager/src/Page/PageMultiInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageMultiInfo.cpp
@@ -34,7 +34,7 @@ DWIDGET_USE_NAMESPACE
 using namespace DDLog;
 
 #define LEAST_PAGE_HEIGHT 315  // PageMultiInfo最小高度 当小于这个高度时，上方的表格就要变小
-static constexpr int kHeaderInfoDefaultHeight = 362; // 滚动区域默认高度
+static const int kAdjustHeight { 2 }; // 高度调节值
 
 PageMultiInfo::PageMultiInfo(QWidget *parent)
     : PageInfo(parent)
@@ -106,13 +106,17 @@ void PageMultiInfo::updateInfo(const QList<DeviceBaseInfo *> &lst)
         QList<QList<QPair<QString, QString>>> headerInfo;
         DeviceManager::instance()->getCpuHeaderInfo(headerInfo);
         clearLayout(mp_HeaderInfoWidgetLay);
+        int defaultHeight { 0 };
         for (int i = 0; i < headerInfo.size(); ++i) {
             HeaderInfoTableWidget *headerWidget = new HeaderInfoTableWidget(mp_HeaderInfoWidget);
             headerWidget->updateData(headerInfo.at(i));
             mp_HeaderInfoWidgetLay->addWidget(headerWidget);
         }
-        mp_HeaderInfoWidget->setMaximumHeight(kHeaderInfoDefaultHeight);
-        mp_HeaderInfoWidget->resize(this->width(), kHeaderInfoDefaultHeight);
+        if (headerInfo.size() > 0 && headerInfo.at(0).size() > 0) {
+            defaultHeight = headerInfo.at(0).size() * ROW_HEIGHT + kAdjustHeight;
+        }
+        mp_HeaderInfoWidget->setMaximumHeight(defaultHeight);
+        mp_HeaderInfoWidget->resize(this->width(), defaultHeight);
         mp_HeaderInfoWidget->setVisible(true);
     } else {
         mp_HeaderInfoWidget->setVisible(false);
@@ -331,7 +335,6 @@ void PageMultiInfo::initWidgets()
     mp_HeaderInfoWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     mp_HeaderInfoWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     mp_HeaderInfoWidget->setFrameShape(QFrame::NoFrame);
-    mp_HeaderInfoWidget->setMaximumHeight(kHeaderInfoDefaultHeight);
     mp_HeaderInfoWidget->setMinimumHeight(0);
     mp_HeaderInfoWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     mp_HeaderInfoWidgetLay->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
…r sizing

--Use dmidecode Version and Manufacturer as fallback values for
  missing CPU model name and vendor_id in DeviceGenerator::generatorCpuDevice
--Remove hard-coded PageMultiInfo header widget height and compute the height dynamically from row count, improving layout handling for varying header data

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-363473.html