### PR TITLE
fix(cpu-header): use CPU(s) label for core count and refresh translat…

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -1548,7 +1548,7 @@ void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &first
         singleCpuHeaderInfo.push_back(arch);
     }
     if (coreNum > 0) {
-        QPair<QString, QString> coreCount(tr("Core(s)"), QString::number(coreNum));
+        QPair<QString, QString> coreCount(tr("CPU(s)"), QString::number(logicalNum));
         singleCpuHeaderInfo.push_back(coreCount);
         QPair<QString, QString> threadPerCore(tr("Thread(s)"), QString::number(logicalNum / coreNum));
         singleCpuHeaderInfo.push_back(threadPerCore);

--- a/deepin-devicemanager/translations/deepin-devicemanager.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager.ts
@@ -92,1391 +92,1391 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Core(s)</source>
         <translation type="unfinished">Core(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
         <source>Processor</source>
         <translation type="unfinished">Processor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>ACL MTU</source>
         <translation type="unfinished">ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Address</source>
         <translation type="unfinished">Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>Alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>ansiversion</source>
         <translation type="unfinished">ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Application</source>
         <translation type="unfinished">Application</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
         <source>Architecture</source>
         <translation type="unfinished">Architecture</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>Array Handle</source>
         <translation type="unfinished">Array Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>Asset Tag</source>
         <translation type="unfinished">Asset Tag</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>Auto Negotiation</source>
         <translation type="unfinished">Auto Negotiation</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>Bank Locator</source>
         <translation type="unfinished">Bank Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>Base Board Information</source>
         <translation type="unfinished">Base Board Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>BD Address</source>
         <translation type="unfinished">BD Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>BIOS Information</source>
         <translation type="unfinished">BIOS Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>BIOS Revision</source>
         <translation type="unfinished">BIOS Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>BIOS ROMSIZE</source>
         <translation type="unfinished">BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Board name</source>
         <translation type="unfinished">Board name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>BogoMIPS</source>
         <translation type="unfinished">BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>Boot-up State</source>
         <translation type="unfinished">Boot-up State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
         <source>Broadcast</source>
         <translation type="unfinished">Broadcast</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>Bus</source>
         <translation type="unfinished">Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>bus info</source>
         <translation type="unfinished">bus info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>Bus Info</source>
         <translation type="unfinished">Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>Cache Size</source>
         <translation type="unfinished">Cache Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>Capabilities</source>
         <translation type="unfinished">Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Capacity</source>
         <translation type="unfinished">Capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Characteristics</source>
         <translation type="unfinished">Characteristics</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>Chassis Handle</source>
         <translation type="unfinished">Chassis Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>Chassis Information</source>
         <translation type="unfinished">Chassis Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Chip</source>
         <translation type="unfinished">Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Chipset</source>
         <translation type="unfinished">Chipset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Class</source>
         <translation type="unfinished">Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>Config Status</source>
         <translation type="unfinished">Config Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>Configured Speed</source>
         <translation type="unfinished">Configured Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>Configured Voltage</source>
         <translation type="unfinished">Configured Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Contained Elements</source>
         <translation type="unfinished">Contained Elements</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Contained Object Handles</source>
         <translation type="unfinished">Contained Object Handles</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>copies</source>
         <translation type="unfinished">copies</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Core ID</source>
         <translation type="unfinished">Core ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
         <source>CPU architecture</source>
         <translation type="unfinished">CPU architecture</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>CPU Family</source>
         <translation type="unfinished">CPU Family</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>CPU ID</source>
         <translation type="unfinished">CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>CPU implementer</source>
         <translation type="unfinished">CPU implementer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>CPU part</source>
         <translation type="unfinished">CPU part</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>CPU revision</source>
         <translation type="unfinished">CPU revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>CPU variant</source>
         <translation type="unfinished">CPU variant</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
         <source>critical-action</source>
         <translation type="unfinished">critical-action</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Currently Installed Language</source>
         <translation type="unfinished">Currently Installed Language</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>Current Resolution</source>
         <translation type="unfinished">Current Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>daemon-version</source>
         <translation type="unfinished">daemon-version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Data Width</source>
         <translation type="unfinished">Data Width</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>description</source>
         <translation type="unfinished">description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>Design Capacity</source>
         <translation type="unfinished">Design Capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Design Voltage</source>
         <translation type="unfinished">Design Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>Device</source>
         <translation type="unfinished">Device</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>Device Class</source>
         <translation type="unfinished">Device Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Device File</source>
         <translation type="unfinished">Device File</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Device Files</source>
         <translation type="unfinished">Device Files</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Device Name</source>
         <translation type="unfinished">Device Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Device Number</source>
         <translation type="unfinished">Device Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>DigitalOutput</source>
         <translation type="unfinished">DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Disable</source>
         <translation type="unfinished">Disable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Discoverable</source>
         <translation type="unfinished">Discoverable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Discovering</source>
         <translation type="unfinished">Discovering</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Display Input</source>
         <translation type="unfinished">Display Input</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Display Output</source>
         <translation type="unfinished">Display Output</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Display Ratio</source>
         <translation type="unfinished">Display Ratio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>DP</source>
         <translation type="unfinished">DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>Driver</source>
         <translation type="unfinished">Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>Driver Activation Cmd</source>
         <translation type="unfinished">Driver Activation Cmd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
         <source>Driver Modules</source>
         <translation type="unfinished">Driver Modules</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
         <source>Driver Status</source>
         <translation type="unfinished">Driver Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
         <source>Driver Version</source>
         <translation type="unfinished">Driver Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
         <source>Duplex</source>
         <translation type="unfinished">Duplex</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
         <source>DVI</source>
         <translation type="unfinished">DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
         <source>eDP</source>
         <translation type="unfinished">eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
         <source>EGL client APIs</source>
         <translation type="unfinished">EGL client APIs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
         <source>EGL version</source>
         <translation type="unfinished">EGL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
         <source>energy</source>
         <translation type="unfinished">energy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
         <source>energy-empty</source>
         <translation type="unfinished">energy-empty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
         <source>energy-full</source>
         <translation type="unfinished">energy-full</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
         <source>energy-full-design</source>
         <translation type="unfinished">energy-full-design</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
         <source>energy-rate</source>
         <translation type="unfinished">energy-rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
         <source>Error Correction Type</source>
         <translation type="unfinished">Error Correction Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
         <source>Error Information Handle</source>
         <translation type="unfinished">Error Information Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
         <source>EV</source>
         <translation type="unfinished">EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
         <source>Extensions</source>
         <translation type="unfinished">Extensions</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
         <source>Family</source>
         <translation type="unfinished">Family</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
         <source>Features</source>
         <translation type="unfinished">Features</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
         <source>Firmware</source>
         <translation type="unfinished">Firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
         <source>Firmware Revision</source>
         <translation type="unfinished">Firmware Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
         <source>Firmware Version</source>
         <translation type="unfinished">Firmware Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
         <source>Flags</source>
         <translation type="unfinished">Flags</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
         <source>Form Factor</source>
         <translation type="unfinished">Form Factor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
         <source>GDDR capacity</source>
         <translation type="unfinished">GDDR capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
         <source>Geometry (Logical)</source>
         <translation type="unfinished">Geometry (Logical)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
         <source>GLSL version</source>
         <translation type="unfinished">GLSL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
         <source>GL version</source>
         <translation type="unfinished">GL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
         <source>GPU type</source>
         <translation type="unfinished">GPU type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
         <source>GPU vendor</source>
         <translation type="unfinished">GPU vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
         <source>Graphics Memory</source>
         <translation type="unfinished">Graphics Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
         <source>guid</source>
         <translation type="unfinished">guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
         <source>Handlers</source>
         <translation type="unfinished">Handlers</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
         <source>Hardware Class</source>
         <translation type="unfinished">Hardware Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
         <source>has history</source>
         <translation type="unfinished">has history</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
         <source>has statistics</source>
         <translation type="unfinished">has statistics</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
         <source>HCI Version</source>
         <translation type="unfinished">HCI Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
         <source>HDMI</source>
         <translation type="unfinished">HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
         <source>icon-name</source>
         <translation type="unfinished">icon-name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
         <source>Input/Output</source>
         <translation type="unfinished">Input/Output</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
         <source>Installable Languages</source>
         <translation type="unfinished">Installable Languages</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
         <source>Interface</source>
         <translation type="unfinished">Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
         <source>Interface Type</source>
         <translation type="unfinished">Interface Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
         <source>ioport</source>
         <translation type="unfinished">ioport</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
         <source>IO Port</source>
         <translation type="unfinished">IO Port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
         <source>IP</source>
         <translation type="unfinished">IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
         <source>IRQ</source>
         <translation type="unfinished">IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
         <source>job-cancel-after</source>
         <translation type="unfinished">job-cancel-after</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
         <source>job-hold-until</source>
         <translation type="unfinished">job-hold-until</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
         <source>job-priority</source>
         <translation type="unfinished">job-priority</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
         <source>KernelModeDriver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
         <source>KEY</source>
         <translation type="unfinished">KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
         <source>L1d Cache</source>
         <translation type="unfinished">L1d Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
         <source>L1i Cache</source>
         <translation type="unfinished">L1i Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
         <source>L2 Cache</source>
         <translation type="unfinished">L2 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
         <source>L3 Cache</source>
         <translation type="unfinished">L3 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
         <source>L4 Cache</source>
         <translation type="unfinished">L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
         <source>Language Description Format</source>
         <translation type="unfinished">Language Description Format</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
         <source>latency</source>
         <translation type="unfinished">latency</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
         <source>Latency</source>
         <translation type="unfinished">Latency</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
         <source>lid-is-closed</source>
         <translation type="unfinished">lid-is-closed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
         <source>lid-is-present</source>
         <translation type="unfinished">lid-is-present</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
         <source>Link</source>
         <translation type="unfinished">Link</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
         <source>Link mode</source>
         <translation type="unfinished">Link mode</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
         <source>Link policy</source>
         <translation type="unfinished">Link policy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
         <source>LMP Version</source>
         <translation type="unfinished">LMP Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
         <source>Location</source>
         <translation type="unfinished">Location</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
         <source>Location In Chassis</source>
         <translation type="unfinished">Location In Chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
         <source>Locator</source>
         <translation type="unfinished">Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
         <source>Lock</source>
         <translation type="unfinished">Lock</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
         <source>logical name</source>
         <translation type="unfinished">logical name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
         <source>Logical Name</source>
         <translation type="unfinished">Logical Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
         <source>logicalsectorsize</source>
         <translation type="unfinished">logicalsectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
         <source>Logical Size</source>
         <translation type="unfinished">Logical Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
         <source>MAC Address</source>
         <translation type="unfinished">MAC Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
         <source>marker-change-time</source>
         <translation type="unfinished">marker-change-time</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
         <source>Max Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
         <source>Maximum Capacity</source>
         <translation type="unfinished">Maximum Capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
         <source>Maximum Current</source>
         <translation type="unfinished">Maximum Current</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
         <source>Maximum Power</source>
         <translation type="unfinished">Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
         <source>Maximum Rate</source>
         <translation type="unfinished">Maximum Rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
         <source>Maximum Resolution</source>
         <translation type="unfinished">Maximum Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
         <source>Maximum Voltage</source>
         <translation type="unfinished">Maximum Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
         <source>Media Type</source>
         <translation type="unfinished">Media Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
         <source>Memory</source>
         <translation type="unfinished">Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
         <source>Memory Address</source>
         <translation type="unfinished">Memory Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
         <source>Memory Operating Mode Capability</source>
         <translation type="unfinished">Memory Operating Mode Capability</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation type="unfinished">Memory Subsystem Controller Manufacturer ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation type="unfinished">Memory Subsystem Controller Product ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
         <source>Memory Technology</source>
         <translation type="unfinished">Memory Technology</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
         <source>Minimum Resolution</source>
         <translation type="unfinished">Minimum Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
         <source>Minimum Voltage</source>
         <translation type="unfinished">Minimum Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
         <source>Modalias</source>
         <translation type="unfinished">Modalias</translation>
     </message>
     <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1352"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Alias</source>
         <translation type="unfinished">Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Manufacturer ID</source>
         <translation type="unfinished">Module Manufacturer ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
         <source>Module Product ID</source>
         <translation type="unfinished">Module Product ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
         <source>MSC</source>
         <translation type="unfinished">MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
         <source>Multicast</source>
         <translation type="unfinished">Multicast</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
         <source>native-path</source>
         <translation type="unfinished">native-path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
         <source>Negotiation Rate</source>
         <translation type="unfinished">Negotiation Rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
         <source>network</source>
         <translation type="unfinished">network</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
         <source>Non-Volatile Size</source>
         <translation type="unfinished">Non-Volatile Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
         <source>Number Of Devices</source>
         <translation type="unfinished">Number Of Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
         <source>Number Of Power Cords</source>
         <translation type="unfinished">Number Of Power Cords</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
         <source>number-up</source>
         <translation type="unfinished">number-up</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
         <source>OEM Information</source>
         <translation type="unfinished">OEM Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
         <source>on-battery</source>
         <translation type="unfinished">on-battery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
         <source>online</source>
         <translation type="unfinished">online</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
         <source>orientation-requested</source>
         <translation type="unfinished">orientation-requested</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
         <source>Packet type</source>
         <translation type="unfinished">Packet type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
         <source>Pairable</source>
         <translation type="unfinished">Pairable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
         <source>Part Number</source>
         <translation type="unfinished">Part Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
         <source>percentage</source>
         <translation type="unfinished">percentage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
         <source>Phys</source>
         <translation type="unfinished">Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
         <source>physical id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
         <source>Physical ID</source>
         <translation type="unfinished">Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
         <source>Physical Memory Array</source>
         <translation type="unfinished">Physical Memory Array</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
         <source>Port</source>
         <translation type="unfinished">Port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
         <source>Powered</source>
         <translation type="unfinished">Powered</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
         <source>power supply</source>
         <translation type="unfinished">power supply</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
         <source>Power Supply State</source>
         <translation type="unfinished">Power Supply State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
         <source>Primary Monitor</source>
         <translation type="unfinished">Primary Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
         <source>print-color-mode</source>
         <translation type="unfinished">print-color-mode</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
         <source>printer-is-accepting-jobs</source>
         <translation type="unfinished">printer-is-accepting-jobs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
         <source>printer-is-shared</source>
         <translation type="unfinished">printer-is-shared</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
         <source>printer-is-temporary</source>
         <translation type="unfinished">printer-is-temporary</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
         <source>printer-make-and-model</source>
         <translation type="unfinished">printer-make-and-model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
         <source>printer-state-change-time</source>
         <translation type="unfinished">printer-state-change-time</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
         <source>printer-state-reasons</source>
         <translation type="unfinished">printer-state-reasons</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
         <source>printer-type</source>
         <translation type="unfinished">printer-type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
         <source>printer-uri-supported</source>
         <translation type="unfinished">printer-uri-supported</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
         <source>product</source>
         <translation type="unfinished">product</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
         <source>Product Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
         <source>Product Name</source>
         <translation type="unfinished">Product Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
         <source>PROP</source>
         <translation type="unfinished">PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
         <source>Rank</source>
         <translation type="unfinished">Rank</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
         <source>rechargeable</source>
         <translation type="unfinished">rechargeable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
         <source>Refresh Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
         <source>Release date</source>
         <translation type="unfinished">Release date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
         <source>Release Date</source>
         <translation type="unfinished">Release Date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
         <source>Revision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
         <source>ROM Size</source>
         <translation type="unfinished">ROM Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
         <source>Rotation Rate</source>
         <translation type="unfinished">Rotation Rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
         <source>Runtime Size</source>
         <translation type="unfinished">Runtime Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
         <source>SBDS Chemistry</source>
         <translation type="unfinished">SBDS Chemistry</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
         <source>SBDS Manufacture Date</source>
         <translation type="unfinished">SBDS Manufacture Date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
         <source>SBDS Serial Number</source>
         <translation type="unfinished">SBDS Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
         <source>SBDS Version</source>
         <translation type="unfinished">SBDS Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
         <source>SCO MTU</source>
         <translation type="unfinished">SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
         <source>sectorsize</source>
         <translation type="unfinished">sectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
         <source>Security Status</source>
         <translation type="unfinished">Security Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
         <source>Serial ID</source>
         <translation type="unfinished">Serial ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
         <source>Serial Number</source>
         <translation type="unfinished">Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
         <source>Service Classes</source>
         <translation type="unfinished">Service Classes</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
         <source>Set</source>
         <translation type="unfinished">Set</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
         <source>Shared</source>
         <translation type="unfinished">Shared</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
         <source>sides</source>
         <translation type="unfinished">sides</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
         <source>Size</source>
         <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
         <source>SKU Number</source>
         <translation type="unfinished">SKU Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
         <source>Slot</source>
         <translation type="unfinished">Slot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
         <source>SMBIOS Version</source>
         <translation type="unfinished">SMBIOS Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
         <source>state</source>
         <translation type="unfinished">state</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
         <source>status</source>
         <translation type="unfinished">status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
         <source>Status</source>
         <translation type="unfinished">Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
         <source>Stepping</source>
         <translation type="unfinished">Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
         <source>SubDevice</source>
         <translation type="unfinished">SubDevice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
         <source>SubVendor</source>
         <translation type="unfinished">SubVendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
         <source>Subversion</source>
         <translation type="unfinished">Subversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
         <source>Support Resolution</source>
         <translation type="unfinished">Support Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
         <source>Sysfs</source>
         <translation type="unfinished">Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
         <source>SysFS_Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
         <source>System Information</source>
         <translation type="unfinished">System Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
         <source>technology</source>
         <translation type="unfinished">technology</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
         <source>temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
         <source>Temperature</source>
         <translation type="unfinished">Temperature</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
         <source>Thermal State</source>
         <translation type="unfinished">Thermal State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
         <source>Threads</source>
         <translation type="unfinished">Threads</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
         <source>Total Width</source>
         <translation type="unfinished">Total Width</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
         <source>Type Detail</source>
         <translation type="unfinished">Type Detail</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
         <source>Unavailable</source>
         <translation type="unfinished">Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
         <source>Uniq</source>
         <translation type="unfinished">Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
         <source>updated</source>
         <translation type="unfinished">updated</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
         <source>URI</source>
         <translation type="unfinished">URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
         <source>UUID</source>
         <translation type="unfinished">UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
         <source>Version</source>
         <translation type="unfinished">Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
         <source>VGA</source>
         <translation type="unfinished">VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
         <source>Virtualization</source>
         <translation type="unfinished">Virtualization</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
         <source>Volatile Size</source>
         <translation type="unfinished">Volatile Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
         <source>voltage</source>
         <translation type="unfinished">voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
         <source>Voltage</source>
         <translation type="unfinished">Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
         <source>Wake-up Type</source>
         <translation type="unfinished">Wake-up Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
         <source>warning-level</source>
         <translation type="unfinished">warning-level</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
         <source>battery</source>
         <translation type="unfinished">battery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
         <source>inch</source>
         <translation type="unfinished">inch</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
         <source>Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
         <source>Speed</source>
         <translation type="unfinished">Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
@@ -1832,47 +1832,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1526"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1539"/>
         <source>Model Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1530"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1543"/>
         <source>Vendor ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1534"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
         <source>Architecture</source>
         <translation type="unfinished">Architecture</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1538"/>
-        <source>Core(s)</source>
-        <translation type="unfinished">Core(s)</translation>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1551"/>
+        <source>CPU(s)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1540"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1553"/>
         <source>Thread(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1562"/>
         <source>L1d cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1555"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1572"/>
         <source>L1i cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1563"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1582"/>
         <source>L2 cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1571"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1592"/>
         <source>L3 cache</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2564,48 +2564,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Storage</source>
         <translation type="unfinished">Storage</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Memory</source>
         <translation type="unfinished">Memory</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Monitor</source>
         <translation type="unfinished">Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="231"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="235"/>
         <source>Failed to enable the device</source>
         <translation>Failed to enable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="234"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="238"/>
         <source>Failed to disable the device</source>
         <translation>Failed to disable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="240"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="244"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Failed to disable it: unable to get the device SN</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="267"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="271"/>
         <source>Update Drivers</source>
         <translation>Update Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="292"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="296"/>
         <source>Uninstall Drivers</source>
         <translation>Uninstall Drivers</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
@@ -92,1391 +92,1391 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Core(s)</source>
         <translation type="unfinished">ལྟེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
         <source>Processor</source>
         <translation type="unfinished">གཏན་ཚིགས་ཐག་གཅོད་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>ACL MTU</source>
         <translation type="unfinished">ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Address</source>
         <translation type="unfinished">གནས་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>Alias</source>
         <translation type="unfinished">འགྲོ་བྱེད</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>ansiversion</source>
         <translation type="unfinished">ANSIཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Application</source>
         <translation type="unfinished">ཉེར་སྤྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
         <source>Architecture</source>
         <translation type="unfinished">གཞི་སྒྲོམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>Array Handle</source>
         <translation type="unfinished">གྲངས་ཚོ་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>Asset Tag</source>
         <translation type="unfinished">རྒྱུ་ནོར་སྒྲིག་ཨང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>Auto Negotiation</source>
         <translation type="unfinished">རང་འགུལ་གྲོས་དོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>Bank Locator</source>
         <translation type="unfinished">ནང་གསོག་རྒྱུ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>Base Board Information</source>
         <translation type="unfinished">མ་པང་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>BD Address</source>
         <translation type="unfinished">སོ་སྔོན་སྒྲིག་ཆས་སྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>BIOS Information</source>
         <translation type="unfinished">BIOSཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>BIOS Revision</source>
         <translation type="unfinished">BIOSབཟོ་བཅོས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>BIOS ROMSIZE</source>
         <translation type="unfinished">BIOS ROMཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Board name</source>
         <translation type="unfinished">མ་པང་གི་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>BogoMIPS</source>
         <translation type="unfinished">BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>Boot-up State</source>
         <translation type="unfinished">འཕྲུལ་སྒོ་ཕྱེ་བའི་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
         <source>Broadcast</source>
         <translation type="unfinished">རྒྱང་བསྒྲགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>Bus</source>
         <translation type="unfinished">མ་སྐུད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>bus info</source>
         <translation type="unfinished">ཆ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>Bus Info</source>
         <translation type="unfinished">མ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>Cache Size</source>
         <translation type="unfinished">ཤོང་གསོག་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>Capabilities</source>
         <translation type="unfinished">བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Capacity</source>
         <translation type="unfinished">ཤོང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Characteristics</source>
         <translation type="unfinished">ཁྱད་གཤིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>Chassis Handle</source>
         <translation type="unfinished">འཁོར་སྒམ་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>Chassis Information</source>
         <translation type="unfinished">འཁོར་སྒམ་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Chip</source>
         <translation type="unfinished">ཉིང་ལྷེབ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Chipset</source>
         <translation type="unfinished">ཉིང་ལྷེབ་ཙུའུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Class</source>
         <translation type="unfinished">རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>Config Status</source>
         <translation type="unfinished">སྒྲིག་སྦྱོར་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>Configured Speed</source>
         <translation type="unfinished">སྒྲིག་སྦྱོར་ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>Configured Voltage</source>
         <translation type="unfinished">སྒྲིག་སྦྱོར་གློག་གནོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Contained Elements</source>
         <translation type="unfinished">ཡོད་པའི་སྒྲིག་ཆས་གྲངས་ཀ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Contained Object Handles</source>
         <translation type="unfinished">བྱ་ཡུལ་བྱ་རིམ་ཚུད་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>copies</source>
         <translation type="unfinished">བསྐྱར་པར་གྲངས་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Core ID</source>
         <translation type="unfinished">ལྟེ་བ། ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
         <source>CPU architecture</source>
         <translation type="unfinished">CPUགཞི་སྒྲོམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>CPU Family</source>
         <translation type="unfinished">ཁྱིམ་རྒྱུད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>CPU ID</source>
         <translation type="unfinished">སྒྲིག་གཅོད་ཆས།  ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>CPU implementer</source>
         <translation type="unfinished">CPUབྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>CPU part</source>
         <translation type="unfinished">CPUལྷུ་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>CPU revision</source>
         <translation type="unfinished">CPUཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>CPU variant</source>
         <translation type="unfinished">CPUའགྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
         <source>critical-action</source>
         <translation type="unfinished">གློག་ཚད་ཆེས་ཉུང་བའི་སྐབས་ལག་བསྟར་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Currently Installed Language</source>
         <translation type="unfinished">མིག་སྔའི་སྒྲིག་སྦྱོར་སྐད་བརྡ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>Current Resolution</source>
         <translation type="unfinished">མིག་སྔའི་འབྱེད་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>daemon-version</source>
         <translation type="unfinished">Daemonཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Data Width</source>
         <translation type="unfinished">གཞི་གྲངས་ཞེང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>Date</source>
         <translation type="unfinished">དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>description</source>
         <translation type="unfinished">ཞིབ་བརྗོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Description</source>
         <translation type="unfinished">ཞིབ་བརྗོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>Design Capacity</source>
         <translation type="unfinished">ཤོང་ཚད་ཇུས་འགོད་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Design Voltage</source>
         <translation type="unfinished">གློག་གནོན་ཇུས་འགོད་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>Device</source>
         <translation type="unfinished">སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>Device Class</source>
         <translation type="unfinished">སྒྲིག་ཆས་རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Device File</source>
         <translation type="unfinished">སྒྲིག་ཆས་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Device Files</source>
         <translation type="unfinished">སྒྲིག་ཆས་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Device Name</source>
         <translation type="unfinished">སྒྲིག་ཆས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Device Number</source>
         <translation type="unfinished">སྒྲིག་ཆས་ཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>DigitalOutput</source>
         <translation type="unfinished">DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Disable</source>
         <translation type="unfinished">སྤྱོད་མི་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Discoverable</source>
         <translation type="unfinished">ཤེས་རྟོགས་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Discovering</source>
         <translation type="unfinished">འཚོལ་ཞིབ་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Display Input</source>
         <translation type="unfinished">ནང་འཇུག་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Display Output</source>
         <translation type="unfinished">ཕྱིར་འདྲེན་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Display Ratio</source>
         <translation type="unfinished">འཆར་བའི་བསྡུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>DP</source>
         <translation type="unfinished">DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>Driver</source>
         <translation type="unfinished">སྒུལ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>Driver Activation Cmd</source>
         <translation type="unfinished">སྒུལ་བྱེད་སྐུལ་སློང་བཀའ་རྒྱ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
         <source>Driver Modules</source>
         <translation type="unfinished">སྒུལ་བྱེད་དཔེ་དུམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
         <source>Driver Status</source>
         <translation type="unfinished">སྒུལ་བྱེད་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
         <source>Driver Version</source>
         <translation type="unfinished">སྒུལ་བྱེད་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
         <source>Duplex</source>
         <translation type="unfinished">གོ་ཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
         <source>DVI</source>
         <translation type="unfinished">DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
         <source>eDP</source>
         <translation type="unfinished">eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
         <source>EGL client APIs</source>
         <translation type="unfinished">EGLམཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
         <source>EGL version</source>
         <translation type="unfinished">EGLཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
         <source>energy</source>
         <translation type="unfinished">ཤོང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
         <source>energy-empty</source>
         <translation type="unfinished">ཤོང་ཚད་ཆུང་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
         <source>energy-full</source>
         <translation type="unfinished">ཤོང་ཚད་ཡོངས་རྫོགས་གསོག་ཟིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
         <source>energy-full-design</source>
         <translation type="unfinished">ཤོང་ཚད་ཇུས་འགོད་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
         <source>energy-rate</source>
         <translation type="unfinished">ནུས་ཚད་སྟུག་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
         <source>Error Correction Type</source>
         <translation type="unfinished">ནོར་བཅོས་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
         <source>Error Information Handle</source>
         <translation type="unfinished">ནོར་འཁྲུལ་ཆ་འཕྲིན་གྱི་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
         <source>EV</source>
         <translation type="unfinished">EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
         <source>Extensions</source>
         <translation type="unfinished">རྒྱ་སྐྱེད་བཀའ་འདུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
         <source>Family</source>
         <translation type="unfinished">ཁྱིམ་རྒྱུད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
         <source>Features</source>
         <translation type="unfinished">ཁྱད་ཆོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
         <source>Firmware</source>
         <translation type="unfinished">བརྟན་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
         <source>Firmware Revision</source>
         <translation type="unfinished">བརྟན་ཆས་བཟོ་བཅོས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
         <source>Firmware Version</source>
         <translation type="unfinished">བརྟན་ཆས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
         <source>Flags</source>
         <translation type="unfinished">ཁྱད་གཤིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
         <source>Form Factor</source>
         <translation type="unfinished">ཚད་གཞི་བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
         <source>GDDR capacity</source>
         <translation type="unfinished">GDDRཤོང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
         <source>Geometry (Logical)</source>
         <translation type="unfinished">དབྱིབས་རྩིས་གཞི་གྲངས།（གཏན་ཚིགས།）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
         <source>GLSL version</source>
         <translation type="unfinished">GLSLཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
         <source>GL version</source>
         <translation type="unfinished">GLཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
         <source>GPU type</source>
         <translation type="unfinished">GPUརིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
         <source>GPU vendor</source>
         <translation type="unfinished">GPUའདོན་སྤྲོད་བྱེད་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
         <source>Graphics Memory</source>
         <translation type="unfinished">འཆར་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
         <source>guid</source>
         <translation type="unfinished">ཁྱོན་ཡོངས་ཀྱི་མཚོན་རྟགས་གཅིག་པུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
         <source>Handlers</source>
         <translation type="unfinished">ཐག་གཅོད་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
         <source>Hardware Class</source>
         <translation type="unfinished">བརྟན་ཆས་རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
         <source>has history</source>
         <translation type="unfinished">ལོ་རྒྱུས་ཟིན་ཐོ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
         <source>has statistics</source>
         <translation type="unfinished">གློག་སྤྱོད་སྡོམ་རྩིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
         <source>HCI Version</source>
         <translation type="unfinished">HCIཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
         <source>HDMI</source>
         <translation type="unfinished">HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
         <source>Height</source>
         <translation type="unfinished">མཐོ་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
         <source>icon-name</source>
         <translation type="unfinished">རྟགས་རིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
         <source>Input/Output</source>
         <translation type="unfinished">ནང་འཇུག/ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
         <source>Installable Languages</source>
         <translation type="unfinished">སྒྲིག་སྦྱོར་བྱ་རུང་བའི་སྐད་བརྡའི་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
         <source>Interface</source>
         <translation type="unfinished">མཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
         <source>Interface Type</source>
         <translation type="unfinished">མཐུད་སྣེའི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
         <source>ioport</source>
         <translation type="unfinished">I/Oམཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
         <source>IO Port</source>
         <translation type="unfinished">I/Oམཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
         <source>IP</source>
         <translation type="unfinished">IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
         <source>IRQ</source>
         <translation type="unfinished">ཆད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
         <source>job-cancel-after</source>
         <translation type="unfinished">དེའི་སྐབས་སུ་པར་འདེབས་ལས་འགན་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
         <source>job-hold-until</source>
         <translation type="unfinished">བར་པར་འདེབས་ལས་འགན་སོར་བཞག་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
         <source>job-priority</source>
         <translation type="unfinished">ལས་འགན་གྱི་སྔོན་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
         <source>KernelModeDriver</source>
         <translation type="unfinished">KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
         <source>KEY</source>
         <translation type="unfinished">KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
         <source>L1d Cache</source>
         <translation type="unfinished">L1ཤོང་གསོག（གཞི་གྲངས།）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
         <source>L1i Cache</source>
         <translation type="unfinished">L1ཤོང་གསོག（བཀའ།）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
         <source>L2 Cache</source>
         <translation type="unfinished">L2ཤོང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
         <source>L3 Cache</source>
         <translation type="unfinished">L3ཤོང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
         <source>L4 Cache</source>
         <translation type="unfinished">L4 འཚོ་བྱེད</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
         <source>Language Description Format</source>
         <translation type="unfinished">སྐད་བརྡ་ཞིབ་བརྗོད་རྣམ་བཞག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
         <source>latency</source>
         <translation type="unfinished">ནར་འགྱངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
         <source>Latency</source>
         <translation type="unfinished">ནར་འགྱངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
         <source>lid-is-closed</source>
         <translation type="unfinished">ལག་ཁྱེར་གློག་ཀླད་ཁ་རྒྱག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
         <source>lid-is-present</source>
         <translation type="unfinished">ལག་ཁྱེར་གློག་ཀླད་ཁ་ཕྱེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
         <source>Link</source>
         <translation type="unfinished">སྦྲེལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
         <source>Link mode</source>
         <translation type="unfinished">སྦྲེལ་མཐུད་དཔེ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
         <source>Link policy</source>
         <translation type="unfinished">སྦྲེལ་མཐུད་དྲིད་ཇུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
         <source>LMP Version</source>
         <translation type="unfinished">LMPཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
         <source>Location</source>
         <translation type="unfinished">གནས་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
         <source>Location In Chassis</source>
         <translation type="unfinished">འཁོར་སྒམ་ནང་གི་སྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
         <source>Locator</source>
         <translation type="unfinished">འཇུག་ཤུར།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
         <source>Lock</source>
         <translation type="unfinished">སྒོ་ལྕག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
         <source>logical name</source>
         <translation type="unfinished">གཏན་ཚིགས་སྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
         <source>Logical Name</source>
         <translation type="unfinished">གཏན་ཚིགས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
         <source>logicalsectorsize</source>
         <translation type="unfinished">གཏན་ཚིགས་ཁུལ་དབྱེའི་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
         <source>Logical Size</source>
         <translation type="unfinished">གཏན་ཚིགས་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
         <source>MAC Address</source>
         <translation type="unfinished">MACསྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
         <source>marker-change-time</source>
         <translation type="unfinished">མཚོན་རྟགས་བཅོས་པའི་ཐེངས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
         <source>Max Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
         <source>Maximum Capacity</source>
         <translation type="unfinished">ཤོང་ཚད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
         <source>Maximum Current</source>
         <translation type="unfinished">གློག་རྒྱུན་ཆེ་ཤོས། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
         <source>Maximum Power</source>
         <translation type="unfinished">ནུས་ཆོད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
         <source>Maximum Rate</source>
         <translation type="unfinished">མྱུར་ཚད་ཆེ་ཤོས། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
         <source>Maximum Resolution</source>
         <translation type="unfinished">འབྱེད་ཕྱོད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
         <source>Maximum Voltage</source>
         <translation type="unfinished">གློག་གནོན་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
         <source>Media Type</source>
         <translation type="unfinished">བར་རྫས་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
         <source>Memory</source>
         <translation type="unfinished">ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
         <source>Memory Address</source>
         <translation type="unfinished">ནང་གསོག་བྱེད་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
         <source>Memory Operating Mode Capability</source>
         <translation type="unfinished">ནང་གསོག་བཀོལ་སྤྱོད་དཔེ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation type="unfinished">ནང་གསོག་མ་ལག་ཡན་ལག་གྱི་ཚོད་འཛིན་ཆས་བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation type="unfinished">ནང་གསོག་མ་ལག་ཡན་ལག་གྱི་ཚོད་འཛིན་ཆས་ཐོན་རྫས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
         <source>Memory Technology</source>
         <translation type="unfinished">ནང་གསོག་ལག་རྩལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
         <source>Minimum Resolution</source>
         <translation type="unfinished">འབྱེད་ཕྱོད་ཆུང་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
         <source>Minimum Voltage</source>
         <translation type="unfinished">གློག་གནོན་ཆུང་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
         <source>Modalias</source>
         <translation type="unfinished">བཀའི་མིང་གཞན་སྒྲིག་བཀོད་བྱེད་པ།</translation>
     </message>
     <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1352"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Alias</source>
         <translation type="unfinished">དཔེ་དུམ་གྱི་མིང་གཞན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Manufacturer ID</source>
         <translation type="unfinished">ལྷུ་ཆས་བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
         <source>Module Product ID</source>
         <translation type="unfinished">ལྷུ་ཆས་ཐོན་རྫས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
         <source>MSC</source>
         <translation type="unfinished">MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
         <source>Multicast</source>
         <translation type="unfinished">མང་བསྒྲགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
         <source>native-path</source>
         <translation type="unfinished">སྒྲིག་སྦྱོར་ཐབས་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
         <source>Negotiation Rate</source>
         <translation type="unfinished">གྲོས་མཐུན་མྱུར་ཚད། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
         <source>network</source>
         <translation type="unfinished">དྲ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
         <source>Non-Volatile Size</source>
         <translation type="unfinished">བོར་མི་སླ་བའི་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
         <source>Number Of Devices</source>
         <translation type="unfinished">གཱ་འཇུག་སའི་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
         <source>Number Of Power Cords</source>
         <translation type="unfinished">གློག་ཁུངས་སྐུད་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
         <source>number-up</source>
         <translation type="unfinished">སྒྲིག་ཨང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
         <source>OEM Information</source>
         <translation type="unfinished">OEMཆ་འཕྲིན། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
         <source>on-battery</source>
         <translation type="unfinished">གློག་རྫས་སྤྱོད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
         <source>online</source>
         <translation type="unfinished">སྐུད་ཐོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
         <source>orientation-requested</source>
         <translation type="unfinished">པར་འདེབས་ཕྱོགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
         <source>Packet type</source>
         <translation type="unfinished">གཞི་གྲངས་ཁུག་གི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
         <source>Pairable</source>
         <translation type="unfinished">ཆ་འགྲིག་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
         <source>Part Number</source>
         <translation type="unfinished">ལྷུ་ཆས་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
         <source>percentage</source>
         <translation type="unfinished">གློག་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
         <source>Phys</source>
         <translation type="unfinished">Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
         <source>physical id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
         <source>Physical ID</source>
         <translation type="unfinished">དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
         <source>Physical Memory Array</source>
         <translation type="unfinished">ནང་གསོག་འཇུག་ཤུར་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
         <source>Port</source>
         <translation type="unfinished">མཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
         <source>Powered</source>
         <translation type="unfinished">གློག་འདོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
         <source>power supply</source>
         <translation type="unfinished">གློག་འདོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
         <source>Power Supply State</source>
         <translation type="unfinished">གློག་འདོན་པའི་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
         <source>Primary Monitor</source>
         <translation type="unfinished">འཆར་ཆས་གཙོ་བོ། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
         <source>print-color-mode</source>
         <translation type="unfinished">ཚོས་གཞི་དཔེ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
         <source>printer-is-accepting-jobs</source>
         <translation type="unfinished">མིག་སྔར་པར་འདེབས་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
         <source>printer-is-shared</source>
         <translation type="unfinished">པར་འདེབས་ཆས་མཉམ་སྤྱོད་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
         <source>printer-is-temporary</source>
         <translation type="unfinished">གནས་སྐབས་པར་འདེབས་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
         <source>printer-make-and-model</source>
         <translation type="unfinished">བཟོ་མཁན་དང་བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
         <source>printer-state-change-time</source>
         <translation type="unfinished">པར་འདེབས་ཆས་ཀྱི་ངང་ཚུལ་བཅོས་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
         <source>printer-state-reasons</source>
         <translation type="unfinished">པར་འདེབས་ཆས་ཀྱི་ངང་ཚུལ་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
         <source>printer-type</source>
         <translation type="unfinished">པར་འདེབས་ཆས་ཀྱི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
         <source>printer-uri-supported</source>
         <translation type="unfinished">རྒྱབ་སྐྱོར་བྱེད་པའི་URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
         <source>product</source>
         <translation type="unfinished">ཐོན་རྫས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
         <source>Product Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
         <source>Product Name</source>
         <translation type="unfinished">ཐོན་རྫས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
         <source>PROP</source>
         <translation type="unfinished">PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
         <source>Rank</source>
         <translation type="unfinished">གནས་སྟར།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
         <source>rechargeable</source>
         <translation type="unfinished">གློག་བསྐྱར་གསོག་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
         <source>Refresh Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
         <source>Release date</source>
         <translation type="unfinished">ཁྱབ་བསྒྲགས་བྱས་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
         <source>Release Date</source>
         <translation type="unfinished">ཡོངས་བསྒྲགས་བྱེད་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
         <source>Revision</source>
         <translation type="unfinished">བཟོ་བཅོས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
         <source>ROM Size</source>
         <translation type="unfinished">ROMཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
         <source>Rotation Rate</source>
         <translation type="unfinished">སྐོར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
         <source>Runtime Size</source>
         <translation type="unfinished">འཁོར་རྒྱུག་ནང་གསོག་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
         <source>SBDS Chemistry</source>
         <translation type="unfinished">SBDSརྒྱུ་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
         <source>SBDS Manufacture Date</source>
         <translation type="unfinished">SBDSབཟོ་བའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
         <source>SBDS Serial Number</source>
         <translation type="unfinished">SBDSརིམ་སྟར་ཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
         <source>SBDS Version</source>
         <translation type="unfinished">SBDSཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
         <source>SCO MTU</source>
         <translation type="unfinished">SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
         <source>sectorsize</source>
         <translation type="unfinished">གཡབ་ཁུལ་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
         <source>Security Status</source>
         <translation type="unfinished">བདེ་འཇགས་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
         <source>Serial ID</source>
         <translation type="unfinished">རིམ་སྟར་ཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
         <source>Serial Number</source>
         <translation type="unfinished">རིམ་སྟར་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
         <source>Service Classes</source>
         <translation type="unfinished">ཞབས་ཞུའི་རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
         <source>Set</source>
         <translation type="unfinished">སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
         <source>Shared</source>
         <translation type="unfinished">མཉམ་སྤྱོད་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
         <source>sides</source>
         <translation type="unfinished">པར་འདེབས་ངོས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
         <source>Size</source>
         <translation type="unfinished">ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
         <source>SKU Number</source>
         <translation type="unfinished">SKUཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
         <source>Slot</source>
         <translation type="unfinished">འཇུག་ཤུར།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
         <source>SMBIOS Version</source>
         <translation type="unfinished">SMBIOSཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
         <source>state</source>
         <translation type="unfinished">ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
         <source>status</source>
         <translation type="unfinished">ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
         <source>Status</source>
         <translation type="unfinished">ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
         <source>Stepping</source>
         <translation type="unfinished">གོམ་བགྲོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
         <source>SubDevice</source>
         <translation type="unfinished">སྒྲིག་ཆས་ཡན་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
         <source>SubVendor</source>
         <translation type="unfinished">བཟོ་མཁན་ཡན་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
         <source>Subversion</source>
         <translation type="unfinished">པར་གཞི་ཡན་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
         <source>Support Resolution</source>
         <translation type="unfinished">རྒྱབ་སྐྱོར་ཐུབ་པའི་འབྱེད་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
         <source>Sysfs</source>
         <translation type="unfinished">Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
         <source>SysFS_Path</source>
         <translation type="unfinished">SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
         <source>System Information</source>
         <translation type="unfinished">མ་ལག་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
         <source>technology</source>
         <translation type="unfinished">གློག་རྫས་ལག་རྩལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
         <source>temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
         <source>Temperature</source>
         <translation type="unfinished">དྲོད་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
         <source>Thermal State</source>
         <translation type="unfinished">དྲོད་འཐོར་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
         <source>Threads</source>
         <translation type="unfinished">སྐུད་རིམ་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
         <source>Total Width</source>
         <translation type="unfinished">སྤྱིའི་ཞེང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
         <source>Type</source>
         <translation type="unfinished">རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
         <source>Type Detail</source>
         <translation type="unfinished">རིགས་གྲས་ཞིབ་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
         <source>Unavailable</source>
         <translation type="unfinished">སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
         <source>Uniq</source>
         <translation type="unfinished">Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
         <source>updated</source>
         <translation type="unfinished">གསར་སྒྱུར་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
         <source>URI</source>
         <translation type="unfinished">URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
         <source>UUID</source>
         <translation type="unfinished">UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
         <source>Version</source>
         <translation type="unfinished">པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
         <source>VGA</source>
         <translation type="unfinished">VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
         <source>Virtualization</source>
         <translation type="unfinished">རྟོག་བཟོ་ཅན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
         <source>Volatile Size</source>
         <translation type="unfinished">བོར་སླ་བའི་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
         <source>voltage</source>
         <translation type="unfinished">གློག་གནོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
         <source>Voltage</source>
         <translation type="unfinished">གློག་གནོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
         <source>Wake-up Type</source>
         <translation type="unfinished">གཉིད་སད་པའི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
         <source>warning-level</source>
         <translation type="unfinished">ཉེན་བརྡའི་བང་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
         <source>battery</source>
         <translation type="unfinished">གློག་རྫས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
         <source>inch</source>
         <translation type="unfinished">དབྱིན་ཚུན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
         <source>Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
         <source>Speed</source>
         <translation type="unfinished">ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
@@ -1832,47 +1832,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1526"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1539"/>
         <source>Model Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1530"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1543"/>
         <source>Vendor ID</source>
         <translation>བཟོ་བྱེད་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1534"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
         <source>Architecture</source>
         <translation>གཞི་སྒྲོམ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1538"/>
-        <source>Core(s)</source>
-        <translation>རིག་རྟགས་འཕྲུལ་འཁོར།</translation>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1551"/>
+        <source>CPU(s)</source>
+        <translation>འཚར་ལོན་སྒྲིག་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1540"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1553"/>
         <source>Thread(s)</source>
         <translation>སྙིང་རྫས་རེའི་ཐིག་སྒྲོན་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1562"/>
         <source>L1d cache</source>
         <translation>L1 གཏོགས་ཁང་ (གཞི་གྲངས)</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1555"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1572"/>
         <source>L1i cache</source>
         <translation>L1 གཏོགས་ཁང་ (བཀའ་རིན)</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1563"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1582"/>
         <source>L2 cache</source>
         <translation>L2 གཏོགས་ཁང་</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1571"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1592"/>
         <source>L3 cache</source>
         <translation>L3 གཏོགས་ཁང་</translation>
     </message>
@@ -2564,48 +2564,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Storage</source>
         <translation type="unfinished">གསོག་འཇོག་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Memory</source>
         <translation type="unfinished">ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Monitor</source>
         <translation type="unfinished">སྒྲིག་ཆས་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="231"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="235"/>
         <source>Failed to enable the device</source>
         <translation>འགོ་སློང་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="234"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="238"/>
         <source>Failed to disable the device</source>
         <translation>སྤྱོད་མི་ཆོག་པ་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="240"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="244"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>སྒྲིག་ཆས་ཀྱི་རིམ་ཨང་ཐོབ་ཐབས་མི་འདུག་པས་སྤྱོད་མི་རུང་བ་ཐུབ་མ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="267"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="271"/>
         <source>Update Drivers</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="292"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="296"/>
         <source>Uninstall Drivers</source>
         <translation>སྐུལ་བྱེད་བཤིག་པ། </translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
@@ -92,1391 +92,1391 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Core(s)</source>
         <translation type="unfinished">يادرو</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
         <source>Processor</source>
         <translation type="unfinished">بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>ACL MTU</source>
         <translation type="unfinished">ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Address</source>
         <translation type="unfinished">ئادرېس</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>Alias</source>
         <translation type="unfinished">ئەلىاس</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>ansiversion</source>
         <translation type="unfinished">ANSI نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Application</source>
         <translation type="unfinished">ئىلتىماس</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
         <source>Architecture</source>
         <translation type="unfinished">قۇرۇلما</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>Array Handle</source>
         <translation type="unfinished">گورۇپپا پىروگرامما</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>Asset Tag</source>
         <translation type="unfinished">مۈلۈك بەلگىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>Auto Negotiation</source>
         <translation type="unfinished">ئاپتوماتىك سۆھبەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>Bank Locator</source>
         <translation type="unfinished">سىغم بەلگىلىگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>Base Board Information</source>
         <translation type="unfinished">ئانا تاختا ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>BD Address</source>
         <translation type="unfinished">BD ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>BIOS Information</source>
         <translation type="unfinished">BIOS ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>BIOS Revision</source>
         <translation type="unfinished">BIOS تۈزىتىلگەن نۇسخىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>BIOS ROMSIZE</source>
         <translation type="unfinished">BIOS ROM سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Board name</source>
         <translation type="unfinished">مۇدىرىيەت ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>BogoMIPS</source>
         <translation type="unfinished">BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>Boot-up State</source>
         <translation type="unfinished">قوزغىتىش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
         <source>Broadcast</source>
         <translation type="unfinished">رادىيو</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>Bus</source>
         <translation type="unfinished">ئومۇمىي لىنىيە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>bus info</source>
         <translation type="unfinished">باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>Bus Info</source>
         <translation type="unfinished">باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>Cache Size</source>
         <translation type="unfinished">ساقلانما سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>Capabilities</source>
         <translation type="unfinished">ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Capacity</source>
         <translation type="unfinished">سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Characteristics</source>
         <translation type="unfinished">ئالاھىدىلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>Chassis Handle</source>
         <translation type="unfinished">ئاساسىي ماشىنا ساندۇقى پىروگراممىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>Chassis Information</source>
         <translation type="unfinished">تەگلىك ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Chip</source>
         <translation type="unfinished">ئۆزەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Chipset</source>
         <translation type="unfinished">ئۆزەك گورۇپىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Class</source>
         <translation type="unfinished">تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>Config Status</source>
         <translation type="unfinished">ھالەتنى تەڭشەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>Configured Speed</source>
         <translation type="unfinished">تەڭشەلگەن سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>Configured Voltage</source>
         <translation type="unfinished">تەڭشەلگەن توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Contained Elements</source>
         <translation type="unfinished">ئۆز ئىچىگە ئېلىنغان ئېلمىنىتلار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Contained Object Handles</source>
         <translation type="unfinished">مەزمۇننى ئۆز ئىچىگە ئالغان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>copies</source>
         <translation type="unfinished">نۇسخىلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Core ID</source>
         <translation type="unfinished">يادرولۇق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
         <source>CPU architecture</source>
         <translation type="unfinished">بىر تەرەپ قىلغۇچ قۇرۇلمىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>CPU Family</source>
         <translation type="unfinished">بىر تەرەپ قىلغۇچ ئائىلىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>CPU ID</source>
         <translation type="unfinished">بىر تەرەپ قىلغۇچ كىملىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>CPU implementer</source>
         <translation type="unfinished">بىر تەرەپ قىلغۇچ پىروگراممىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>CPU part</source>
         <translation type="unfinished">بىر تەرەپ قىلغۇچ قىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>CPU revision</source>
         <translation type="unfinished">بىر تەرەپ قىلغۇچ تۈزىتىلگەن نۇسخىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>CPU variant</source>
         <translation type="unfinished">مەركىزى بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
         <source>critical-action</source>
         <translation type="unfinished">توك بەك ئاز قالغاندا ئىجرا بولسۇن</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Currently Installed Language</source>
         <translation type="unfinished">ھازىر قاچىلانغان تىل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>Current Resolution</source>
         <translation type="unfinished">نۆۋەتتىكى قارار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>daemon-version</source>
         <translation type="unfinished">Daemon نەشىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Data Width</source>
         <translation type="unfinished">سان-سىپېر چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>Date</source>
         <translation type="unfinished">چېسلا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>description</source>
         <translation type="unfinished">چۈشەندۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Description</source>
         <translation type="unfinished">چۈشەندۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>Design Capacity</source>
         <translation type="unfinished">لايىھەلەنگەن ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Design Voltage</source>
         <translation type="unfinished">لايىھەنگەن بېسىم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>Device</source>
         <translation type="unfinished">ئۈسكۈنە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>Device Class</source>
         <translation type="unfinished">ئۈسكۈنە سىنىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Device File</source>
         <translation type="unfinished">ئۈسكۈنە ھۆججىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Device Files</source>
         <translation type="unfinished">ئۈسكۈنە ھۆججەتلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Device Name</source>
         <translation type="unfinished">ئۈسكۈنىنىڭ ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Device Number</source>
         <translation type="unfinished">ئۈسكۈنە نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>DigitalOutput</source>
         <translation type="unfinished">DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Disable</source>
         <translation type="unfinished">چەكلەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Discoverable</source>
         <translation type="unfinished">بايقاشقا بولىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Discovering</source>
         <translation type="unfinished">ئىزدەۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Display Input</source>
         <translation type="unfinished">كىرگۈزۈشنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Display Output</source>
         <translation type="unfinished">چىقىرىشنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Display Ratio</source>
         <translation type="unfinished">كۆرسىتىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>DP</source>
         <translation type="unfinished">DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>Driver</source>
         <translation type="unfinished">قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>Driver Activation Cmd</source>
         <translation type="unfinished">قوزغاتقۇچ ئاكتىپلاش بۇيرۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
         <source>Driver Modules</source>
         <translation type="unfinished">قوزغاتقۇچ مودۇلى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
         <source>Driver Status</source>
         <translation type="unfinished">قوزغاتقۇ ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
         <source>Driver Version</source>
         <translation type="unfinished">قوزغاتقۇچ نەشىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
         <source>Duplex</source>
         <translation type="unfinished">قوش ئىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
         <source>DVI</source>
         <translation type="unfinished">DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
         <source>eDP</source>
         <translation type="unfinished">eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
         <source>EGL client APIs</source>
         <translation type="unfinished">EGL خېرىدار API لىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
         <source>EGL version</source>
         <translation type="unfinished">EGL نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
         <source>energy</source>
         <translation type="unfinished">ئېنېرگىيە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
         <source>energy-empty</source>
         <translation type="unfinished">ئېنېرگىيەسىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
         <source>energy-full</source>
         <translation type="unfinished">ئېنېرگىيە تولۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
         <source>energy-full-design</source>
         <translation type="unfinished">ئېنېرگىيە تولۇق لايىھىلەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
         <source>energy-rate</source>
         <translation type="unfinished">ئېنېرگىيە نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
         <source>Error Correction Type</source>
         <translation type="unfinished">خاتالىق تۈزىتىش تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
         <source>Error Information Handle</source>
         <translation type="unfinished">خاتالىق ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
         <source>EV</source>
         <translation type="unfinished">EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
         <source>Extensions</source>
         <translation type="unfinished">كېڭەيتىلمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
         <source>Family</source>
         <translation type="unfinished">ئائىلە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
         <source>Features</source>
         <translation type="unfinished">خاسلىقلار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
         <source>Firmware</source>
         <translation type="unfinished">قۇيما ماتېرىيال</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
         <source>Firmware Revision</source>
         <translation type="unfinished">زاپچاس يامىقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
         <source>Firmware Version</source>
         <translation type="unfinished">يۇمشاق دېتال نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
         <source>Flags</source>
         <translation type="unfinished">بايراق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
         <source>Form Factor</source>
         <translation type="unfinished">سىغىم شەكلى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
         <source>GDDR capacity</source>
         <translation type="unfinished">GDDR سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
         <source>Geometry (Logical)</source>
         <translation type="unfinished">گېئومېتىرىيە (لوگىكىلىق)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
         <source>GLSL version</source>
         <translation type="unfinished">GLSL نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
         <source>GL version</source>
         <translation type="unfinished">GL نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
         <source>GPU type</source>
         <translation type="unfinished">GPU تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
         <source>GPU vendor</source>
         <translation type="unfinished">GPU ساتقۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
         <source>Graphics Memory</source>
         <translation type="unfinished">گرافىك ئەستە ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
         <source>guid</source>
         <translation type="unfinished">كۆرسەتمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
         <source>Handlers</source>
         <translation type="unfinished">بېجىرگۈچىلەر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
         <source>Hardware Class</source>
         <translation type="unfinished">قاتتىق دېتال سىنىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
         <source>has history</source>
         <translation type="unfinished">خاتىرە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
         <source>has statistics</source>
         <translation type="unfinished">ئىستاتىستىكا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
         <source>HCI Version</source>
         <translation type="unfinished">HCI نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
         <source>HDMI</source>
         <translation type="unfinished">HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
         <source>Height</source>
         <translation type="unfinished">ئېگىزلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
         <source>icon-name</source>
         <translation type="unfinished">سىنبەلگە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
         <source>Input/Output</source>
         <translation type="unfinished">كىرگۈزۈش / چىقىرىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
         <source>Installable Languages</source>
         <translation type="unfinished">قاچىلىغىلى بولىدىغان تىللار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
         <source>Interface</source>
         <translation type="unfinished">كۆرۈنمە يۈزى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
         <source>Interface Type</source>
         <translation type="unfinished">كۆرۈنمە يۈزى تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
         <source>ioport</source>
         <translation type="unfinished">I/O ئېغىزى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
         <source>IO Port</source>
         <translation type="unfinished">I/O ئېغىزى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
         <source>IP</source>
         <translation type="unfinished">IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
         <source>IRQ</source>
         <translation type="unfinished">ئۈزۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
         <source>job-cancel-after</source>
         <translation type="unfinished">خىزمەتنى ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
         <source>job-hold-until</source>
         <translation type="unfinished">خىزمەتنى تۇتۇش بۆلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
         <source>job-priority</source>
         <translation type="unfinished">خىزمەت تەرتىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
         <source>KernelModeDriver</source>
         <translation type="unfinished">KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
         <source>KEY</source>
         <translation type="unfinished">KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
         <source>L1d Cache</source>
         <translation type="unfinished">L1d غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
         <source>L1i Cache</source>
         <translation type="unfinished">L1i غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
         <source>L2 Cache</source>
         <translation type="unfinished">L2 غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
         <source>L3 Cache</source>
         <translation type="unfinished">L3 غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
         <source>L4 Cache</source>
         <translation type="unfinished">L4 ھەجىمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
         <source>Language Description Format</source>
         <translation type="unfinished">تىل چۈشەندۈرۈش فورماتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
         <source>latency</source>
         <translation type="unfinished">كېچىكىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
         <source>Latency</source>
         <translation type="unfinished">كېچىكتۈرمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
         <source>lid-is-closed</source>
         <translation type="unfinished">قاپاق تاقالغان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
         <source>lid-is-present</source>
         <translation type="unfinished">لەپتوپنى ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
         <source>Link</source>
         <translation type="unfinished">ئۇلىنىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
         <source>Link mode</source>
         <translation type="unfinished">ئۇلىنىش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
         <source>Link policy</source>
         <translation type="unfinished">ئۇلىنىش سىياسىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
         <source>LMP Version</source>
         <translation type="unfinished">LMP نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
         <source>Location</source>
         <translation type="unfinished">ئورنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
         <source>Location In Chassis</source>
         <translation type="unfinished">تەگلىك ئورنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
         <source>Locator</source>
         <translation type="unfinished">ئورۇن بەلگىلىگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
         <source>Lock</source>
         <translation type="unfinished">قۇلۇپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
         <source>logical name</source>
         <translation type="unfinished">لوگىكىلىق ئىسىم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
         <source>Logical Name</source>
         <translation type="unfinished">لوگىكىلىق ئىسىم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
         <source>logicalsectorsize</source>
         <translation type="unfinished">لوگىكىلىق سېكتور چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
         <source>Logical Size</source>
         <translation type="unfinished">لوگىكىلىق چوڭلۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
         <source>MAC Address</source>
         <translation type="unfinished">MAC ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
         <source>marker-change-time</source>
         <translation type="unfinished">ئۆزگەرتىش سانىغا بەلگە سېلىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
         <source>Max Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
         <source>Maximum Capacity</source>
         <translation type="unfinished">ئەڭ چوڭ سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
         <source>Maximum Current</source>
         <translation type="unfinished">ئەڭ چوڭ توك ئېقىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
         <source>Maximum Power</source>
         <translation type="unfinished">ئەڭ چوڭ قۇۋۋەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
         <source>Maximum Rate</source>
         <translation type="unfinished">ئەڭ چوڭ تېزلىنىشى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
         <source>Maximum Resolution</source>
         <translation type="unfinished">ئەڭ چوڭ ئېنىقلىق دەرىجىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
         <source>Maximum Voltage</source>
         <translation type="unfinished">ئەڭ چوڭ توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
         <source>Media Type</source>
         <translation type="unfinished">مېدىيا تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
         <source>Memory</source>
         <translation type="unfinished">ساقلىغۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
         <source>Memory Address</source>
         <translation type="unfinished">ئىچكى ساقلىغۇچ ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
         <source>Memory Operating Mode Capability</source>
         <translation type="unfinished">ئىچكى ساقلىغۇچ مەشغۇلات ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation type="unfinished">ئىچكى ساقلىغۇچ سىستېمىسى كونتروللىغۇچ ئىشلەپچىقارغۇچى كىملىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation type="unfinished">ئىچكى ساقلىغۇچ سىستېمىسى كونتروللىغۇچ مەھسۇلات IDسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
         <source>Memory Technology</source>
         <translation type="unfinished">ئىچكى ساقلىغۇچ تېخنىكىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
         <source>Minimum Resolution</source>
         <translation type="unfinished">ئەڭ تۆۋەن ئېنىقلىق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
         <source>Minimum Voltage</source>
         <translation type="unfinished">ئەڭ تۆۋەن توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
         <source>Modalias</source>
         <translation type="unfinished">بۇيرۇققا باشقا نام بەلگىلەش</translation>
     </message>
     <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1352"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Alias</source>
         <translation type="unfinished">مودېلنىڭ باشقا نامى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Manufacturer ID</source>
         <translation type="unfinished">مودېل ئىشلەپچىقارغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
         <source>Module Product ID</source>
         <translation type="unfinished">IDمودۇل مەھسۇلات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
         <source>MSC</source>
         <translation type="unfinished">MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
         <source>Multicast</source>
         <translation type="unfinished">قويغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
         <source>native-path</source>
         <translation type="unfinished">قاچىلاش ئورنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
         <source>Negotiation Rate</source>
         <translation type="unfinished">كېڭىشىش تېزلىك نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
         <source>network</source>
         <translation type="unfinished">تور</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
         <source>Non-Volatile Size</source>
         <translation type="unfinished">تۇراقسىز چوڭلۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
         <source>Number Of Devices</source>
         <translation type="unfinished">ئۈسكۈنىلەرنىڭ سانى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
         <source>Number Of Power Cords</source>
         <translation type="unfinished">توك سىمىنىڭ سانى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
         <source>number-up</source>
         <translation type="unfinished">تەريىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
         <source>OEM Information</source>
         <translation type="unfinished">OEM ئۇچۇرلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
         <source>on-battery</source>
         <translation type="unfinished">باتارېيەدە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
         <source>online</source>
         <translation type="unfinished">توردا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
         <source>orientation-requested</source>
         <translation type="unfinished">يۆنىلىش تەلەپ قىلىنغان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
         <source>Packet type</source>
         <translation type="unfinished">بولاق تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
         <source>Pairable</source>
         <translation type="unfinished">مۇۋاپىق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
         <source>Part Number</source>
         <translation type="unfinished">بۆلەك نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
         <source>percentage</source>
         <translation type="unfinished">پىرسەنت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
         <source>Phys</source>
         <translation type="unfinished">Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
         <source>physical id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
         <source>Physical ID</source>
         <translation type="unfinished">فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
         <source>Physical Memory Array</source>
         <translation type="unfinished">فىزىكىلىق ساقلىغۇچ گورۇپىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
         <source>Port</source>
         <translation type="unfinished">پورت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
         <source>Powered</source>
         <translation type="unfinished">تۆھپىكار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
         <source>power supply</source>
         <translation type="unfinished">توك بىلەن تەمىنلەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
         <source>Power Supply State</source>
         <translation type="unfinished">توك بىلەن تەمىنلەش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
         <source>Primary Monitor</source>
         <translation type="unfinished">دەسلەپكى كۆزەتكۈ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
         <source>print-color-mode</source>
         <translation type="unfinished">رەڭلىك بىسىش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
         <source>printer-is-accepting-jobs</source>
         <translation type="unfinished">نۆۋەتتە باسقىلى بولىدىغىنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
         <source>printer-is-shared</source>
         <translation type="unfinished">پىرىنتېر ئورتاقلاندى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
         <source>printer-is-temporary</source>
         <translation type="unfinished">ۋاقىتلىق پىرىنتېر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
         <source>printer-make-and-model</source>
         <translation type="unfinished">پىرىنتېر ياسىغۇچى ۋە تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
         <source>printer-state-change-time</source>
         <translation type="unfinished">بېسىش ھالىتىنى ئۆزگەرتكەن ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
         <source>printer-state-reasons</source>
         <translation type="unfinished">بېسىش ھالىتى ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
         <source>printer-type</source>
         <translation type="unfinished">پرىنتېر تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
         <source>printer-uri-supported</source>
         <translation type="unfinished">URI نى قوللايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
         <source>product</source>
         <translation type="unfinished">مەھسۇلات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
         <source>Product Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
         <source>Product Name</source>
         <translation type="unfinished">مەھسۇلات ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
         <source>PROP</source>
         <translation type="unfinished">PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
         <source>Rank</source>
         <translation type="unfinished">رەت تەرتىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
         <source>rechargeable</source>
         <translation type="unfinished">توك قاچىلىغىلى بولىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
         <source>Refresh Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
         <source>Release date</source>
         <translation type="unfinished">ئېلان قىلىنغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
         <source>Release Date</source>
         <translation type="unfinished">ئېلان قىلىنغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
         <source>Revision</source>
         <translation type="unfinished">تۈزىتىلگەن نۇسخىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
         <source>ROM Size</source>
         <translation type="unfinished">ROM سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
         <source>Rotation Rate</source>
         <translation type="unfinished">ئايلىنىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
         <source>Runtime Size</source>
         <translation type="unfinished">ئىجرا ۋاقتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
         <source>SBDS Chemistry</source>
         <translation type="unfinished">SBDS ماتېرىيالى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
         <source>SBDS Manufacture Date</source>
         <translation type="unfinished">SBDS ئىشلەپچىقىرىش ۋاقتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
         <source>SBDS Serial Number</source>
         <translation type="unfinished">SBDS تەرتىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
         <source>SBDS Version</source>
         <translation type="unfinished">SBDS نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
         <source>SCO MTU</source>
         <translation type="unfinished">SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
         <source>sectorsize</source>
         <translation type="unfinished">ساھە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
         <source>Security Status</source>
         <translation type="unfinished">بىخەتەرلىك ھالەتلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
         <source>Serial ID</source>
         <translation type="unfinished">تەرتىپ نومۇر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
         <source>Serial Number</source>
         <translation type="unfinished">تەرتىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
         <source>Service Classes</source>
         <translation type="unfinished">مۇلازىمەت دەرسلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
         <source>Set</source>
         <translation type="unfinished">بېكىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
         <source>Shared</source>
         <translation type="unfinished">ئورتاقلاشقان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
         <source>sides</source>
         <translation type="unfinished">يان تەرەپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
         <source>Size</source>
         <translation type="unfinished">چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
         <source>SKU Number</source>
         <translation type="unfinished">SKU نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
         <source>Slot</source>
         <translation type="unfinished">ئوقۇر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
         <source>SMBIOS Version</source>
         <translation type="unfinished">SMBIOS نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
         <source>state</source>
         <translation type="unfinished">ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
         <source>status</source>
         <translation type="unfinished">ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
         <source>Status</source>
         <translation type="unfinished">ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
         <source>Stepping</source>
         <translation type="unfinished">قەدەم بېسىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
         <source>SubDevice</source>
         <translation type="unfinished">قوشۇمچى ئۈسكىنە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
         <source>SubVendor</source>
         <translation type="unfinished">قوشۇمچە ساتقۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
         <source>Subversion</source>
         <translation type="unfinished">قوشۇمچە نەشىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
         <source>Support Resolution</source>
         <translation type="unfinished">قوللاش قارارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
         <source>Sysfs</source>
         <translation type="unfinished">Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
         <source>SysFS_Path</source>
         <translation type="unfinished">SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
         <source>System Information</source>
         <translation type="unfinished">سىستېما ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
         <source>technology</source>
         <translation type="unfinished">باتارىيە تېخنىكىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
         <source>temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
         <source>Temperature</source>
         <translation type="unfinished">تېمپېراتۇرا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
         <source>Thermal State</source>
         <translation type="unfinished">قىززىق ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
         <source>Threads</source>
         <translation type="unfinished">تېما</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
         <source>Total Width</source>
         <translation type="unfinished">ئومۇمىي كەڭلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
         <source>Type</source>
         <translation type="unfinished">تىپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
         <source>Type Detail</source>
         <translation type="unfinished">تەپسىلات تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
         <source>Unavailable</source>
         <translation type="unfinished">ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
         <source>Uniq</source>
         <translation type="unfinished">Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
         <source>updated</source>
         <translation type="unfinished">يېڭىلاندى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
         <source>URI</source>
         <translation type="unfinished">URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
         <source>UUID</source>
         <translation type="unfinished">UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
         <source>Version</source>
         <translation type="unfinished">نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
         <source>VGA</source>
         <translation type="unfinished">VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
         <source>Virtualization</source>
         <translation type="unfinished">مەۋھۇملاشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
         <source>Volatile Size</source>
         <translation type="unfinished">ئۆزگىرىشچان چوڭلۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
         <source>voltage</source>
         <translation type="unfinished">توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
         <source>Voltage</source>
         <translation type="unfinished">توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
         <source>Wake-up Type</source>
         <translation type="unfinished">ئويغىنىش تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
         <source>warning-level</source>
         <translation type="unfinished">ئاگاھلاندۇرۇش دەرىجىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
         <source>battery</source>
         <translation type="unfinished">باتارېيە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
         <source>inch</source>
         <translation type="unfinished">ئىنگىلىزچىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
         <source>Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
         <source>Speed</source>
         <translation type="unfinished">سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
         <source>Model</source>
         <translation>مودېل</translation>
     </message>
@@ -1832,47 +1832,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1526"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1539"/>
         <source>Model Name</source>
         <translation>نامى</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1530"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1543"/>
         <source>Vendor ID</source>
         <translation>ئىشلەپچىقارغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1534"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
         <source>Architecture</source>
         <translation>قۇرۇلما</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1538"/>
-        <source>Core(s)</source>
-        <translation>مەنتىقىي پىروتسېسسور</translation>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1551"/>
+        <source>CPU(s)</source>
+        <translation>مەنتىقىي پىروتسېسور</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1540"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1553"/>
         <source>Thread(s)</source>
         <translation>ھەر يادرو خېتى سانى</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1562"/>
         <source>L1d cache</source>
         <translation>كېش (سانلىق) L1</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1555"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1572"/>
         <source>L1i cache</source>
         <translation>كېش (بۇيرۇق) L1</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1563"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1582"/>
         <source>L2 cache</source>
         <translation>كېش L2</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1571"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1592"/>
         <source>L3 cache</source>
         <translation>كېش L3</translation>
     </message>
@@ -2564,48 +2564,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Storage</source>
         <translation type="unfinished">ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Memory</source>
         <translation type="unfinished">ساقلىغۇ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Monitor</source>
         <translation type="unfinished">نازارەتچى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="231"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="235"/>
         <source>Failed to enable the device</source>
         <translation>ئۈسكۈنىنى قوزغىتىش مەغلۇب بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="234"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="238"/>
         <source>Failed to disable the device</source>
         <translation>ئۈسكۈنىنى چەكلىيەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="240"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="244"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>ئۈسكۈنە تەرتىپ نومۇرىنى ئئالالمىدى، چەكلەش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="267"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="271"/>
         <source>Update Drivers</source>
         <translation> قوزغاتقۇچ يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="292"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="296"/>
         <source>Uninstall Drivers</source>
         <translation>قوزغاتقۇچنى چىقىرۋىتىش</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
@@ -92,1391 +92,1391 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Device Name</source>
         <translation>设备名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Chip</source>
         <translation>芯片</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
         <source>SysFS_Path</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
         <source>Revision</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
         <source>KernelModeDriver</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
         <source>IRQ</source>
         <translation>中断</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Chipset</source>
         <translation>芯片组</translation>
     </message>
     <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1352"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Alias</source>
         <translation>模块别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>Driver</source>
         <translation>驱动</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
         <source>Driver Version</source>
         <translation>驱动版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
         <source>logical name</source>
         <translation>逻辑名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
         <source>Logical Name</source>
         <translation>逻辑名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
         <source>MAC Address</source>
         <translation>物理地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>CPU ID</source>
         <translation>处理器ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Core ID</source>
         <translation>核心ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
         <source>Threads</source>
         <translation>线程数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>BogoMIPS</source>
         <translation>运行速度（Bogomips）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
         <source>Architecture</source>
         <translation>架构</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>CPU Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
         <source>Processor</source>
         <translation>逻辑处理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
         <source>Virtualization</source>
         <translation>虚拟化</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
         <source>Flags</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
         <source>Extensions</source>
         <translation>扩展指令集</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
         <source>L3 Cache</source>
         <translation>L3缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
         <source>L4 Cache</source>
         <translation>L4缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
         <source>L2 Cache</source>
         <translation>L2缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
         <source>L1i Cache</source>
         <translation>L1缓存（指令）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
         <source>L1d Cache</source>
         <translation>L1缓存（数据）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
         <source>Stepping</source>
         <translation>步进</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
         <source>Frequency</source>
         <translation>频率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
         <source>Max Frequency</source>
         <translation>最大频率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
         <source>Graphics Memory</source>
         <translation>显存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
         <source>Memory Address</source>
         <translation>内存地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
         <source>IO Port</source>
         <translation>I/O端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
         <source>Maximum Resolution</source>
         <translation>最大分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
         <source>Minimum Resolution</source>
         <translation>最小分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Display Output</source>
         <translation>显示输出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
         <source>Interface</source>
         <translation>接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>Bus Info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>bus info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
         <source>Maximum Current</source>
         <translation>最大电流</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
         <source>Total Width</source>
         <translation>总位宽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
         <source>Locator</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>Configured Voltage</source>
         <translation>配置电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
         <source>Maximum Voltage</source>
         <translation>最高电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
         <source>Minimum Voltage</source>
         <translation>最低电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>Configured Speed</source>
         <translation>配置速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Data Width</source>
         <translation>数据位宽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Display Input</source>
         <translation>显示输入</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
         <source>Interface Type</source>
         <translation>接口类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
         <source>Support Resolution</source>
         <translation>支持分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>Current Resolution</source>
         <translation>当前分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
         <source>Refresh Rate</source>
         <translation>刷新率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Display Ratio</source>
         <translation>显示比例</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
         <source>Primary Monitor</source>
         <translation>主显示器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
         <source>Maximum Rate</source>
         <translation>最大速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
         <source>Negotiation Rate</source>
         <translation>协商速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
         <source>Port</source>
         <translation>端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
         <source>Multicast</source>
         <translation>组播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
         <source>Link</source>
         <translation>连接</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
         <source>Latency</source>
         <translation>延迟</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
         <source>IP</source>
         <translation>IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
         <source>Firmware</source>
         <translation>固件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
         <source>Duplex</source>
         <translation>双工</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
         <source>Broadcast</source>
         <translation>广播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>Auto Negotiation</source>
         <translation>自动协商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
         <source>Input/Output</source>
         <translation>输入/输出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Capacity</source>
         <translation>最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
         <source>Voltage</source>
         <translation>电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
         <source>Slot</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>Design Capacity</source>
         <translation>设计容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Design Voltage</source>
         <translation>设计电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
         <source>SBDS Version</source>
         <translation>SBDS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
         <source>SBDS Serial Number</source>
         <translation>SBDS序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
         <source>SBDS Manufacture Date</source>
         <translation>SBDS制造日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
         <source>SBDS Chemistry</source>
         <translation>SBDS材料</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
         <source>Temperature</source>
         <translation>温度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
         <source>Shared</source>
         <translation>已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
         <source>Media Type</source>
         <translation>介质类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
         <source>Firmware Version</source>
         <translation>固件版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
         <source>Serial Number</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
         <source>Rotation Rate</source>
         <translation>转速</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
         <source>SubVendor</source>
         <translation>子制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
         <source>SubDevice</source>
         <translation>子设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
         <source>Driver Status</source>
         <translation>驱动状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>Driver Activation Cmd</source>
         <translation>驱动激活命令</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>Config Status</source>
         <translation>配置状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
         <source>latency</source>
         <translation>延迟</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
         <source>Handlers</source>
         <translation>处理程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>Bus</source>
         <translation>总线</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>BIOS Information</source>
         <translation>BIOS信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>Base Board Information</source>
         <translation>主板信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
         <source>System Information</source>
         <translation>系统信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>Chassis Information</source>
         <translation>机箱信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
         <source>Physical Memory Array</source>
         <translation>内存插槽信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
         <source>Release Date</source>
         <translation>发布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
         <source>Runtime Size</source>
         <translation>运行内存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
         <source>ROM Size</source>
         <translation>ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Characteristics</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>BIOS Revision</source>
         <translation>BIOS修订版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
         <source>Firmware Revision</source>
         <translation>固件修订版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
         <source>Product Name</source>
         <translation>产品名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>Asset Tag</source>
         <translation>资产编号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
         <source>Features</source>
         <translation>特征</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
         <source>Location In Chassis</source>
         <translation>机箱内位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>Chassis Handle</source>
         <translation>机箱程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Contained Object Handles</source>
         <translation>包含对象程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
         <source>Wake-up Type</source>
         <translation>唤醒类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
         <source>SKU Number</source>
         <translation>SKU号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
         <source>Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
         <source>Lock</source>
         <translation>锁</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>Boot-up State</source>
         <translation>开机状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
         <source>Power Supply State</source>
         <translation>供电状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
         <source>Thermal State</source>
         <translation>散热状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
         <source>Security Status</source>
         <translation>安全状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
         <source>OEM Information</source>
         <translation>OEM信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
         <source>Height</source>
         <translation>高度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
         <source>Number Of Power Cords</source>
         <translation>电源线数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Contained Elements</source>
         <translation>包含组件数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
         <source>Error Correction Type</source>
         <translation>纠错类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
         <source>Maximum Capacity</source>
         <translation>最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
         <source>Error Information Handle</source>
         <translation>错误信息程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
         <source>Number Of Devices</source>
         <translation>卡槽数量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
         <source>Release date</source>
         <translation>发布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Board name</source>
         <translation>主板名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
         <source>Language Description Format</source>
         <translation>语言描述格式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
         <source>Installable Languages</source>
         <translation>可安装语言数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Currently Installed Language</source>
         <translation>当前安装语言</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>BD Address</source>
         <translation>蓝牙设备地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
         <source>Packet type</source>
         <translation>数据包类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
         <source>Link policy</source>
         <translation>连接策略</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
         <source>Link mode</source>
         <translation>连接模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Class</source>
         <translation>类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
         <source>Service Classes</source>
         <translation>服务类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>Device Class</source>
         <translation>设备类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
         <source>HCI Version</source>
         <translation>HCI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
         <source>LMP Version</source>
         <translation>LMP版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
         <source>Subversion</source>
         <translation>子版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>Device</source>
         <translation>设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
         <source>Serial ID</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
         <source>product</source>
         <translation>产品</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
         <source>Powered</source>
         <translation>供电</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Discoverable</source>
         <translation>可发现</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
         <source>Pairable</source>
         <translation>可配对</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
         <source>Modalias</source>
         <translation>设置命令别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Discovering</source>
         <translation>搜索中</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Device File</source>
         <translation>设备文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Device Files</source>
         <translation>设备文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Device Number</source>
         <translation>设备编号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Application</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
         <source>status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>ansiversion</source>
         <translation>ANSI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>CPU implementer</source>
         <translation>CPU程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
         <source>CPU architecture</source>
         <translation>CPU架构</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>CPU variant</source>
         <translation>CPU变量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>CPU part</source>
         <translation>CPU部件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>CPU revision</source>
         <translation>CPU版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
         <source>GDDR capacity</source>
         <translation>GDDR容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
         <source>GPU vendor</source>
         <translation>GPU供应商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
         <source>GPU type</source>
         <translation>GPU类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
         <source>EGL version</source>
         <translation>EGL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
         <source>EGL client APIs</source>
         <translation>EGL接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
         <source>GL version</source>
         <translation>GL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
         <source>GLSL version</source>
         <translation>GLSL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
         <source>Hardware Class</source>
         <translation>硬件类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>Array Handle</source>
         <translation>数组程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
         <source>Form Factor</source>
         <translation>尺寸型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
         <source>Set</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>Bank Locator</source>
         <translation>内存通道</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
         <source>Part Number</source>
         <translation>部件号码</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
         <source>Rank</source>
         <translation>位列</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
         <source>Memory Technology</source>
         <translation>内存技术</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
         <source>Memory Operating Mode Capability</source>
         <translation>内存操作模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Manufacturer ID</source>
         <translation>组件制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
         <source>Module Product ID</source>
         <translation>组件产品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>内存子系统控制器制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>内存子系统控制器产品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
         <source>Non-Volatile Size</source>
         <translation>不易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
         <source>Volatile Size</source>
         <translation>易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>Cache Size</source>
         <translation>缓存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
         <source>Logical Size</source>
         <translation>逻辑大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
         <source>inch</source>
         <translation>英寸</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
         <source>ioport</source>
         <translation>I/O端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
         <source>network</source>
         <translation>网络</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
         <source>Width</source>
         <translation>位宽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
         <source>battery</source>
         <translation>电池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
         <source>native-path</source>
         <translation>安装路径</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
         <source>power supply</source>
         <translation>供电</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
         <source>updated</source>
         <translation>更新时间</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
         <source>has history</source>
         <translation>历史记录</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
         <source>has statistics</source>
         <translation>用电统计</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
         <source>rechargeable</source>
         <translation>可再充电</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
         <source>state</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
         <source>warning-level</source>
         <translation>警告等级</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
         <source>energy</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
         <source>energy-empty</source>
         <translation>最低容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
         <source>energy-full</source>
         <translation>完全充满容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
         <source>energy-full-design</source>
         <translation>设计容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
         <source>energy-rate</source>
         <translation>能量密度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
         <source>temperature</source>
         <translation>温度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
         <source>Type Detail</source>
         <translation>详细类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
         <source>voltage</source>
         <translation>电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
         <source>percentage</source>
         <translation>电量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
         <source>technology</source>
         <translation>电池技术</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
         <source>icon-name</source>
         <translation>图标</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
         <source>online</source>
         <translation>在线</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>daemon-version</source>
         <translation>Daemon版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
         <source>on-battery</source>
         <translation>使用电池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
         <source>lid-is-closed</source>
         <translation>笔记本合盖</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
         <source>lid-is-present</source>
         <translation>打开笔记本盖子</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
         <source>critical-action</source>
         <translation>电量极低时执行</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>Alias</source>
         <translation>别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>Clock</source>
         <translation>时钟</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>copies</source>
         <translation>复印数量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
         <source>Driver Modules</source>
         <translation>驱动模块</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
         <source>job-cancel-after</source>
         <translation>此时取消打印任务</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
         <source>job-hold-until</source>
         <translation>保留打印任务直至</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
         <source>job-priority</source>
         <translation>任务优先级</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
         <source>marker-change-time</source>
         <translation>标记修改次数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
         <source>number-up</source>
         <translation>编号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
         <source>orientation-requested</source>
         <translation>打印方向</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
         <source>physical id</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
         <source>print-color-mode</source>
         <translation>颜色模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
         <source>printer-is-accepting-jobs</source>
         <translation>当前可打印</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
         <source>printer-is-shared</source>
         <translation>打印机已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
         <source>printer-is-temporary</source>
         <translation>临时打印机</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
         <source>printer-make-and-model</source>
         <translation>制造商和型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
         <source>printer-state-change-time</source>
         <translation>打印机状态修改时间</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
         <source>printer-state-reasons</source>
         <translation>打印机状态信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
         <source>printer-type</source>
         <translation>打印机类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
         <source>printer-uri-supported</source>
         <translation>支持的URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
         <source>Product Date</source>
         <translation>产品日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
         <source>sides</source>
         <translation>打印面数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
         <source>logicalsectorsize</source>
         <translation>逻辑分区大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
         <source>sectorsize</source>
         <translation>扇区大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
         <source>guid</source>
         <translation>全局唯一标识符</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
         <source>Geometry (Logical)</source>
         <translation>几何数据（逻辑）</translation>
     </message>
@@ -1832,47 +1832,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1526"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1539"/>
         <source>Model Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1530"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1543"/>
         <source>Vendor ID</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1534"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
         <source>Architecture</source>
         <translation>架构</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1538"/>
-        <source>Core(s)</source>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1551"/>
+        <source>CPU(s)</source>
         <translation>逻辑处理器</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1540"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1553"/>
         <source>Thread(s)</source>
         <translation>每核线程数</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1562"/>
         <source>L1d cache</source>
         <translation>L1缓存（数据）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1555"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1572"/>
         <source>L1i cache</source>
         <translation>L1缓存（指令）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1563"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1582"/>
         <source>L2 cache</source>
         <translation>L2缓存</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1571"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1592"/>
         <source>L3 cache</source>
         <translation>L3缓存</translation>
     </message>
@@ -2564,48 +2564,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Storage</source>
         <translation>存储设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Monitor</source>
         <translation>显示设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="231"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="235"/>
         <source>Failed to enable the device</source>
         <translation>启用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="234"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="238"/>
         <source>Failed to disable the device</source>
         <translation>禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="240"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="244"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>无法获取设备序列号，禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="267"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="271"/>
         <source>Update Drivers</source>
         <translation>更新驱动</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="292"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="296"/>
         <source>Uninstall Drivers</source>
         <translation>卸载驱动</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
@@ -92,1391 +92,1391 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
         <source>Processor</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>Alias</source>
         <translation>別名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>ansiversion</source>
         <translation>ANSI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Application</source>
         <translation>應用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
         <source>Architecture</source>
         <translation>架構</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>Array Handle</source>
         <translation>數組程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>Asset Tag</source>
         <translation>資產編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>Auto Negotiation</source>
         <translation>自動協商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>Bank Locator</source>
         <translation>內存通道</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>Base Board Information</source>
         <translation>主板訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>BD Address</source>
         <translation>藍牙設備地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>BIOS Information</source>
         <translation>BIOS訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>BIOS Revision</source>
         <translation>BIOS修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Board name</source>
         <translation>主板名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>Boot-up State</source>
         <translation>開機狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
         <source>Broadcast</source>
         <translation>廣播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>Bus</source>
         <translation>總線</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>bus info</source>
         <translation>總線訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>Bus Info</source>
         <translation>總線訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>Cache Size</source>
         <translation>緩存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Capacity</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Characteristics</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>Chassis Handle</source>
         <translation>機箱程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>Chassis Information</source>
         <translation>機箱訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Chip</source>
         <translation>晶片</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Chipset</source>
         <translation>晶片組</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Class</source>
         <translation>類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>Clock</source>
         <translation>時鐘</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>Config Status</source>
         <translation>配置狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>Configured Speed</source>
         <translation>配置頻率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>Configured Voltage</source>
         <translation>配置電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Contained Elements</source>
         <translation>包含組件數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Contained Object Handles</source>
         <translation>包含對象程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>copies</source>
         <translation>複印數量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Core ID</source>
         <translation>核心ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
         <source>CPU architecture</source>
         <translation>CPU架構</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>CPU Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>CPU ID</source>
         <translation>處理器ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>CPU implementer</source>
         <translation>CPU程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>CPU part</source>
         <translation>CPU部件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>CPU revision</source>
         <translation>CPU版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>CPU variant</source>
         <translation>CPU變量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
         <source>critical-action</source>
         <translation>電量極低時執行</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Currently Installed Language</source>
         <translation>當前安裝語言</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>Current Resolution</source>
         <translation>當前解像度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>daemon-version</source>
         <translation>Daemon版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Data Width</source>
         <translation>數據位寬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>Design Capacity</source>
         <translation>設計容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Design Voltage</source>
         <translation>設計電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>Device</source>
         <translation>設備</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>Device Class</source>
         <translation>設備類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Device File</source>
         <translation>設備文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Device Files</source>
         <translation>設備文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Device Name</source>
         <translation>設備名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Device Number</source>
         <translation>設備編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Discoverable</source>
         <translation>可發現</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Discovering</source>
         <translation>搜索中</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Display Input</source>
         <translation>顯示輸入</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Display Output</source>
         <translation>顯示輸出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Display Ratio</source>
         <translation>顯示比例</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>Driver</source>
         <translation>驅動</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>Driver Activation Cmd</source>
         <translation>驅動啟動命令</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
         <source>Driver Modules</source>
         <translation>驅動模塊</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
         <source>Driver Status</source>
         <translation>驅動狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
         <source>Driver Version</source>
         <translation>驅動版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
         <source>Duplex</source>
         <translation>雙工</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
         <source>EGL client APIs</source>
         <translation>EGL接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
         <source>EGL version</source>
         <translation>EGL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
         <source>energy</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
         <source>energy-empty</source>
         <translation>最低容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
         <source>energy-full</source>
         <translation>完全充滿容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
         <source>energy-full-design</source>
         <translation>設計容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
         <source>energy-rate</source>
         <translation>能量密度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
         <source>Error Correction Type</source>
         <translation>糾錯類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
         <source>Error Information Handle</source>
         <translation>錯誤訊息程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
         <source>Extensions</source>
         <translation>擴展指令集</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
         <source>Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
         <source>Features</source>
         <translation>特徵</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
         <source>Firmware</source>
         <translation>固件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
         <source>Firmware Revision</source>
         <translation>固件修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
         <source>Firmware Version</source>
         <translation>固件版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
         <source>Flags</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
         <source>Form Factor</source>
         <translation>尺寸型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
         <source>GDDR capacity</source>
         <translation>GDDR容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
         <source>Geometry (Logical)</source>
         <translation>幾何數據（邏輯）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
         <source>GLSL version</source>
         <translation>GLSL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
         <source>GL version</source>
         <translation>GL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
         <source>GPU type</source>
         <translation>GPU類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
         <source>GPU vendor</source>
         <translation>GPU供應商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
         <source>Graphics Memory</source>
         <translation>顯存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
         <source>guid</source>
         <translation>全局唯一標識符</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
         <source>Handlers</source>
         <translation>進程</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
         <source>Hardware Class</source>
         <translation>硬件類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
         <source>has history</source>
         <translation>歷史記錄</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
         <source>has statistics</source>
         <translation>用電統計</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
         <source>HCI Version</source>
         <translation>HCI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
         <source>Height</source>
         <translation>高度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
         <source>icon-name</source>
         <translation>圖標</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
         <source>Input/Output</source>
         <translation>輸入/輸出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
         <source>Installable Languages</source>
         <translation>可安裝語言數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
         <source>Interface</source>
         <translation>接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
         <source>Interface Type</source>
         <translation>接口類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
         <source>ioport</source>
         <translation>I/O端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
         <source>IO Port</source>
         <translation>I/O端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
         <source>IP</source>
         <translation>IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
         <source>IRQ</source>
         <translation>中斷</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
         <source>job-cancel-after</source>
         <translation>此時取消打印任務</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
         <source>job-hold-until</source>
         <translation>保留打印任務直至</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
         <source>job-priority</source>
         <translation>任務優先級</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
         <source>L1d Cache</source>
         <translation>L1緩存（數據）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
         <source>L1i Cache</source>
         <translation>L1緩存（指令）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
         <source>L2 Cache</source>
         <translation>L2緩存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
         <source>L3 Cache</source>
         <translation>L3緩存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
         <source>L4 Cache</source>
         <translation>L4 緩存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
         <source>Language Description Format</source>
         <translation>語言描述格式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
         <source>latency</source>
         <translation>延遲</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
         <source>Latency</source>
         <translation>延遲</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
         <source>lid-is-closed</source>
         <translation>筆記本合蓋</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
         <source>lid-is-present</source>
         <translation>打開筆記本蓋子</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
         <source>Link</source>
         <translation>連接</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
         <source>Link mode</source>
         <translation>連接模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
         <source>Link policy</source>
         <translation>連接策略</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
         <source>LMP Version</source>
         <translation>LMP版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
         <source>Location In Chassis</source>
         <translation>機箱內位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
         <source>Locator</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
         <source>Lock</source>
         <translation>鎖</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
         <source>logical name</source>
         <translation>邏輯地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
         <source>Logical Name</source>
         <translation>邏輯名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
         <source>logicalsectorsize</source>
         <translation>邏輯分區大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
         <source>Logical Size</source>
         <translation>邏輯大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
         <source>MAC Address</source>
         <translation>物理地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
         <source>marker-change-time</source>
         <translation>標記修改次數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
         <source>Max Frequency</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
         <source>Maximum Capacity</source>
         <translation>最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
         <source>Maximum Current</source>
         <translation>最大電流</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
         <source>Maximum Rate</source>
         <translation>最大速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
         <source>Maximum Resolution</source>
         <translation>最大解像度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
         <source>Maximum Voltage</source>
         <translation>最高電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
         <source>Media Type</source>
         <translation>介質類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
         <source>Memory</source>
         <translation>內存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
         <source>Memory Address</source>
         <translation>內存地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
         <source>Memory Operating Mode Capability</source>
         <translation>內存操作模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>內存子系統控制器製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>內存子系統控制器產品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
         <source>Memory Technology</source>
         <translation>內存技術</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
         <source>Minimum Resolution</source>
         <translation>最小解像度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
         <source>Minimum Voltage</source>
         <translation>最低電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
         <source>Modalias</source>
         <translation>設置命令別名</translation>
     </message>
     <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1352"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Alias</source>
         <translation>模塊別名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Manufacturer ID</source>
         <translation>組件製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
         <source>Module Product ID</source>
         <translation>組件產品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
         <source>Multicast</source>
         <translation>組播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
         <source>native-path</source>
         <translation>安裝路徑</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
         <source>Negotiation Rate</source>
         <translation>協商速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
         <source>network</source>
         <translation>網絡</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
         <source>Non-Volatile Size</source>
         <translation>不易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
         <source>Number Of Devices</source>
         <translation>卡槽數量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
         <source>Number Of Power Cords</source>
         <translation>電源線數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
         <source>number-up</source>
         <translation>編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
         <source>OEM Information</source>
         <translation>OEM訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
         <source>on-battery</source>
         <translation>使用電池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
         <source>online</source>
         <translation>在線</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
         <source>orientation-requested</source>
         <translation>打印方向</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
         <source>Packet type</source>
         <translation>數據包類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
         <source>Pairable</source>
         <translation>可配對</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
         <source>Part Number</source>
         <translation>部件號碼</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
         <source>percentage</source>
         <translation>電量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
         <source>physical id</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
         <source>Physical Memory Array</source>
         <translation>物理內存數組</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
         <source>Port</source>
         <translation>端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
         <source>Powered</source>
         <translation>供電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
         <source>power supply</source>
         <translation>供電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
         <source>Power Supply State</source>
         <translation>供電狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
         <source>Primary Monitor</source>
         <translation>主顯示器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
         <source>print-color-mode</source>
         <translation>顏色模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
         <source>printer-is-accepting-jobs</source>
         <translation>當前可打印</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
         <source>printer-is-shared</source>
         <translation>打印機已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
         <source>printer-is-temporary</source>
         <translation>臨時打印機</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
         <source>printer-make-and-model</source>
         <translation>製造商和型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
         <source>printer-state-change-time</source>
         <translation>打印機狀態修改時間</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
         <source>printer-state-reasons</source>
         <translation>打印機狀態訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
         <source>printer-type</source>
         <translation>打印機類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
         <source>printer-uri-supported</source>
         <translation>支持的URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
         <source>product</source>
         <translation>產品</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
         <source>Product Date</source>
         <translation>產品日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
         <source>Product Name</source>
         <translation>產品名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
         <source>Rank</source>
         <translation>位列</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
         <source>rechargeable</source>
         <translation>可再充電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
         <source>Refresh Rate</source>
         <translation>刷新率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
         <source>Release date</source>
         <translation>發佈日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
         <source>Release Date</source>
         <translation>發佈日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
         <source>Revision</source>
         <translation>修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
         <source>ROM Size</source>
         <translation>ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
         <source>Rotation Rate</source>
         <translation>轉速</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
         <source>Runtime Size</source>
         <translation>運行內存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
         <source>SBDS Chemistry</source>
         <translation>SBDS材料</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
         <source>SBDS Manufacture Date</source>
         <translation>SBDS製造日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
         <source>SBDS Serial Number</source>
         <translation>SBDS序列號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
         <source>SBDS Version</source>
         <translation>SBDS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
         <source>sectorsize</source>
         <translation>扇區大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
         <source>Security Status</source>
         <translation>安全狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
         <source>Serial ID</source>
         <translation>序列號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
         <source>Serial Number</source>
         <translation>序列號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
         <source>Service Classes</source>
         <translation>服務類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
         <source>Set</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
         <source>Shared</source>
         <translation>已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
         <source>sides</source>
         <translation>打印面數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
         <source>SKU Number</source>
         <translation>SKU號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
         <source>Slot</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
         <source>state</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
         <source>status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
         <source>Stepping</source>
         <translation>步進</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
         <source>SubDevice</source>
         <translation>子設備</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
         <source>SubVendor</source>
         <translation>子製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
         <source>Subversion</source>
         <translation>子版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
         <source>Support Resolution</source>
         <translation>支持解像度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
         <source>System Information</source>
         <translation>系統訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
         <source>technology</source>
         <translation>電池技術</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
         <source>temperature</source>
         <translation>溫度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
         <source>Temperature</source>
         <translation>溫度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
         <source>Thermal State</source>
         <translation>散熱狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
         <source>Threads</source>
         <translation>線程數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
         <source>Total Width</source>
         <translation>總位寬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
         <source>Type Detail</source>
         <translation>類型詳情</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
         <source>updated</source>
         <translation>更新時間</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
         <source>Vendor</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
         <source>Virtualization</source>
         <translation>虛擬化</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
         <source>Volatile Size</source>
         <translation>易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
         <source>voltage</source>
         <translation>電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
         <source>Voltage</source>
         <translation>電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
         <source>Wake-up Type</source>
         <translation>喚醒類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
         <source>warning-level</source>
         <translation>警告等級</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
         <source>Width</source>
         <translation>位闊</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
         <source>battery</source>
         <translation>電池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
         <source>inch</source>
         <translation>英吋</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
         <source>Frequency</source>
         <translation>頻率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
         <source>Speed</source>
         <translation>速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
         <source>Model</source>
         <translation>型號</translation>
     </message>
@@ -1832,47 +1832,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1526"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1539"/>
         <source>Model Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1530"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1543"/>
         <source>Vendor ID</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1534"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
         <source>Architecture</source>
         <translation>架構</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1538"/>
-        <source>Core(s)</source>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1551"/>
+        <source>CPU(s)</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1540"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1553"/>
         <source>Thread(s)</source>
         <translation>每核心線程數</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1562"/>
         <source>L1d cache</source>
         <translation>一級緩存（數據）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1555"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1572"/>
         <source>L1i cache</source>
         <translation>一級緩存（指令）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1563"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1582"/>
         <source>L2 cache</source>
         <translation>二級緩存</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1571"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1592"/>
         <source>L3 cache</source>
         <translation>三級緩存</translation>
     </message>
@@ -2564,48 +2564,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Storage</source>
         <translation>存儲設備</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Memory</source>
         <translation>內存</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Monitor</source>
         <translation>顯示設備</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="231"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="235"/>
         <source>Failed to enable the device</source>
         <translation>啟用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="234"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="238"/>
         <source>Failed to disable the device</source>
         <translation>禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="240"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="244"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>無法獲取設備序列號，禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="267"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="271"/>
         <source>Update Drivers</source>
         <translation>更新驅動</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="292"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="296"/>
         <source>Uninstall Drivers</source>
         <translation>卸載驅動</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
@@ -92,1391 +92,1391 @@
 <context>
     <name>DeviceBaseInfo</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1182"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1183"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
         <source>Processor</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1184"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1185"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1186"/>
         <source>Alias</source>
         <translation>別名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1187"/>
         <source>ansiversion</source>
         <translation>ANSI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1188"/>
         <source>Application</source>
         <translation>應用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1189"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
         <source>Architecture</source>
         <translation>架構</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1190"/>
         <source>Array Handle</source>
         <translation>數組程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1191"/>
         <source>Asset Tag</source>
         <translation>資產編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1192"/>
         <source>Auto Negotiation</source>
         <translation>自動協商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1193"/>
         <source>Bank Locator</source>
         <translation>記憶體通道</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1194"/>
         <source>Base Board Information</source>
         <translation>主機板訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1195"/>
         <source>BD Address</source>
         <translation>藍牙裝置地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1196"/>
         <source>BIOS Information</source>
         <translation>BIOS訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1197"/>
         <source>BIOS Revision</source>
         <translation>BIOS修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1198"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1199"/>
         <source>Board name</source>
         <translation>主機板名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1200"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1201"/>
         <source>Boot-up State</source>
         <translation>開機狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1202"/>
         <source>Broadcast</source>
         <translation>廣播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1203"/>
         <source>Bus</source>
         <translation>匯流排</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1204"/>
         <source>bus info</source>
         <translation>匯流排訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1205"/>
         <source>Bus Info</source>
         <translation>匯流排訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1206"/>
         <source>Cache Size</source>
         <translation>快取大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1207"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1208"/>
         <source>Capacity</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1209"/>
         <source>Characteristics</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1210"/>
         <source>Chassis Handle</source>
         <translation>機箱程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1211"/>
         <source>Chassis Information</source>
         <translation>機箱訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1212"/>
         <source>Chip</source>
         <translation>晶片</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1213"/>
         <source>Chipset</source>
         <translation>晶片組</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1214"/>
         <source>Class</source>
         <translation>類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1215"/>
         <source>Clock</source>
         <translation>時鐘</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1216"/>
         <source>Config Status</source>
         <translation>配置狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1217"/>
         <source>Configured Speed</source>
         <translation>配置頻率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1218"/>
         <source>Configured Voltage</source>
         <translation>配置電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1219"/>
         <source>Contained Elements</source>
         <translation>包含組件數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1220"/>
         <source>Contained Object Handles</source>
         <translation>包含對象程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1221"/>
         <source>copies</source>
         <translation>影印數量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1222"/>
         <source>Core ID</source>
         <translation>核心ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1223"/>
         <source>CPU architecture</source>
         <translation>CPU架構</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1224"/>
         <source>CPU Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1225"/>
         <source>CPU ID</source>
         <translation>處理器ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1226"/>
         <source>CPU implementer</source>
         <translation>CPU程式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1227"/>
         <source>CPU part</source>
         <translation>CPU部件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1228"/>
         <source>CPU revision</source>
         <translation>CPU版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1229"/>
         <source>CPU variant</source>
         <translation>CPU變數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1230"/>
         <source>critical-action</source>
         <translation>電量極低時執行</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1231"/>
         <source>Currently Installed Language</source>
         <translation>當前安裝語言</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1232"/>
         <source>Current Resolution</source>
         <translation>目前解析度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1233"/>
         <source>daemon-version</source>
         <translation>Daemon版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1234"/>
         <source>Data Width</source>
         <translation>數據位寬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1235"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1236"/>
         <source>description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1237"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1238"/>
         <source>Design Capacity</source>
         <translation>設計容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1239"/>
         <source>Design Voltage</source>
         <translation>設計電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1240"/>
         <source>Device</source>
         <translation>裝置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1241"/>
         <source>Device Class</source>
         <translation>裝置類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1242"/>
         <source>Device File</source>
         <translation>裝置文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1243"/>
         <source>Device Files</source>
         <translation>裝置文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1244"/>
         <source>Device Name</source>
         <translation>裝置名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1245"/>
         <source>Device Number</source>
         <translation>裝置編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1246"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1247"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1248"/>
         <source>Discoverable</source>
         <translation>可發現</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1249"/>
         <source>Discovering</source>
         <translation>搜索中</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1250"/>
         <source>Display Input</source>
         <translation>顯示輸入</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1251"/>
         <source>Display Output</source>
         <translation>顯示輸出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1252"/>
         <source>Display Ratio</source>
         <translation>顯示比例</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1253"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1254"/>
         <source>Driver</source>
         <translation>驅動</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1255"/>
         <source>Driver Activation Cmd</source>
         <translation>驅動啟動指令</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1256"/>
         <source>Driver Modules</source>
         <translation>驅動模組</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1257"/>
         <source>Driver Status</source>
         <translation>驅動狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1258"/>
         <source>Driver Version</source>
         <translation>驅動版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1259"/>
         <source>Duplex</source>
         <translation>雙工</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1260"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1261"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1262"/>
         <source>EGL client APIs</source>
         <translation>EGL介面</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1263"/>
         <source>EGL version</source>
         <translation>EGL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1264"/>
         <source>energy</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1265"/>
         <source>energy-empty</source>
         <translation>最低容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1266"/>
         <source>energy-full</source>
         <translation>完全充滿容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1267"/>
         <source>energy-full-design</source>
         <translation>設計容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1268"/>
         <source>energy-rate</source>
         <translation>能量密度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1269"/>
         <source>Error Correction Type</source>
         <translation>糾錯類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1270"/>
         <source>Error Information Handle</source>
         <translation>錯誤訊息程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1271"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1272"/>
         <source>Extensions</source>
         <translation>擴展指令集</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1273"/>
         <source>Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1274"/>
         <source>Features</source>
         <translation>特徵</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1275"/>
         <source>Firmware</source>
         <translation>韌體</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1276"/>
         <source>Firmware Revision</source>
         <translation>韌體修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1277"/>
         <source>Firmware Version</source>
         <translation>韌體版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1278"/>
         <source>Flags</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1279"/>
         <source>Form Factor</source>
         <translation>尺寸型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1280"/>
         <source>GDDR capacity</source>
         <translation>GDDR容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1281"/>
         <source>Geometry (Logical)</source>
         <translation>幾何資料（邏輯）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1282"/>
         <source>GLSL version</source>
         <translation>GLSL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1283"/>
         <source>GL version</source>
         <translation>GL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1284"/>
         <source>GPU type</source>
         <translation>GPU類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1285"/>
         <source>GPU vendor</source>
         <translation>GPU供應商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1286"/>
         <source>Graphics Memory</source>
         <translation>視訊記憶體</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1287"/>
         <source>guid</source>
         <translation>全局唯一標識符</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1288"/>
         <source>Handlers</source>
         <translation>處理程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1289"/>
         <source>Hardware Class</source>
         <translation>硬體類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1290"/>
         <source>has history</source>
         <translation>歷史記錄</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1291"/>
         <source>has statistics</source>
         <translation>用電統計</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1292"/>
         <source>HCI Version</source>
         <translation>HCI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1293"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1294"/>
         <source>Height</source>
         <translation>高度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1295"/>
         <source>icon-name</source>
         <translation>圖示</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1296"/>
         <source>Input/Output</source>
         <translation>輸入/輸出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1297"/>
         <source>Installable Languages</source>
         <translation>可安裝語言數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1298"/>
         <source>Interface</source>
         <translation>介面</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1299"/>
         <source>Interface Type</source>
         <translation>介面類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1300"/>
         <source>ioport</source>
         <translation>IO埠</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1301"/>
         <source>IO Port</source>
         <translation>I/O埠</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1302"/>
         <source>IP</source>
         <translation>IP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1303"/>
         <source>IRQ</source>
         <translation>中斷</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1304"/>
         <source>job-cancel-after</source>
         <translation>此時取消列印任務</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1305"/>
         <source>job-hold-until</source>
         <translation>保留列印任務直至</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1306"/>
         <source>job-priority</source>
         <translation>任務優先度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1307"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1308"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1309"/>
         <source>L1d Cache</source>
         <translation>L1快取（數據）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1310"/>
         <source>L1i Cache</source>
         <translation>L1快取（指令）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1311"/>
         <source>L2 Cache</source>
         <translation>L2快取</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1312"/>
         <source>L3 Cache</source>
         <translation>L3快取</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1313"/>
         <source>L4 Cache</source>
         <translation>L4 快取</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1314"/>
         <source>Language Description Format</source>
         <translation>語言描述格式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1315"/>
         <source>latency</source>
         <translation>延遲</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1316"/>
         <source>Latency</source>
         <translation>延遲</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1317"/>
         <source>lid-is-closed</source>
         <translation>筆記本合蓋</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1318"/>
         <source>lid-is-present</source>
         <translation>打開筆記本蓋子</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1319"/>
         <source>Link</source>
         <translation>連結</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1320"/>
         <source>Link mode</source>
         <translation>連接模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1321"/>
         <source>Link policy</source>
         <translation>連接策略</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1322"/>
         <source>LMP Version</source>
         <translation>LMP版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1323"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1324"/>
         <source>Location In Chassis</source>
         <translation>機箱內位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1325"/>
         <source>Locator</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1326"/>
         <source>Lock</source>
         <translation>鎖</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1327"/>
         <source>logical name</source>
         <translation>邏輯地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1328"/>
         <source>Logical Name</source>
         <translation>邏輯名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1329"/>
         <source>logicalsectorsize</source>
         <translation>邏輯分區大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1330"/>
         <source>Logical Size</source>
         <translation>邏輯大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1331"/>
         <source>MAC Address</source>
         <translation>物理地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1332"/>
         <source>marker-change-time</source>
         <translation>標記修改次數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1333"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
         <source>Max Frequency</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1334"/>
         <source>Maximum Capacity</source>
         <translation>最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1335"/>
         <source>Maximum Current</source>
         <translation>最大電流</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1336"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1337"/>
         <source>Maximum Rate</source>
         <translation>最大速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1338"/>
         <source>Maximum Resolution</source>
         <translation>最大解析度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1339"/>
         <source>Maximum Voltage</source>
         <translation>最高電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1340"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1460"/>
         <source>Media Type</source>
         <translation>介質類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1341"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1342"/>
         <source>Memory Address</source>
         <translation>記憶體地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1343"/>
         <source>Memory Operating Mode Capability</source>
         <translation>記憶體操作模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1344"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>記憶體子系統控制器製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1345"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>記憶體子系統控制器產品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1346"/>
         <source>Memory Technology</source>
         <translation>記憶體技術</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1347"/>
         <source>Minimum Resolution</source>
         <translation>最小解析度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1348"/>
         <source>Minimum Voltage</source>
         <translation>最低電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1349"/>
         <source>Modalias</source>
         <translation>設置命令別名</translation>
     </message>
     <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1352"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Alias</source>
         <translation>模組別名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1353"/>
         <source>Module Manufacturer ID</source>
         <translation>元件製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1354"/>
         <source>Module Product ID</source>
         <translation>元件產品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1355"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1356"/>
         <source>Multicast</source>
         <translation>組播</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1357"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1461"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1358"/>
         <source>native-path</source>
         <translation>安裝路徑</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1359"/>
         <source>Negotiation Rate</source>
         <translation>協商速率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1360"/>
         <source>network</source>
         <translation>網路</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1361"/>
         <source>Non-Volatile Size</source>
         <translation>不易遺失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1362"/>
         <source>Number Of Devices</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1363"/>
         <source>Number Of Power Cords</source>
         <translation>電源線數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1364"/>
         <source>number-up</source>
         <translation>編號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1365"/>
         <source>OEM Information</source>
         <translation>OEM訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1366"/>
         <source>on-battery</source>
         <translation>使用電池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1367"/>
         <source>online</source>
         <translation>線上</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1368"/>
         <source>orientation-requested</source>
         <translation>列印方向</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1369"/>
         <source>Packet type</source>
         <translation>封包類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1370"/>
         <source>Pairable</source>
         <translation>可配對</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1371"/>
         <source>Part Number</source>
         <translation>部件號碼</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1372"/>
         <source>percentage</source>
         <translation>電量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1373"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1374"/>
         <source>physical id</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1375"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1376"/>
         <source>Physical Memory Array</source>
         <translation>物理記憶體陣列</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1377"/>
         <source>Port</source>
         <translation>埠</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1378"/>
         <source>Powered</source>
         <translation>供電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1379"/>
         <source>power supply</source>
         <translation>供電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1380"/>
         <source>Power Supply State</source>
         <translation>供電狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1381"/>
         <source>Primary Monitor</source>
         <translation>主顯示器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1382"/>
         <source>print-color-mode</source>
         <translation>顏色模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1383"/>
         <source>printer-is-accepting-jobs</source>
         <translation>當前可列印</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1384"/>
         <source>printer-is-shared</source>
         <translation>印表機已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1385"/>
         <source>printer-is-temporary</source>
         <translation>臨時印表機</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1386"/>
         <source>printer-make-and-model</source>
         <translation>製造商和型號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1387"/>
         <source>printer-state-change-time</source>
         <translation>印表機狀態修改時間</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1388"/>
         <source>printer-state-reasons</source>
         <translation>印表機狀態訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1389"/>
         <source>printer-type</source>
         <translation>印表機類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1390"/>
         <source>printer-uri-supported</source>
         <translation>支持的URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1391"/>
         <source>product</source>
         <translation>產品</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1392"/>
         <source>Product Date</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1393"/>
         <source>Product Name</source>
         <translation>產品名稱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1394"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1395"/>
         <source>Rank</source>
         <translation>位列</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1396"/>
         <source>rechargeable</source>
         <translation>可再充電</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1397"/>
         <source>Refresh Rate</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1398"/>
         <source>Release date</source>
         <translation>發布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1399"/>
         <source>Release Date</source>
         <translation>發布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1400"/>
         <source>Revision</source>
         <translation>修訂版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1401"/>
         <source>ROM Size</source>
         <translation>ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1402"/>
         <source>Rotation Rate</source>
         <translation>轉速</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1403"/>
         <source>Runtime Size</source>
         <translation>運行內存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1404"/>
         <source>SBDS Chemistry</source>
         <translation>SBDS材料</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1405"/>
         <source>SBDS Manufacture Date</source>
         <translation>SBDS製造日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1406"/>
         <source>SBDS Serial Number</source>
         <translation>SBDS序號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1407"/>
         <source>SBDS Version</source>
         <translation>SBDS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1408"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1409"/>
         <source>sectorsize</source>
         <translation>扇區大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1410"/>
         <source>Security Status</source>
         <translation>安全狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1411"/>
         <source>Serial ID</source>
         <translation>序號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1412"/>
         <source>Serial Number</source>
         <translation>序號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1413"/>
         <source>Service Classes</source>
         <translation>服務類別</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1414"/>
         <source>Set</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1415"/>
         <source>Shared</source>
         <translation>已共享</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1416"/>
         <source>sides</source>
         <translation>列印面數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1417"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1462"/>
         <source>Size</source>
         <translation>容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1418"/>
         <source>SKU Number</source>
         <translation>SKU號</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1419"/>
         <source>Slot</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1420"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1421"/>
         <source>state</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1422"/>
         <source>status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1423"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1424"/>
         <source>Stepping</source>
         <translation>步進</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1425"/>
         <source>SubDevice</source>
         <translation>子裝置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1426"/>
         <source>SubVendor</source>
         <translation>子製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1427"/>
         <source>Subversion</source>
         <translation>子版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1428"/>
         <source>Support Resolution</source>
         <translation>支持解析度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1429"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1430"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1431"/>
         <source>System Information</source>
         <translation>系統訊息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1432"/>
         <source>technology</source>
         <translation>電池技術</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1433"/>
         <source>temperature</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1434"/>
         <source>Temperature</source>
         <translation>溫度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1435"/>
         <source>Thermal State</source>
         <translation>散熱狀態</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1436"/>
         <source>Threads</source>
         <translation>執行緒數</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1437"/>
         <source>Total Width</source>
         <translation>總位寬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1438"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1439"/>
         <source>Type Detail</source>
         <translation>類型詳情</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1440"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1441"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1442"/>
         <source>updated</source>
         <translation>更新時間</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1443"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1444"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1445"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1465"/>
         <source>Vendor</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1446"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1447"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1448"/>
         <source>Virtualization</source>
         <translation>虛擬化</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1449"/>
         <source>Volatile Size</source>
         <translation>易遺失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1450"/>
         <source>voltage</source>
         <translation>電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1451"/>
         <source>Voltage</source>
         <translation>電壓</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1452"/>
         <source>Wake-up Type</source>
         <translation>喚醒類型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1453"/>
         <source>warning-level</source>
         <translation>警告等級</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1454"/>
         <source>Width</source>
         <translation>位寬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1455"/>
         <source>battery</source>
         <translation>電池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1456"/>
         <source>inch</source>
         <translation>英寸</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1458"/>
         <source>Frequency</source>
         <translation>頻率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1463"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1351"/>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="1350"/>
         <source>Model</source>
         <translation>型號</translation>
     </message>
@@ -1832,47 +1832,47 @@
 <context>
     <name>DeviceGenerator</name>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1526"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1539"/>
         <source>Model Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1530"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1543"/>
         <source>Vendor ID</source>
         <translation>製造商</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1534"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
         <source>Architecture</source>
         <translation>架構</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1538"/>
-        <source>Core(s)</source>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1551"/>
+        <source>CPU(s)</source>
         <translation>邏輯處理器</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1540"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1553"/>
         <source>Thread(s)</source>
         <translation>每核心執行緒數</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1547"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1562"/>
         <source>L1d cache</source>
         <translation>第一級快取（資料）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1555"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1572"/>
         <source>L1i cache</source>
         <translation>第一級快取（指令）</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1563"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1582"/>
         <source>L2 cache</source>
         <translation>第二級快取</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1571"/>
+        <location filename="../src/GenerateDevice/DeviceGenerator.cpp" line="1592"/>
         <source>L3 cache</source>
         <translation>第三級快取</translation>
     </message>
@@ -2564,48 +2564,48 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Storage</source>
         <translation>儲存裝置</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="133"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="182"/>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="191"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="137"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="186"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="195"/>
         <source>Monitor</source>
         <translation>顯示裝置</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="231"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="235"/>
         <source>Failed to enable the device</source>
         <translation>啟用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="234"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="238"/>
         <source>Failed to disable the device</source>
         <translation>禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="240"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="244"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>無法獲取裝置序號，禁用失敗</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="267"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="271"/>
         <source>Update Drivers</source>
         <translation>更新驅動</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="292"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="296"/>
         <source>Uninstall Drivers</source>
         <translation>移除驅動</translation>
     </message>


### PR DESCRIPTION
…ions

changed CPU header label from Core(s) to CPU(s) in DeviceGenerator.cpp updated core count to use logicalNum
regenerated translation source files in translations

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-363563.html