### PR TITLE
fix(security): use safe QProcess API to prevent command injection

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/drivermanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -209,7 +209,7 @@ bool DriverManager::unInstallDriver(const QString &modulename)
 static void depmod_a()
 {
     QProcess process;
-    process.start("depmod -a");
+    process.start("depmod", QStringList() << "-a");
     process.waitForFinished(-1);
 }
 
@@ -758,7 +758,7 @@ bool DriverManager::delDeb(const QString &debname)
 static void cmdAptUpdate()
 {
     QProcess process;
-    process.start("apt update");
+    process.start("apt", QStringList() << "update");
     process.waitForFinished(-1);
 }
 bool DriverManager::aptUpdate()

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/modcore.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/modcore.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -495,7 +495,7 @@ void ModCore::updateInitramfs()
 {
     qCDebug(appLog) << "Updating initramfs";
     QProcess process;
-    process.start("update-initramfs -u");
+    process.start("update-initramfs", QStringList() << "-u");
     process.waitForFinished(-1);
 }
 

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/utils.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/drivercontrol/utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -187,13 +187,7 @@ bool Utils::updateModDeps(bool bquick)
 {
     qCDebug(appLog) << "Updating module dependencies, quick mode:" << bquick;
     QProcess process;
-    QString strcomd;
-    if (bquick) {
-        strcomd = QString("depmod %1").arg("--quick");
-    } else {
-        strcomd = QString("depmod %1").arg("--all");
-    }
-    process.start(strcomd);
+    process.start("depmod", QStringList() << (bquick ? "--quick" : "--all"));
     if (!process.waitForFinished())
         return  false;
 

--- a/deepin-devicemanager-server/deepin-deviceinfo/src/hotplug/detectthread.cpp
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/hotplug/detectthread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -104,7 +104,7 @@ void DetectThread::curHwinfoUsbInfo(QMap<QString, QMap<QString, QString>> &usbIn
 {
     qCDebug(appLog) << "Getting current USB info from hwinfo";
     QProcess process;
-    process.start("hwinfo --usb --keyboard --mouse");
+    process.start("hwinfo", QStringList() << "--usb" << "--keyboard" << "--mouse");
     process.waitForFinished(-1);
     QString info = process.readAllStandardOutput();
     qCDebug(appLog) << "hwinfo output length:" << info.length();

--- a/deepin-devicemanager-server/deepin-deviceinfo/src/hotplug/monitorusb.cpp
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/hotplug/monitorusb.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -92,7 +92,7 @@ void MonitorUsb::monitor()
         if ((0 == strcmp("add", buf) || 0 == strcmp("remove", buf)) && m_workingFlag) {
             qCDebug(appLog) << "USB device " << buf << " detected";
             QProcess process;
-            process.start("hwinfo --usb");
+            process.start("hwinfo", QStringList() << "--usb");
             process.waitForFinished(-1);
             QString info = process.readAllStandardOutput();
             if (0 == strcmp("add", buf)) {

--- a/deepin-devicemanager-server/deepin-deviceinfo/src/mainjob.cpp
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/mainjob.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -89,8 +89,11 @@ void MainJob::slotWakeupHandle(bool isSleep)
             return;
 
         QProcess process; //先唤醒DBUS
-        QString command = "gdbus call --system --dest org.deepin.DeviceControl --object-path /org/deepin/DeviceControl --method org.deepin.DeviceControl.disableInDevice";
-        process.start(command);
+        process.start("gdbus", QStringList()
+            << "call" << "--system"
+            << "--dest" << "org.deepin.DeviceControl"
+            << "--object-path" << "/org/deepin/DeviceControl"
+            << "--method" << "org.deepin.DeviceControl.disableInDevice");
         process.waitForFinished(1000);
 
         //有的硬件唤醒起来也需要延时
@@ -159,9 +162,8 @@ void MainJob::initDriverRepoSource()
     }
     file.close();
 
-    QString cmd = "apt update";
     QProcess process;
-    process.start(cmd);
+    process.start("apt", QStringList() << "update");
     process.waitForFinished(-1);
 }
 

--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -348,7 +348,7 @@ bool DeviceInput::isBluetoothDevice(const QString &dfs)
             if (match.hasMatch()) {
                 QString id = match.captured(1);
                 QProcess process;
-                process.start("hcitool con");
+                process.start("hcitool", QStringList() << "con");
                 process.waitForFinished(-1);
                 QString hciInfo = process.readAllStandardOutput();
                 if (!hciInfo.contains(id))

--- a/deepin-devicemanager/src/GenerateDevice/DBusInterface.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DBusInterface.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -42,8 +42,12 @@ bool DBusInterface::getInfo(const QString &key, QString &info)
     } else {
         qCInfo(appLog) << "unsucess in getting info from getInfo :"  << key;
         QProcess process;
-        QString command = "gdbus call --system --dest org.deepin.DeviceInfo --object-path /org/deepin/DeviceInfo --method org.deepin.DeviceInfo.getInfo hwinfo";
-        process.start(command);
+        process.start("gdbus", QStringList()
+            << "call" << "--system"
+            << "--dest" << "org.deepin.DeviceInfo"
+            << "--object-path" << "/org/deepin/DeviceInfo"
+            << "--method" << "org.deepin.DeviceInfo.getInfo"
+            << "hwinfo");
         process.waitForFinished();
         QByteArray output = process.readAllStandardOutput();
         QString outputStr = QString::fromLocal8Bit(output);

--- a/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -316,13 +316,13 @@ void HWGenerator::generatorDiskDevice()
 
             // 读取interface版本
             QProcess process;
-            process.start("cat /sys/devices/platform/f8200000.ufs/host0/scsi_host/host0/wb_en");
+            process.start("cat", QStringList() << "/sys/devices/platform/f8200000.ufs/host0/scsi_host/host0/wb_en");
             process.waitForFinished(-1);
             int exitCode = process.exitCode();
             if (exitCode != 127 && exitCode != 126) {
                 QString deviceInfo = process.readAllStandardOutput();
                 if (deviceInfo.trimmed() == "true") {
-                    process.start("cat /sys/block/sdd/device/spec_version");
+                    process.start("cat", QStringList() << "/sys/block/sdd/device/spec_version");
                     process.waitForFinished(-1);
                     exitCode = process.exitCode();
                     if (exitCode != 127 && exitCode != 126) {

--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -229,8 +229,11 @@ void MainWindow::refreshBatteryStatus()
     if (interfaceService.isValid()) {
         qCDebug(appLog) << "UPower interface valid";
          QProcess process;
-         QString command = "gdbus call --system --dest org.freedesktop.UPower --object-path /org/freedesktop/UPower --method org.freedesktop.UPower.EnumerateDevices";
-         process.start(command);
+         process.start("gdbus", QStringList()
+             << "call" << "--system"
+             << "--dest" << "org.freedesktop.UPower"
+             << "--object-path" << "/org/freedesktop/UPower"
+             << "--method" << "org.freedesktop.UPower.EnumerateDevices");
          process.waitForFinished();
 
          QByteArray output = process.readAllStandardOutput();

--- a/deepin-devicemanager/src/Tool/LoadCpuInfoThread.cpp
+++ b/deepin-devicemanager/src/Tool/LoadCpuInfoThread.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 UnionTech Software Technology Co.,Ltd
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 - 2026 UnionTech Software Technology Co.,Ltd
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -30,7 +30,7 @@ void LoadCpuInfoThread::runCmd(QString &info, const QString &cmd)
     qCDebug(appLog) << "Executing command:" << cmd;
 
     QProcess process;
-    process.start(cmd);
+    process.startCommand(cmd);
     process.waitForFinished(-1);
     info = process.readAllStandardOutput();
 }

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -82,7 +82,7 @@ void ThreadExecXrandr::runCmd(QString &info, const QString &cmd)
     qCDebug(appLog) << "Executing command:" << cmd;
 
     QProcess process;
-    process.start(cmd);
+    process.startCommand(cmd);
     process.waitForFinished(-1);
     info = process.readAllStandardOutput();
 }


### PR DESCRIPTION

Replace QProcess::start(QString) with the safer start(program, args) form that separates the executable from its arguments, avoiding shell interpretation. For cases where the full command string is intentional, use QProcess::startCommand() which explicitly documents shell behavior.

Affected areas:
- Driver management: depmod, apt update, update-initramfs
- Device info: hwinfo queries for USB detection
- DBus calls: gdbus call commands via QStringList args
- Input device: hcitool bluetooth connection check
- Disk device: cat sysfs paths for UFS info
- System tools: CPU info and xrandr commands

Also updates SPDX copyright years to include 2026 where needed.