### PR TITLE
feat: format network speed as Mbps and remove hard-coded UFS interface

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceNetwork.cpp
@@ -73,6 +73,10 @@ void DeviceNetwork::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "ip", m_Ip);
     setAttribute(mapInfo, "size", m_Speed);
     setAttribute(mapInfo, "capacity", m_Capacity);
+    if (Common::isHwPlatform()) {
+        m_Speed = Common::formatNetworkSpeed(m_Speed);
+        m_Capacity = Common::formatNetworkSpeed(m_Capacity);
+    }
     setAttribute(mapInfo, "Latency", m_Latency);
     setAttribute(mapInfo, "multicast", m_Multicast);
     if (driverIsKernelIn(m_DriverModules) || driverIsKernelIn(m_Driver)) {
@@ -100,6 +104,10 @@ TomlFixMethod DeviceNetwork::setInfoFromTomlOneByOne(const QMap<QString, QString
     // 添加其他信息,成员变量
     setTomlAttribute(mapInfo, "Maximum Rate", m_Capacity);
     setTomlAttribute(mapInfo, "Negotiation Rate", m_Speed);
+    if (Common::isHwPlatform()) {
+        m_Capacity = Common::formatNetworkSpeed(m_Capacity);
+        m_Speed = Common::formatNetworkSpeed(m_Speed);
+    }
     setTomlAttribute(mapInfo, "Port", m_Port);
     setTomlAttribute(mapInfo, "Multicast", m_Multicast);
     setTomlAttribute(mapInfo, "Link", m_Link);

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -214,7 +214,7 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     if (file.open(QIODevice::ReadOnly)) {
         QString output = file.readAll();
         if (!output.isEmpty()) {
-            m_Interface = "UFS";
+            m_Interface = "";
         }
         file.close();
     }

--- a/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/HWGenerator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -281,7 +281,7 @@ void HWGenerator::generatorDiskDevice()
                 tempMap["Name"] = "nouse";
 
             if (Common::specialComType == Common::kSpecialType2) {
-                tempMap["Interface"] = "UFS";
+                tempMap["Interface"] = "";
             }
 
             // 读取interface版本
@@ -299,7 +299,7 @@ void HWGenerator::generatorDiskDevice()
                         deviceInfo = process.readAllStandardOutput();
 
                         if (!deviceInfo.trimmed().isEmpty()) {
-                            tempMap["interface"] = "UFS";
+                            tempMap["interface"] = "";
                         }
                     }
                 }

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -346,4 +346,50 @@ int Common::parseSharedCpuCount(const QString &sharedCpuList)
         }
     }
     return count;
+}
+
+QString Common::formatNetworkSpeed(const QString& speed)
+{
+    // 1. Trim whitespace; return original if empty
+    QString s = speed.trimmed();
+    if (s.isEmpty())
+        return speed;
+
+    // 2. Convert "Gbit/s" -> "Mbps" (1Gbit/s = 1000Mbps), case-sensitive
+    const QString gbitSuffix = "Gbit/s";
+    if (s.endsWith(gbitSuffix, Qt::CaseSensitive)) {
+        QString numStr = s.left(s.length() - gbitSuffix.length()).trimmed();
+        bool ok = false;
+        double num = numStr.toDouble(&ok);
+        if (ok) {
+            double mbps = num * 1000.0;
+            // Format: integer values get no decimal point, otherwise keep one decimal
+            double intPart;
+            if (std::abs(std::modf(mbps, &intPart)) < 1e-6) {
+                return QString::number(static_cast<long long>(mbps)) + "Mbps";
+            } else {
+                return QString::number(mbps, 'f', 1) + "Mbps";
+            }
+        }
+    }
+
+    // 3. Normalize "Mbit/s" -> "Mbps" (value unchanged, case-sensitive)
+    const QString mbitSuffix = "Mbit/s";
+    if (s.endsWith(mbitSuffix, Qt::CaseSensitive)) {
+        QString numStr = s.left(s.length() - mbitSuffix.length()).trimmed();
+        bool ok = false;
+        double num = numStr.toDouble(&ok);
+        if (ok) {
+            // Format: integer values get no decimal point, otherwise keep one decimal
+            double intPart;
+            if (std::abs(std::modf(num, &intPart)) < 1e-6) {
+                return QString::number(static_cast<long long>(num)) + "Mbps";
+            } else {
+                return QString::number(num, 'f', 1) + "Mbps";
+            }
+        }
+    }
+
+    // 4. Return original string if no known suffix matches
+    return speed;
 }

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2019 - 2026 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -60,5 +60,14 @@ public:
     static QString formatTotalCache(const QString& perThreadCache, int coreCount);
 
     static int parseSharedCpuCount(const QString &sharedCpuList);
+
+    /**
+     * @brief formatNetworkSpeed: Convert network speed units to Mbps
+     * @param speed: Original speed string (e.g., "1Gbit/s", "100Mbit/s")
+     * @return Converted speed string in Mbps format (e.g., "1000Mbps", "100Mbps")
+     *         Returns the original string if no conversion is needed.
+     *         Note: Case-sensitive - "Gbit/s" -> "Mbps", "Mbit/s" -> "Mbps"
+     */
+    static QString formatNetworkSpeed(const QString& speed);
 };
 #endif // COMMONFUNCTION_H


### PR DESCRIPTION
- Add Common::formatNetworkSpeed() to convert speed units: "Gbit/s" -> "Mbps" (x1000), "Mbit/s" -> "Mbps" (unit normalization)
- Apply the conversion to network Speed and Capacity on HW platform in DeviceNetwork for both lshw and toml info sources
- Remove hard-coded "UFS" storage interface in DeviceStorage and HWGenerator

Log: 网卡速率统一转换为Mbps显示，移除硬盘接口硬编码的UFS
Task: https://pms.uniontech.com/task-view-390747.html
Change-Id: If4834ad6080330e5ce0a350a37c7e1698d13f2c2

## Summary by Sourcery

Normalize hardware network speed display to Mbps and remove hard-coded UFS storage interface values.

New Features:
- Add a common utility to convert network speed strings to normalized Mbps values.

Enhancements:
- Apply unified Mbps formatting for network speed and capacity on hardware platforms for both lshw and TOML data sources.
- Clear storage interface fields instead of using a hard-coded UFS value for certain hardware configurations.
- Update copyright headers to cover the 2019-2026 and 2022-2026 periods in touched files.