### PR TITLE
Fix: Except for special models, the driver management page is displayed.

### DIFF
--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -421,7 +421,7 @@ void MainWindow::initWindowTitle()
     });
     titlebar()->addWidget(mp_ButtonBox);
     // 特殊处理
-    if (!Common::boardVendorType().isEmpty())
+    if (Common::isHwPlatform())
         mp_ButtonBox->hide();
 #ifdef DISABLE_DRIVER
     mp_ButtonBox->hide();


### PR DESCRIPTION
-- Except for special models, the driver management page is displayed.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-364251.html

## Summary by Sourcery

Bug Fixes:
- Correct driver management button visibility so it is only hidden on specific hardware platforms instead of whenever a board vendor type is present.