### PR TITLE
fix: 支持通过 Video RAM 匹配定制显存大小

### DIFF
--- a/deepin-devicemanager/assets/org.deepin.devicemanager.json
+++ b/deepin-devicemanager/assets/org.deepin.devicemanager.json
@@ -35,6 +35,16 @@
             "permissions": "readwrite",
             "visibility": "private"
           },
+          "specialVRAMType": {
+            "value": 0,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Special VRAM Type",
+            "name[zh_CN]": "定制VRAM类型",
+            "description": "Special VRAM Type: VRAM type(value:0)",
+            "permissions": "readwrite",
+            "visibility": "private"
+          },
           "TomlFilesName": {
             "value": "tomlFilesName",
             "serial": 0,

--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -425,7 +425,21 @@ void CmdTool::loadDmesgInfo(const QString &debugfile)
     // 获取显存大小信息
     QMap<QString, QString> mapInfo;
     QStringList lines = deviceInfo.split("\n");
+    const bool isSpecialVRAM = Common::curVRAMType == Common::kSpecialVRAMType1;
+    bool hasCustomVRAMSize = false;
+    QRegExp regCustom(".*([0-9a-z]{4}:[0-9a-z]{2}:[0-9a-z]{2}\\.[0-9]{1}):.*Video RAM[^0-9]*([0-9]+)[\\s]{0,1}M.*");
     foreach (const QString &line, lines) {
+        if (isSpecialVRAM && regCustom.exactMatch(line)) {
+            double size = regCustom.cap(2).toDouble();
+            QString sizeS = QString("%1GB").arg(size / 1024);
+            mapInfo["Size"] = regCustom.cap(1) + "=" + sizeS;
+            hasCustomVRAMSize = true;
+            continue;
+        }
+
+        if (hasCustomVRAMSize)
+            continue;
+
         // DeviceCdrom m_HwinfoToLshw 值为0000:01:00.0 此处同步修改,否则显存大小无法显示
         QRegExp reg(".*([0-9a-z]{4}:[0-9a-z]{2}:[0-9a-z]{2}.[0-9]{1}):.*VRAM([=:]{1}) ([0-9]*)[\\s]{0,1}M.*");
         if (reg.exactMatch(line)) {

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -37,6 +37,7 @@ static bool initBoardVendorFlag = false;
 static QString boardVendorKey = "";
 int Common::specialComType = -1;
 Common::SpecialCpuType Common::curCpuType = Common::SpecialCpuType::kUnknowCpuType;
+Common::SpecialVRAMType Common::curVRAMType = Common::SpecialVRAMType::kNormalVRAMType;
 static QString tomlFilesName = "tomlFilesName";
 QString Common::getArch()
 {

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -34,6 +34,12 @@ public:
         kSpecialCpuType1
     };
 
+    enum SpecialVRAMType {
+        kNormalVRAMType = 0,
+        kSpecialVRAMType1,
+        kSpecialVRAMTypeMax
+    };
+
     static QString getArch();
 
     static QString getArchStore();
@@ -53,6 +59,7 @@ public:
      */
     static int specialComType;
     static SpecialCpuType curCpuType;
+    static SpecialVRAMType curVRAMType;
 
     static QByteArray executeClientCmd(const QString& cmd, const QStringList& args = QStringList(), const QString& workPath = QString(), int msecsWaiting = 30000);
 

--- a/deepin-devicemanager/src/main.cpp
+++ b/deepin-devicemanager/src/main.cpp
@@ -124,6 +124,13 @@ int main(int argc, char *argv[])
         }
         if (dconfig->keyList().contains("specialCpuType"))
             Common::curCpuType = static_cast<Common::SpecialCpuType>(dconfig->value("specialCpuType").toInt());
+        if (dconfig->keyList().contains("specialVRAMType")) {
+            const int vramTypeValue = dconfig->value("specialVRAMType").toInt();
+            if (vramTypeValue >= Common::kNormalVRAMType && vramTypeValue < Common::kSpecialVRAMTypeMax)
+                Common::curVRAMType = static_cast<Common::SpecialVRAMType>(vramTypeValue);
+            else
+                Common::curVRAMType = Common::kNormalVRAMType;
+        }
     }
 
     // 特殊机型，提前缓存GPU信息


### PR DESCRIPTION
Log: 通过 specialVRAMType 配置启用定制显存解析逻辑，匹配 dmesg 中的 Video RAM
字段并提取显存大小；Video RAM 与数值之间不再限制必须使用冒号分隔，兼容 Video RAM: 2048M、Video RAM
2048M 等格式。
Task: https://pms.uniontech.com/task-view-391143.html

## Summary by Sourcery

Add configurable handling for parsing custom Video RAM formats from dmesg and integrate a new VRAM type flag into the device manager configuration.

New Features:
- Introduce a configurable special VRAM type to enable custom Video RAM parsing logic based on dmesg output.

Bug Fixes:
- Correct Video RAM size detection by supporting dmesg lines where the value is not strictly separated by a colon, e.g. 'Video RAM 2048M'.

Enhancements:
- Update device manager startup to load the special VRAM type from configuration and use it when computing GPU memory size.