### PR TITLE
fix: 支持更多定制机型通过 Video RAM 匹配显存

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -425,7 +425,8 @@ void CmdTool::loadDmesgInfo(const QString &debugfile)
     // 获取显存大小信息
     QMap<QString, QString> mapInfo;
     QStringList lines = deviceInfo.split("\n");
-    const bool isSpecialVRAM = Common::curVRAMType == Common::kSpecialVRAMType1;
+    const bool isSpecialVRAM = Common::curVRAMType == Common::kSpecialVRAMType1
+            || Common::curVRAMType == Common::kSpecialVRAMType2;
     bool hasCustomVRAMSize = false;
     QRegExp regCustom(".*([0-9a-z]{4}:[0-9a-z]{2}:[0-9a-z]{2}\\.[0-9]{1}):.*Video RAM[^0-9]*([0-9]+)[\\s]{0,1}M.*");
     foreach (const QString &line, lines) {

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -37,6 +37,7 @@ public:
     enum SpecialVRAMType {
         kNormalVRAMType = 0,
         kSpecialVRAMType1,
+        kSpecialVRAMType2,
         kSpecialVRAMTypeMax
     };
 


### PR DESCRIPTION
  Log: 新增 specialVRAMType 取值 2 的显存解析支持，使 NL321B 等定制机型可复用 Video RAM
  字段匹配逻辑
  Task: https://pms.uniontech.com/task-view-391203.html