### PR TITLE
refactor(driver): move driver repo source init to installer

### DIFF
--- a/deepin-devicemanager-server/src/DriverControl/DriverInstaller.cpp
+++ b/deepin-devicemanager-server/src/DriverControl/DriverInstaller.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,12 +14,16 @@
 #include <QDebug>
 #include <QProcess>
 #include <QTimer>
+#include <QFile>
+#include <QFileInfo>
 
 #include <unistd.h>
 #include <fstream>
 #include <string>
 #include <vector>
 
+const QString DriverInstaller::DEVICE_REPO_PATH = "/etc/apt/sources.list.d/devicemanager.list";
+const QString DriverInstaller::DRIVER_REPO_PATH = "/etc/apt/sources.list.d/driver.list";
 const int MAX_DPKGRUNING_TEST = 20;
 const int TEST_TIME_INTERVAL = 2000;
 
@@ -132,9 +136,13 @@ bool DriverInstaller::isNetworkOnline(uint usec)
 
 void DriverInstaller::doOperate(const QString &package, const QString &version)
 {
+    // 按需创建驱动仓库源文件，仅在 driver.list 中不存在 pro-driver-packages 时创建
+    ensureDriverRepoSource();
+
     if (!initBackend()) {
         emit errorOccurred(EC_NULL);
         qInfo() << "DRIVER_LOG : ************************** 初始化backend失败";
+        cleanupTempSource();
         return;
     }
 
@@ -143,6 +151,7 @@ void DriverInstaller::doOperate(const QString &package, const QString &version)
     if (nullptr == p) {
         emit errorOccurred(EC_NOTFOUND);
         qInfo() << "DRIVER_LOG : ************************** 安装包不存在";
+        cleanupTempSource();
         return;
     }
 
@@ -152,6 +161,7 @@ void DriverInstaller::doOperate(const QString &package, const QString &version)
         emit errorOccurred(EC_NOTFOUND);
         delete p;
         p = nullptr;
+        cleanupTempSource();
         return;
     }
 
@@ -162,6 +172,7 @@ void DriverInstaller::doOperate(const QString &package, const QString &version)
     if (nullptr == mp_Trans) {
         emit errorOccurred(EC_NULL);
         qInfo() << "DRIVER_LOG : ************************** installPackages";
+        cleanupTempSource();
         return;
     }
 
@@ -189,6 +200,9 @@ void DriverInstaller::doOperate(const QString &package, const QString &version)
 
         qInfo() << "DRIVER_LOG : ************************** 安装结束 结束状态码" << status;
         qInfo() << "DRIVER_LOG : ************************** 安装结束 结束错误码" << code;
+
+        // 清理本次创建的临时源文件
+        cleanupTempSource();
 
         mp_Trans->disconnect();
         mp_Trans->deleteLater();
@@ -219,4 +233,60 @@ void DriverInstaller::doOperate(const QString &package, const QString &version)
 
     mp_Trans->run();
 }
+
+void DriverInstaller::ensureDriverRepoSource()
+{
+    // 重置临时源标记，避免因前一次安装失败导致残留标记
+    m_tempSourceCreated = false;
+
+    // 优先检查系统自带的 driver.list 中是否已包含驱动仓库源
+    QFile fileDriver(DRIVER_REPO_PATH);
+    if (fileDriver.open(QIODevice::ReadOnly)) {
+        QString info = fileDriver.readAll();
+        QStringList lines = info.split("\n");
+        foreach (QString line, lines) {
+            if (line.contains("pro-driver-packages")) {
+                fileDriver.close();
+                return;
+            }
+        }
+        fileDriver.close();
+    }
+
+    // 使用 O_EXCL 原子创建文件，避免 TOCTOU 竞争条件（CWE-367）
+    // NewOnly 保证文件不存在时才创建，若已存在则 open 失败，无需先检查
+    QFile file(DEVICE_REPO_PATH);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text | QFile::NewOnly)) {
+        // 文件已存在属于正常情况（第三方创建），静默返回
+        if (!QFile::exists(DEVICE_REPO_PATH)) {
+            qInfo() << "DRIVER_LOG : 创建驱动源文件失败:" << file.errorString();
+        }
+        return;
+    }
+
+    file.write("deb https://pro-driver-packages.uniontech.com eagle non-free\n");
+    file.close();
+    m_tempSourceCreated = true;
+    qInfo() << "DRIVER_LOG : 创建临时驱动源文件:" << DEVICE_REPO_PATH;
+
+    // 新源创建后需执行 apt update 更新包索引，
+    // 否则 QApt::Backend 无法识别该源的软件包
+    // 使用列表传参绕过 shell 解析，避免命令注入风险
+    QProcess process;
+    process.start("apt", QStringList() << "update");
+    process.waitForFinished(50000);
+    qInfo() << "DRIVER_LOG : 临时源 apt update 完成";
+}
+
+void DriverInstaller::cleanupTempSource()
+{
+    if (!m_tempSourceCreated) {
+        return;
+    }
+
+    QFile::remove(DEVICE_REPO_PATH);
+    m_tempSourceCreated = false;
+    qWarning() << "DRIVER_LOG : 清理临时驱动源文件:" << DEVICE_REPO_PATH;
+}
+
 #endif // DISABLE_DRIVER

--- a/deepin-devicemanager-server/src/DriverControl/DriverInstaller.h
+++ b/deepin-devicemanager-server/src/DriverControl/DriverInstaller.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -27,6 +26,10 @@ class DriverInstaller : public QObject
     Q_OBJECT
 public:
     explicit DriverInstaller(QObject *parent = nullptr);
+
+    // 驱动仓库源文件路径
+    static const QString DEVICE_REPO_PATH;
+    static const QString DRIVER_REPO_PATH;
 
 public slots:
     /**
@@ -70,11 +73,23 @@ private:
      * @param version
      */
     void doOperate(const QString &package, const QString &version);
+    /**
+     * @brief ensureDriverRepoSource 按需创建驱动仓库源文件
+     *        仅在 driver.list 中不存在 pro-driver-packages 时创建 devicemanager.list
+     */
+    void ensureDriverRepoSource();
+
+    /**
+     * @brief cleanupTempSource 清理本次创建的临时源文件
+     */
+    void cleanupTempSource();
+
 private:
     QApt::Backend *mp_Backend = nullptr;
     QApt::Transaction *mp_Trans = nullptr;
     int m_iRuningTestCount = 0;
     bool m_Cancel;
+    bool m_tempSourceCreated = false;  // 是否在本次安装中创建了临时源
 };
 
 #endif // DRIVERINSTALLER_H

--- a/deepin-devicemanager-server/src/MainJob.cpp
+++ b/deepin-devicemanager-server/src/MainJob.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,7 +25,6 @@
 #include <QMutexLocker>
 #include <QDBusConnection>
 #include <QDebug>
-#include <QFile>
 
 #include <unistd.h>
 
@@ -37,8 +36,6 @@ const QString ENABLE_SERVICE_PATH = "/com/deepin/enablemanager";
 const QString WAKEUP_SERVICE_PATH = "/com/deepin/wakeupmanager";
 bool  MainJob::s_ServerIsUpdating = false;
 bool  MainJob::s_ClientIsUpdating = false;
-const QString DEVICE_REPO_PATH = "/etc/apt/sources.list.d/devicemanager.list";
-const QString DRIVER_REPO_PATH = "/etc/apt/sources.list.d/driver.list";
 
 MainJob::MainJob(QObject *parent)
     : QObject(parent)
@@ -77,10 +74,6 @@ void MainJob::working()
 
     // 在驱动管理延迟加载1000ms
     QTimer::singleShot(1000, this, [ = ]() {
-        //初始化源
-#ifndef DISABLE_DRIVER
-        initDriverRepoSource();
-#endif
         // 后台加载后先禁用设备
         const QString &info = DeviceInfoManager::getInstance()->getInfo("hwinfo");
         EnableUtils::disableOutDevice(info);
@@ -246,37 +239,3 @@ bool MainJob::initDriverDbus()
 
     return true;
 }
-
-void MainJob::initDriverRepoSource()
-{
-    QFile fileDriver(DRIVER_REPO_PATH);
-    if (fileDriver.open(QIODevice::ReadOnly)) {
-        QString info = fileDriver.readAll();
-        QStringList lines = info.split("\n");
-        foreach (QString line, lines) {
-            if (line.contains("pro-driver-packages")) {
-                fileDriver.close();
-                return;
-            }
-        }
-        fileDriver.close();
-    }
-
-    QFile file(DEVICE_REPO_PATH);
-    if (QFile::exists(DEVICE_REPO_PATH)) {
-        return;
-    }
-    if (!file.open(QIODevice::ReadWrite | QIODevice::Text)) {
-        qInfo() << file.errorString();
-        return;
-    }
-
-    file.write("deb https://pro-driver-packages.uniontech.com eagle non-free\n");
-    file.close();
-
-    QString cmd = "apt update";
-    QProcess process;
-    process.start(cmd);
-    process.waitForFinished(-1);
-}
-

--- a/deepin-devicemanager-server/src/MainJob.h
+++ b/deepin-devicemanager-server/src/MainJob.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -97,12 +97,6 @@ private:
      * @return : 返回bool
      */
     bool initDriverDbus();
-
-    /**
-     * @brief initDriverRepoSource : 初始化驱动仓库
-     * @return : 无
-     */
-    void initDriverRepoSource();
 
 private:
     ThreadPool            *mp_Pool = nullptr;                 //<! 生成文件的线程池


### PR DESCRIPTION
Move driver repo source creation from MainJob to DriverInstaller, creating temp source only when installing and cleaning up after.

将驱动仓库源初始化逻辑从MainJob迁移到DriverInstaller，
仅在安装驱动时按需创建临时源并在安装完成后清理。

Log: 驱动仓库源创建逻辑迁移至安装器按需执行
PMS: BUG-366349
Influence: 驱动仓库源文件不再在服务启动时创建，改为安装驱动时按需创建和清理，避免非社区版系统不必要的源文件残留。