### PR TITLE
fix: enable touch screen scrolling for QScrollArea-based views

### DIFF
--- a/deepin-devicemanager/src/MacroDefinition.h
+++ b/deepin-devicemanager/src/MacroDefinition.h
@@ -215,6 +215,11 @@
 #define   WIDGET_MARGIN      2     // 页边距
 #define   BOTTOM_MARGIN      11    // 下边距
 #define   LABEL_MARGIN       12    // 页面标签的上下边距
+
+// 触摸屏滚动参数
+#define SCROLLER_OVERSHOOT_DISTANCE_FACTOR     0.3  // 超出滚动距离系数
+#define SCROLLER_OVERSHOOT_DRAG_RESIST_FACTOR   0.3  // 超出拖拽阻力系数
+#define SCROLLER_DRAG_VELOCITY_SMOOTH_FACTOR    0.6  // 拖拽速度平滑系数
 #define   HORSCROLL_WIDTH    11    // TreeWidget 横向滚动条高度
 #define   MIN_NUM            5     // num
 

--- a/deepin-devicemanager/src/Page/PageDetail.cpp
+++ b/deepin-devicemanager/src/Page/PageDetail.cpp
@@ -25,6 +25,8 @@
 #include <QAction>
 #include <QClipboard>
 #include <QPainterPath>
+#include <QScroller>
+#include <QScrollerProperties>
 
 // 宏定义
 #define SPACE_HEIGHT 0  //
@@ -180,6 +182,15 @@ PageDetail::PageDetail(QWidget *parent)
     // 设置ScrollArea里面的widget,这个widget是必须要的
     mp_ScrollWidget->setContentsMargins(15, 0, 0, 0);
     mp_ScrollArea->setWidget(mp_ScrollWidget);
+
+    // 启用触摸屏滚动支持
+    QScroller::grabGesture(mp_ScrollArea, QScroller::LeftMouseButtonGesture);
+    QScrollerProperties sp;
+    sp.setScrollMetric(QScrollerProperties::OvershootScrollDistanceFactor, SCROLLER_OVERSHOOT_DISTANCE_FACTOR);
+    sp.setScrollMetric(QScrollerProperties::OvershootDragResistanceFactor, SCROLLER_OVERSHOOT_DRAG_RESIST_FACTOR);
+    sp.setScrollMetric(QScrollerProperties::DragVelocitySmoothingFactor, SCROLLER_DRAG_VELOCITY_SMOOTH_FACTOR);
+    QScroller::scroller(mp_ScrollArea)->setScrollerProperties(sp);
+
     hLayout->addWidget(mp_ScrollArea);
     setLayout(hLayout);
 

--- a/deepin-devicemanager/src/Page/PageDriverInstallInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageDriverInstallInfo.cpp
@@ -1,9 +1,11 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <QBoxLayout>
 
+#include <QScroller>
+#include <QScrollerProperties>
 #include <DScrollArea>
 
 #include "PageDriverInstallInfo.h"
@@ -58,6 +60,15 @@ void PageDriverInstallInfo::initUI()
     area->setMinimumHeight(10);
     area->setFrameShape(QFrame::NoFrame);
     area->setWidgetResizable(true);
+
+    // 启用触摸屏滚动支持
+    QScroller::grabGesture(area, QScroller::LeftMouseButtonGesture);
+    QScrollerProperties sp;
+    sp.setScrollMetric(QScrollerProperties::OvershootScrollDistanceFactor, SCROLLER_OVERSHOOT_DISTANCE_FACTOR);
+    sp.setScrollMetric(QScrollerProperties::OvershootDragResistanceFactor, SCROLLER_OVERSHOOT_DRAG_RESIST_FACTOR);
+    sp.setScrollMetric(QScrollerProperties::DragVelocitySmoothingFactor, SCROLLER_DRAG_VELOCITY_SMOOTH_FACTOR);
+    QScroller::scroller(area)->setScrollerProperties(sp);
+
     DWidget *frame = new DWidget(this);
     frame->setContentsMargins(0, 0, 0, 0);
     QVBoxLayout *frameLayout = new QVBoxLayout();


### PR DESCRIPTION
The PageDetail and PageDriverInstallInfo views use QScrollArea to display content, which only responds to mouse wheel events by default. On touch screens, finger swipe gestures do not trigger scrolling, causing text selection to be activated instead.

Register QScroller gestures on the affected QScrollArea widgets to enable kinetic touch scrolling. Extract scroller properties into named constants in MacroDefinition.h for reuse and maintainability.

Files changed:
- MacroDefinition.h: add SCROLLER_OVERSHOOT_DISTANCE_FACTOR, SCROLLER_OVERSHOOT_DRAG_RESIST_FACTOR, SCROLLER_DRAG_VELOCITY_SMOOTH_FACTOR
- PageDetail.cpp: register QScroller on mp_ScrollArea
- PageDriverInstallInfo.cpp: register QScroller on driver list scroll area

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-366201.html