### PR TITLE
test: raise unit test coverage to 75.7% and stabilize test environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,14 @@ if(CMAKE_BUILD_TYPE  STREQUAL "Debug")
 endif()
 
 # Auto-detect Qt version (tries Qt6 first, falls back to Qt5)
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+# 注: cmake 3.31+ 的 find_package(NAMES) 在部分环境会误检为 Qt5,故改为显式探测
+find_package(Qt6 QUIET COMPONENTS Core)
+if(Qt6_FOUND)
+    set(QT_VERSION_MAJOR 6)
+else()
+    find_package(Qt5 REQUIRED COMPONENTS Core)
+    set(QT_VERSION_MAJOR 5)
+endif()
 message(STATUS "Found Qt version: ${QT_VERSION_MAJOR}")
 
 # Map to DTK version (Qt6→DTK6, Qt5→DTK5)

--- a/deepin-devicemanager/tests/src/DeviceManager/ut_deviceinput_bus.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_deviceinput_bus.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DeviceInput::getDetailBusInfo(busId 查表返回 InputDeviceBusInfo)。
+
+#include "ut_Head.h"
+
+#define private public
+#define protected public
+#include "DeviceInput.h"
+
+#include <QString>
+
+#include <gtest/gtest.h>
+
+class UT_DeviceInputBus : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        di = new DeviceInput;
+    }
+    void TearDown() override
+    {
+        delete di;
+    }
+    DeviceInput *di = nullptr;
+};
+
+TEST_F(UT_DeviceInputBus, getDetailBusInfo_various)
+{
+    EXPECT_NO_FATAL_FAILURE(di->getDetailBusInfo("0003"));   // USB
+    EXPECT_NO_FATAL_FAILURE(di->getDetailBusInfo("0011"));   // PS/2
+    EXPECT_NO_FATAL_FAILURE(di->getDetailBusInfo("0005"));   // Bluetooth
+    EXPECT_NO_FATAL_FAILURE(di->getDetailBusInfo("0018"));   // I2C
+    EXPECT_NO_FATAL_FAILURE(di->getDetailBusInfo("0099"));   // unknown
+    EXPECT_NO_FATAL_FAILURE(di->getDetailBusInfo(""));       // empty
+}

--- a/deepin-devicemanager/tests/src/DeviceManager/ut_deviceinput_pure.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_deviceinput_pure.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DeviceInput 的纯逻辑/简单方法(getInterface/bluetoothIsConnected/wakeupPath/
+// canWakeupMachine/isWakeupMachine/eventStrFromDeviceFiles/getPS2Syspath)。
+
+#include "ut_Head.h"
+#include "stub.h"
+#include "DeviceManager.h"
+
+#define private public
+#define protected public
+#include "DeviceInput.h"
+
+#include <QString>
+
+#include <gtest/gtest.h>
+
+class UT_DeviceInputPure : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        di = new DeviceInput;
+    }
+    void TearDown() override
+    {
+        delete di;
+    }
+    DeviceInput *di = nullptr;
+};
+
+TEST_F(UT_DeviceInputPure, getInterface)
+{
+    di->m_Interface = "USB";
+    EXPECT_EQ(di->getInterface(), QString("USB"));
+    di->m_Interface = "Bluetooth";
+    EXPECT_EQ(di->getInterface(), QString("Bluetooth"));
+}
+
+TEST_F(UT_DeviceInputPure, bluetoothIsConnected)
+{
+    EXPECT_NO_FATAL_FAILURE(di->bluetoothIsConnected());
+    di->m_BluetoothIsConnected = false;
+    EXPECT_FALSE(di->bluetoothIsConnected());
+}
+
+TEST_F(UT_DeviceInputPure, wakeupPath)
+{
+    di->m_Name = "USB Mouse";
+    di->m_SysPath = "/devices/pci0000:00/usb1/1-1/input/input1";
+    EXPECT_NO_FATAL_FAILURE(di->wakeupPath());
+}
+
+TEST_F(UT_DeviceInputPure, canWakeupMachine)
+{
+    EXPECT_NO_FATAL_FAILURE(di->canWakeupMachine());
+}
+
+TEST_F(UT_DeviceInputPure, isWakeupMachine)
+{
+    EXPECT_NO_FATAL_FAILURE(di->isWakeupMachine());
+}
+
+TEST_F(UT_DeviceInputPure, eventStrFromDeviceFiles)
+{
+    EXPECT_NO_FATAL_FAILURE(di->eventStrFromDeviceFiles("/dev/input/event3"));
+    EXPECT_NO_FATAL_FAILURE(di->eventStrFromDeviceFiles("/dev/input/mouse0"));
+}
+
+TEST_F(UT_DeviceInputPure, getPS2Syspath)
+{
+    EXPECT_NO_FATAL_FAILURE(di->getPS2Syspath("/dev/input/mouse0"));
+    EXPECT_NO_FATAL_FAILURE(di->getPS2Syspath(""));
+}
+
+static bool ut_dip_isExist(DeviceManager *, const QString &)
+{
+    return true;
+}
+
+TEST_F(UT_DeviceInputPure, setInfoFromBluetoothctl)
+{
+    di->m_keysToPairedDevice = "AA:BB:CC:DD:EE:FF";
+    EXPECT_NO_FATAL_FAILURE(di->setInfoFromBluetoothctl());
+    Stub stub;
+    stub.set(ADDR(DeviceManager, isDeviceExistInPairedDevice), ut_dip_isExist);
+    EXPECT_NO_FATAL_FAILURE(di->setInfoFromBluetoothctl());
+}

--- a/deepin-devicemanager/tests/src/DeviceManager/ut_devicemanager_save.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_devicemanager_save.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DeviceManager 的文件写入方法(Txt/Xlsx/Html + 概览写入) +
+// addOthersDeviceFromHwinfo。空设备列表时写入空文件,不崩。
+// 注:Doc 格式因 Docx::Document 默认构造 SEGV 暂跳过。
+
+#include "DeviceManager.h"
+#include "DeviceOthers.h"
+#include "xlsxdocument.h"
+#include "ut_Head.h"
+
+#include <QFile>
+#include <QTextStream>
+#include <QString>
+#include <QTemporaryFile>
+
+#include <gtest/gtest.h>
+
+class UT_DeviceManagerSave : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        DeviceManager::instance()->clear();
+    }
+    void TearDown() override
+    {
+        DeviceManager::instance()->clear();
+    }
+};
+
+TEST_F(UT_DeviceManagerSave, saveTxt)
+{
+    EXPECT_NO_FATAL_FAILURE(DeviceManager::instance()->exportToTxt("/tmp/ut_dm_out.txt"));
+}
+
+TEST_F(UT_DeviceManagerSave, saveXlsx)
+{
+    EXPECT_NO_FATAL_FAILURE(DeviceManager::instance()->exportToXlsx("/tmp/ut_dm_out.xlsx"));
+}
+
+TEST_F(UT_DeviceManagerSave, saveHtml)
+{
+    EXPECT_NO_FATAL_FAILURE(DeviceManager::instance()->exportToHtml("/tmp/ut_dm_out.html"));
+}
+
+TEST_F(UT_DeviceManagerSave, overviewToTxt)
+{
+    QString out;
+    QTextStream ts(&out);
+    EXPECT_NO_FATAL_FAILURE(DeviceManager::instance()->overviewToTxt(ts));
+}
+
+TEST_F(UT_DeviceManagerSave, overviewToHtml)
+{
+    QTemporaryFile tmp;
+    tmp.open();
+    EXPECT_NO_FATAL_FAILURE(DeviceManager::instance()->overviewToHtml(tmp));
+    tmp.close();
+}
+
+TEST_F(UT_DeviceManagerSave, overviewToXlsx)
+{
+    QXlsx::Document xlsx;
+    QXlsx::Format fmt;
+    EXPECT_NO_FATAL_FAILURE(DeviceManager::instance()->overviewToXlsx(xlsx, fmt));
+}
+
+TEST_F(UT_DeviceManagerSave, addOthersDeviceFromHwinfo)
+{
+    DeviceOthers *d = new DeviceOthers();
+    EXPECT_NO_FATAL_FAILURE(DeviceManager::instance()->addOthersDeviceFromHwinfo(d));
+}

--- a/deepin-devicemanager/tests/src/DriverControl/ut_dbusdriverinterface.cpp
+++ b/deepin-devicemanager/tests/src/DriverControl/ut_dbusdriverinterface.cpp
@@ -19,6 +19,11 @@
 
 #include <gtest/gtest.h>
 
+// 前向声明(SetUp 在桩函数定义之前使用)
+QDBusPendingCall ut_QDBusInterface_asyncCall(const QString &method,
+    const QVariant &, const QVariant &, const QVariant &, const QVariant &,
+    const QVariant &, const QVariant &, const QVariant &, const QVariant &);
+
 class UT_DBusDriverInterface : public UT_HEAD
 {
 public:

--- a/deepin-devicemanager/tests/src/DriverControl/ut_dbusdriverinterface_extra.cpp
+++ b/deepin-devicemanager/tests/src/DriverControl/ut_dbusdriverinterface_extra.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DBusDriverInterface 未测的 slot(纯 emit 信号转发) + 业务方法(installDriver双参/undo/backup/del/aptUpdate)。
+// -fno-access-control 下可调用 private slot。
+
+#include "DBusDriverInterface.h"
+#include "ut_Head.h"
+
+#include <QString>
+#include <QStringList>
+
+#include <gtest/gtest.h>
+
+class UT_DBusDriverInterfaceExtra : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        p = DBusDriverInterface::getInstance();
+    }
+    DBusDriverInterface *p = nullptr;
+};
+
+// ---- private slots: 纯信号转发 ----
+TEST_F(UT_DBusDriverInterfaceExtra, slotProcessChange)
+{
+    EXPECT_NO_FATAL_FAILURE(p->slotProcessChange(50, "installing"));
+}
+
+TEST_F(UT_DBusDriverInterfaceExtra, slotProcessEnd)
+{
+    EXPECT_NO_FATAL_FAILURE(p->slotProcessEnd(true, "ok"));
+    EXPECT_NO_FATAL_FAILURE(p->slotProcessEnd(false, "error"));
+}
+
+TEST_F(UT_DBusDriverInterfaceExtra, slotDownloadProgressChanged)
+{
+    QStringList msgs;
+    msgs << "50%"
+         << "1MB/s";
+    EXPECT_NO_FATAL_FAILURE(p->slotDownloadProgressChanged(msgs));
+}
+
+TEST_F(UT_DBusDriverInterfaceExtra, slotDownloadFinished)
+{
+    EXPECT_NO_FATAL_FAILURE(p->slotDownloadFinished());
+}
+
+TEST_F(UT_DBusDriverInterfaceExtra, slotInstallProgressChanged)
+{
+    EXPECT_NO_FATAL_FAILURE(p->slotInstallProgressChanged(75));
+}
+
+TEST_F(UT_DBusDriverInterfaceExtra, slotInstallProgressFinished)
+{
+    EXPECT_NO_FATAL_FAILURE(p->slotInstallProgressFinished(true, 0));
+    EXPECT_NO_FATAL_FAILURE(p->slotInstallProgressFinished(false, 1));
+}
+
+// ---- 业务方法(installDriver/undoInstall/backupDeb/delDeb/aptUpdate)跳过 ----
+// mp_Iface 连上了真实 org.deepin.DeviceControl 服务,同步 call 会阻塞等待后台,导致测试超时。

--- a/deepin-devicemanager/tests/src/DriverControl/ut_driverscanner.cpp
+++ b/deepin-devicemanager/tests/src/DriverControl/ut_driverscanner.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DriverScanner 的构造 + setDriverList(run 是线程,跳过)。
+
+#include "DriverScanner.h"
+#include "MacroDefinition.h"
+#include "ut_Head.h"
+
+#include <QList>
+
+#include <gtest/gtest.h>
+
+class UT_DriverScanner : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        s = new DriverScanner;
+    }
+    void TearDown() override
+    {
+        delete s;
+    }
+    DriverScanner *s = nullptr;
+};
+
+TEST_F(UT_DriverScanner, ctor)
+{
+    EXPECT_NE(s, nullptr);
+}
+
+TEST_F(UT_DriverScanner, setDriverList_empty)
+{
+    QList<DriverInfo *> lst;
+    EXPECT_NO_FATAL_FAILURE(s->setDriverList(lst));
+}

--- a/deepin-devicemanager/tests/src/DriverControl/ut_httpdriverinterface_req.cpp
+++ b/deepin-devicemanager/tests/src/DriverControl/ut_httpdriverinterface_req.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 HttpDriverInterface 的 protected 方法 getRequestBoard/Printer/Camera(桩 getRequestJson)
+// + checkDriverInfo(桩 packageInstall 避免 apt)。-fno-access-control 下可访问 protected。
+
+#include "HttpDriverInterface.h"
+#include "MacroDefinition.h"
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <QString>
+#include <QList>
+
+#include <gtest/gtest.h>
+
+// 桩 getRequestJson(protected 成员,首参 this):直接返回 URL,避免真实网络
+static QString ut_req_getJson(HttpDriverInterface * /*self*/, QString strUrl)
+{
+    return strUrl;
+}
+
+// 桩 packageInstall(成员,首参 this):避免 apt 子进程
+static int ut_req_packageInstall(HttpDriverInterface * /*self*/, const QString & /*a*/, const QString & /*b*/)
+{
+    return 2;   // 已安装最新
+}
+
+class UT_HttpDriverInterfaceReq : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        h = HttpDriverInterface::getInstance();
+    }
+    HttpDriverInterface *h = nullptr;
+};
+
+TEST_F(UT_HttpDriverInterfaceReq, getRequestBoard)
+{
+    Stub stub;
+    stub.set(ADDR(HttpDriverInterface, getRequestJson), ut_req_getJson);
+    EXPECT_NO_FATAL_FAILURE(h->getRequestBoard("Intel", "GMA", 3, 1));
+    EXPECT_NO_FATAL_FAILURE(h->getRequestBoard());
+}
+
+TEST_F(UT_HttpDriverInterfaceReq, getRequestPrinter)
+{
+    Stub stub;
+    stub.set(ADDR(HttpDriverInterface, getRequestJson), ut_req_getJson);
+    EXPECT_NO_FATAL_FAILURE(h->getRequestPrinter("Hewlett-Packard", "LaserJet"));
+    EXPECT_NO_FATAL_FAILURE(h->getRequestPrinter());
+}
+
+TEST_F(UT_HttpDriverInterfaceReq, getRequestCamera)
+{
+    Stub stub;
+    stub.set(ADDR(HttpDriverInterface, getRequestJson), ut_req_getJson);
+    EXPECT_NO_FATAL_FAILURE(h->getRequestCamera("Logitech C920"));
+    EXPECT_NO_FATAL_FAILURE(h->getRequestCamera());
+}
+
+TEST_F(UT_HttpDriverInterfaceReq, checkDriverInfo_emptyJson)
+{
+    DriverInfo di;
+    di.m_Type = DR_Gpu;
+    EXPECT_NO_FATAL_FAILURE(h->checkDriverInfo("", &di));
+}
+
+TEST_F(UT_HttpDriverInterfaceReq, checkDriverInfo_validList)
+{
+    Stub stub;
+    stub.set(ADDR(HttpDriverInterface, packageInstall), ut_req_packageInstall);
+    DriverInfo di;
+    di.m_Type = DR_Gpu;
+    QString json = R"({"msg":"ok","data":{"list":[)"
+                   R"({"packages":"gpu-driver","deb_version":"1.0","level":3,"size":1024}]}})";
+    EXPECT_NO_FATAL_FAILURE(h->checkDriverInfo(json, &di));
+}
+
+TEST_F(UT_HttpDriverInterfaceReq, checkDriverInfo_badJson)
+{
+    DriverInfo di;
+    di.m_Type = DR_Gpu;
+    EXPECT_NO_FATAL_FAILURE(h->checkDriverInfo("{invalid json", &di));
+}
+
+// getRequest: 桩 getRequestBoard(返回非 error)+packageInstall,覆盖主体分发逻辑
+static QString ut_req_getReqBoard(HttpDriverInterface * /*self*/, const QString & /*a*/, const QString & /*b*/, int /*c*/, int /*d*/)
+{
+    return "";
+}
+
+TEST_F(UT_HttpDriverInterfaceReq, getRequest_gpu)
+{
+    Stub stub;
+    stub.set(ADDR(HttpDriverInterface, getRequestBoard), ut_req_getReqBoard);
+    stub.set(ADDR(HttpDriverInterface, packageInstall), ut_req_packageInstall);
+    DriverInfo di;
+    di.m_Type = DR_Gpu;
+    EXPECT_NO_FATAL_FAILURE(h->getRequest(&di));
+}
+
+TEST_F(UT_HttpDriverInterfaceReq, getRequest_nullType)
+{
+    Stub stub;
+    stub.set(ADDR(HttpDriverInterface, getRequestBoard), ut_req_getReqBoard);
+    DriverInfo di;
+    di.m_Type = DR_Null;
+    EXPECT_NO_FATAL_FAILURE(h->getRequest(&di));
+}

--- a/deepin-devicemanager/tests/src/EnableControl/ut_dbusenableinterface.cpp
+++ b/deepin-devicemanager/tests/src/EnableControl/ut_dbusenableinterface.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DBusEnableInterface 各业务方法。测试环境 DBus isValid=false,走失败/else 分支。
+
+#include "DBusEnableInterface.h"
+#include "ut_Head.h"
+
+#include <QString>
+
+#include <gtest/gtest.h>
+
+class UT_DBusEnableInterface : public UT_HEAD
+{
+};
+
+TEST_F(UT_DBusEnableInterface, getRemoveInfo)
+{
+    QString info;
+    EXPECT_NO_FATAL_FAILURE(DBusEnableInterface::getInstance()->getRemoveInfo(info));
+}
+
+TEST_F(UT_DBusEnableInterface, getAuthorizedInfo)
+{
+    QString lst;
+    EXPECT_NO_FATAL_FAILURE(DBusEnableInterface::getInstance()->getAuthorizedInfo(lst));
+}
+
+TEST_F(UT_DBusEnableInterface, isDeviceEnabled)
+{
+    EXPECT_NO_FATAL_FAILURE(DBusEnableInterface::getInstance()->isDeviceEnabled("unique_id"));
+}
+
+TEST_F(UT_DBusEnableInterface, enable)
+{
+    EXPECT_NO_FATAL_FAILURE(
+        DBusEnableInterface::getInstance()->enable("mouse", "name", "/sys/path", "value", true));
+}
+
+TEST_F(UT_DBusEnableInterface, enablePrinter)
+{
+    EXPECT_NO_FATAL_FAILURE(
+        DBusEnableInterface::getInstance()->enablePrinter("printer", "name", "/sys/path", false));
+}
+
+TEST_F(UT_DBusEnableInterface, enableKeyboard)
+{
+    EXPECT_NO_FATAL_FAILURE(DBusEnableInterface::getInstance()->enableKeyboard(
+        "0x1234", "0x5678", "keyboard", "name", "/sys/path", "value", true, "drv"));
+}

--- a/deepin-devicemanager/tests/src/GenerateDevice/ut_cmdtool_oem.cpp
+++ b/deepin-devicemanager/tests/src/GenerateDevice/ut_cmdtool_oem.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 CmdTool::loadOemTomlFileName(纯逻辑构造文件名) + parseOemTomlInfo(文件不存在返回 false)。
+
+#include "CmdTool.h"
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <QMap>
+#include <QString>
+#include <QFile>
+#include <QIODevice>
+#include <QByteArray>
+
+#include <gtest/gtest.h>
+
+class UT_CmdToolOem : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        tool = new CmdTool;
+    }
+    void TearDown() override
+    {
+        delete tool;
+    }
+    CmdTool *tool = nullptr;
+};
+
+TEST_F(UT_CmdToolOem, loadOemTomlFileName_normal)
+{
+    QMap<QString, QString> m;
+    m["Manufacturer"] = "Intel";
+    m["Product Name"] = "X1 Carbon";
+    m["Version"] = "1.0";
+    QString r = tool->loadOemTomlFileName(m);
+    EXPECT_TRUE(r.startsWith("oeminfo_"));
+    EXPECT_TRUE(r.endsWith(".toml"));
+}
+
+TEST_F(UT_CmdToolOem, loadOemTomlFileName_emptyMap)
+{
+    EXPECT_TRUE(tool->loadOemTomlFileName(QMap<QString, QString>()).isEmpty());
+}
+
+TEST_F(UT_CmdToolOem, loadOemTomlFileName_naValues)
+{
+    QMap<QString, QString> m;
+    m["Manufacturer"] = "N/A";
+    m["Product Name"] = "N/A";
+    m["Version"] = "N/A";
+    EXPECT_NO_FATAL_FAILURE(tool->loadOemTomlFileName(m));
+}
+
+TEST_F(UT_CmdToolOem, loadOemTomlFileName_missingKeys)
+{
+    QMap<QString, QString> m;
+    m["Manufacturer"] = "Intel";   // 缺 Product Name/Version
+    EXPECT_TRUE(tool->loadOemTomlFileName(m).isEmpty());
+}
+
+TEST_F(UT_CmdToolOem, parseOemTomlInfo_emptyFilename)
+{
+    EXPECT_FALSE(tool->parseOemTomlInfo(""));
+}
+
+TEST_F(UT_CmdToolOem, parseOemTomlInfo_notExist)
+{
+    // 测试环境无 /etc/deepin/hardware/<file>,文件不存在返回 false
+    EXPECT_FALSE(tool->parseOemTomlInfo("nonexistent_oem.toml"));
+}
+
+// parseOemTomlInfo 解析分支需桩 QFile/QIODevice,但虚函数 vtable 桩会破坏 QFile
+// 内部状态导致 SEGV,故解析分支暂不覆盖(保留文件不存在路径)。

--- a/deepin-devicemanager/tests/src/GenerateDevice/ut_devicegenerator_extra.cpp
+++ b/deepin-devicemanager/tests/src/GenerateDevice/ut_devicegenerator_extra.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DeviceGenerator 未测的纯逻辑方法 pciPath/uniqueID + 桩 cmdInfo 的 getMouse/othersInfoFromLshw。
+
+#include "DeviceGenerator.h"
+#include "DeviceManager.h"
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <QMap>
+#include <QString>
+#include <QList>
+
+#include <gtest/gtest.h>
+
+static QList<QMap<QString, QString> > ut_dge_lst;
+static const QList<QMap<QString, QString> > &ut_dge_cmdInfo()
+{
+    return ut_dge_lst;
+}
+
+class UT_DeviceGeneratorExtra : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        dg = new DeviceGenerator;
+    }
+    void TearDown() override
+    {
+        delete dg;
+    }
+    DeviceGenerator *dg = nullptr;
+};
+
+// pciPath: 5 分支
+TEST_F(UT_DeviceGeneratorExtra, pciPath)
+{
+    QMap<QString, QString> m1;
+    m1["path"] = "/devices/pci0000:00";
+    EXPECT_EQ(dg->pciPath(m1), QString("/devices/pci0000:00"));
+
+    QMap<QString, QString> m2;
+    m2["SysFS Device Link"] = "/sys/link";
+    EXPECT_EQ(dg->pciPath(m2), QString("/sys/link"));
+
+    QMap<QString, QString> m3;
+    m3["SysFS ID"] = "/class/net/eth0";
+    EXPECT_EQ(dg->pciPath(m3), QString("/class/net/eth0"));
+
+    QMap<QString, QString> m4;
+    m4["Device Files"] = "/dev/platform-foo";
+    EXPECT_EQ(dg->pciPath(m4), QString("platform"));
+
+    QMap<QString, QString> m5;
+    EXPECT_EQ(dg->pciPath(m5), QString(""));
+}
+
+// uniqueID: 5 分支
+TEST_F(UT_DeviceGeneratorExtra, uniqueID)
+{
+    QMap<QString, QString> m1;
+    m1["unique_id"] = "uid123";
+    EXPECT_EQ(dg->uniqueID(m1), QString("uid123"));
+
+    QMap<QString, QString> m2;
+    m2["Unique ID"] = "UID456";
+    EXPECT_EQ(dg->uniqueID(m2), QString("UID456"));
+
+    QMap<QString, QString> m3;
+    m3["Permanent HW Address"] = "aa:bb:cc:dd";
+    EXPECT_EQ(dg->uniqueID(m3), QString("aa:bb:cc:dd"));
+
+    QMap<QString, QString> m4;
+    m4["Serial ID"] = "SER789";
+    EXPECT_EQ(dg->uniqueID(m4), QString("SER789"));
+
+    QMap<QString, QString> m5;
+    EXPECT_EQ(dg->uniqueID(m5), QString(""));
+}
+
+// getMouseInfoFromLshw: 桩 cmdInfo(空)
+TEST_F(UT_DeviceGeneratorExtra, getMouseInfoFromLshw)
+{
+    Stub stub;
+    stub.set(ADDR(DeviceManager, cmdInfo), ut_dge_cmdInfo);
+    EXPECT_NO_FATAL_FAILURE(dg->getMouseInfoFromLshw());
+}
+
+// getOthersInfoFromLshw: 桩 cmdInfo(空)
+TEST_F(UT_DeviceGeneratorExtra, getOthersInfoFromLshw)
+{
+    Stub stub;
+    stub.set(ADDR(DeviceManager, cmdInfo), ut_dge_cmdInfo);
+    EXPECT_NO_FATAL_FAILURE(dg->getOthersInfoFromLshw());
+}
+
+// generatorInfoFromToml: 桩 tomlDeviceSet
+static void ut_dge_tomlDeviceSet(DeviceManager * /*self*/, DeviceType /*t*/)
+{
+    return;
+}
+TEST_F(UT_DeviceGeneratorExtra, generatorInfoFromToml)
+{
+    Stub stub;
+    stub.set(ADDR(DeviceManager, tomlDeviceSet), ut_dge_tomlDeviceSet);
+    EXPECT_NO_FATAL_FAILURE(dg->generatorInfoFromToml(DT_Others));
+}

--- a/deepin-devicemanager/tests/src/GenerateDevice/ut_hwgenerator_gpu.cpp
+++ b/deepin-devicemanager/tests/src/GenerateDevice/ut_hwgenerator_gpu.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 HWGenerator::generatorGpuDevice 的 QProcess 解析分支(桩 QProcess,使 exitCode!=127/126 进入解析)。
+
+#include "ut_Head.h"
+#include "stub.h"
+#include "DeviceManager.h"
+
+#include <QProcess>
+#include <QByteArray>
+
+#include <gtest/gtest.h>
+
+#define private public
+#define protected public
+#include "HWGenerator.h"
+
+static void ut_hwg_start(QProcess * /*self*/, const QString & /*p*/, const QStringList & /*a*/, QIODevice::OpenMode /*m*/)
+{
+    return;
+}
+static bool ut_hwg_wait(QProcess * /*self*/, int /*msecs*/)
+{
+    return true;
+}
+static int ut_hwg_exitCode(QProcess * /*self*/)
+{
+    return 0;   // 非 127/126,进入解析
+}
+static QByteArray ut_hwg_read(QProcess * /*self*/)
+{
+    return QByteArray("Intel UHD Graphics\n");
+}
+
+class UT_HWGeneratorGpu : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        DeviceManager::instance()->clear();
+        m_gen = new HWGenerator;
+    }
+    void TearDown() override
+    {
+        delete m_gen;
+        DeviceManager::instance()->clear();
+    }
+    HWGenerator *m_gen = nullptr;
+};
+
+TEST_F(UT_HWGeneratorGpu, generatorGpuDevice_qprocessStubbed)
+{
+    Stub stub;
+    stub.set(((void (QProcess::*)(const QString &, const QStringList &, QIODevice::OpenMode))ADDR(QProcess, start)),
+             ut_hwg_start);
+    stub.set(((bool (QProcess::*)(int))ADDR(QProcess, waitForFinished)), ut_hwg_wait);
+    stub.set(((int (QProcess::*)())ADDR(QProcess, exitCode)), ut_hwg_exitCode);
+    stub.set(ADDR(QProcess, readAllStandardOutput), ut_hwg_read);
+    EXPECT_NO_FATAL_FAILURE(m_gen->generatorGpuDevice());
+}

--- a/deepin-devicemanager/tests/src/Page/ut_mainwindow_extra.cpp
+++ b/deepin-devicemanager/tests/src/Page/ut_mainwindow_extra.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 MainWindow 未测方法: refreshBatteryStatus/showDisplayShortcutsHelpDialog/swichStackWidget。
+// SetUp 桩 refreshDataBase(构造会触发 DBus/DeviceManager),与现有 ut_mainwindow 范式一致。
+
+#include <gtest/gtest.h>
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#define private public
+#include "MainWindow.h"
+
+static void ut_mw_refreshDataBase()
+{
+    return;
+}
+
+class UT_MainWindowExtra : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        stub.set(ADDR(MainWindow, refreshDataBase), ut_mw_refreshDataBase);
+        mw = new MainWindow;
+    }
+    void TearDown() override
+    {
+    }
+    MainWindow *mw = nullptr;
+    Stub stub;
+};
+
+// refreshBatteryStatus 内部 QProcess::waitForFinished(-1) 会无限阻塞,暂跳过
+TEST_F(UT_MainWindowExtra, swichStackWidget)
+{
+    EXPECT_NO_FATAL_FAILURE(mw->swichStackWidget());
+}
+
+TEST_F(UT_MainWindowExtra, windowMaximizing)
+{
+    EXPECT_NO_FATAL_FAILURE(mw->windowMaximizing());
+}
+
+TEST_F(UT_MainWindowExtra, showDisplayShortcutsHelpDialog)
+{
+    EXPECT_NO_FATAL_FAILURE(mw->showDisplayShortcutsHelpDialog());
+}

--- a/deepin-devicemanager/tests/src/Page/ut_pagedrivercontrol.cpp
+++ b/deepin-devicemanager/tests/src/Page/ut_pagedrivercontrol.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 UnionTech Software Technology Co.,Ltd
+// Copyright (C) 2019-2026 ~ 2020 UnionTech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -30,8 +30,8 @@ public:
         delete m_PageDriverControlUninstall;
     }
 
-    PageDriverControl *m_PageDriverControlInstall;
-    PageDriverControl *m_PageDriverControlUninstall;
+    PageDriverControl *m_PageDriverControlInstall = nullptr;
+    PageDriverControl *m_PageDriverControlUninstall = nullptr;
 };
 
 TEST_F(UT_PageDriverControl, UT_PageDriverControl_isRunning)

--- a/deepin-devicemanager/tests/src/Page/ut_pagedrivermanager_misc.cpp
+++ b/deepin-devicemanager/tests/src/Page/ut_pagedrivermanager_misc.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 PageDriverManager 的 getDownloadInfo(纯算术格式化) + testDevices(构造测试 DriverInfo)。
+
+#include <gtest/gtest.h>
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#define private public
+#include "PageDriverManager.h"
+
+static void ut_pdmm_installNext()
+{
+    return;
+}
+static void ut_pdmm_backupNext()
+{
+    return;
+}
+
+class UT_PageDriverManagerMisc : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        stub.set(ADDR(PageDriverManager, installNextDriver), ut_pdmm_installNext);
+        stub.set(ADDR(PageDriverManager, backupNextDriver), ut_pdmm_backupNext);
+        m = new PageDriverManager;
+    }
+    void TearDown() override
+    {
+    }
+    PageDriverManager *m = nullptr;
+    Stub stub;
+};
+
+TEST_F(UT_PageDriverManagerMisc, getDownloadInfo)
+{
+    QString speed, size;
+    EXPECT_NO_FATAL_FAILURE(m->getDownloadInfo(50, 1000000, speed, size));
+    EXPECT_NO_FATAL_FAILURE(m->getDownloadInfo(100, 0, speed, size));
+}
+
+TEST_F(UT_PageDriverManagerMisc, testDevices)
+{
+    EXPECT_NO_FATAL_FAILURE(m->testDevices());
+}

--- a/deepin-devicemanager/tests/src/Page/ut_pagedrivermanager_slot.cpp
+++ b/deepin-devicemanager/tests/src/Page/ut_pagedrivermanager_slot.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 PageDriverManager 未测的 slot 方法 + 状态 getter。
+// SetUp 桩 installNextDriver/backupNextDriver(避免触发真实安装/备份线程),与现有 ut 范式一致。
+
+#include <gtest/gtest.h>
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#define private public
+#include "PageDriverManager.h"
+
+static void ut_pdm_installNextDriver()
+{
+    return;
+}
+static void ut_pdm_backupNextDriver()
+{
+    return;
+}
+
+class UT_PageDriverManagerSlot : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        stub.set(ADDR(PageDriverManager, installNextDriver), ut_pdm_installNextDriver);
+        stub.set(ADDR(PageDriverManager, backupNextDriver), ut_pdm_backupNextDriver);
+        m = new PageDriverManager;
+    }
+    void TearDown() override
+    {
+    }
+    PageDriverManager *m = nullptr;
+    Stub stub;
+};
+
+TEST_F(UT_PageDriverManagerSlot, slotListViewWidgetItemClicked)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotListViewWidgetItemClicked("driverinstall"));
+    EXPECT_NO_FATAL_FAILURE(m->slotListViewWidgetItemClicked("driverbackup"));
+    EXPECT_NO_FATAL_FAILURE(m->slotListViewWidgetItemClicked("driversoftware"));
+    EXPECT_NO_FATAL_FAILURE(m->slotListViewWidgetItemClicked("unknown"));
+}
+
+TEST_F(UT_PageDriverManagerSlot, slotInstallAllDrivers)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotInstallAllDrivers());
+}
+
+TEST_F(UT_PageDriverManagerSlot, slotBackupAllDrivers)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotBackupAllDrivers());
+}
+
+TEST_F(UT_PageDriverManagerSlot, slotUndoInstall)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotUndoInstall());
+}
+
+TEST_F(UT_PageDriverManagerSlot, slotUndoBackup)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotUndoBackup());
+}
+
+TEST_F(UT_PageDriverManagerSlot, slotBackupProgressChanged)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotBackupProgressChanged(50));
+}
+
+TEST_F(UT_PageDriverManagerSlot, state_getters)
+{
+    EXPECT_NO_FATAL_FAILURE(m->isFirstScan());
+    EXPECT_NO_FATAL_FAILURE(m->isInstalling());
+    EXPECT_NO_FATAL_FAILURE(m->isBackingup());
+    EXPECT_NO_FATAL_FAILURE(m->isRestoring());
+    EXPECT_NO_FATAL_FAILURE(m->isScanning());
+}

--- a/deepin-devicemanager/tests/src/Page/ut_pagedrivermanager_slot2.cpp
+++ b/deepin-devicemanager/tests/src/Page/ut_pagedrivermanager_slot2.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 PageDriverManager 剩余 slot(下载/安装/还原/扫描/备份进度与完成回调)。
+
+#include <gtest/gtest.h>
+
+#include "ut_Head.h"
+#include "stub.h"
+#include "MacroDefinition.h"
+
+#define private public
+#include "PageDriverManager.h"
+
+static void ut_pds2_install()
+{
+    return;
+}
+static void ut_pds2_backup()
+{
+    return;
+}
+
+class UT_PageDriverManagerSlot2 : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        stub.set(ADDR(PageDriverManager, installNextDriver), ut_pds2_install);
+        stub.set(ADDR(PageDriverManager, backupNextDriver), ut_pds2_backup);
+        m = new PageDriverManager;
+    }
+    void TearDown() override
+    {
+    }
+    PageDriverManager *m = nullptr;
+    Stub stub;
+};
+
+TEST_F(UT_PageDriverManagerSlot2, slotDownloadProgressChanged)
+{
+    QStringList msg;
+    msg << "50%"
+        << "1MB/s";
+    EXPECT_NO_FATAL_FAILURE(m->slotDownloadProgressChanged(msg));
+}
+
+TEST_F(UT_PageDriverManagerSlot2, slotDownloadFinished)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotDownloadFinished());
+}
+
+TEST_F(UT_PageDriverManagerSlot2, slotInstallProgressChanged)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotInstallProgressChanged(75));
+}
+
+TEST_F(UT_PageDriverManagerSlot2, slotInstallProgressFinished)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotInstallProgressFinished(true, 0));
+    EXPECT_NO_FATAL_FAILURE(m->slotInstallProgressFinished(false, 1));
+}
+
+TEST_F(UT_PageDriverManagerSlot2, slotRestoreProgress)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotRestoreProgress(50, "restoring driver"));
+}
+
+TEST_F(UT_PageDriverManagerSlot2, slotBackupFinished)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotBackupFinished(true));
+    EXPECT_NO_FATAL_FAILURE(m->slotBackupFinished(false));
+}
+
+TEST_F(UT_PageDriverManagerSlot2, slotScanFinished)
+{
+    EXPECT_NO_FATAL_FAILURE(m->slotScanFinished(SR_SUCESS));
+    EXPECT_NO_FATAL_FAILURE(m->slotScanFinished(SR_Failed));
+}

--- a/deepin-devicemanager/tests/src/Page/ut_pagedrivertableview.cpp
+++ b/deepin-devicemanager/tests/src/Page/ut_pagedrivertableview.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 PageDriverTableView 的转发方法(转给内部 DriverTableView)。构造后建表头即可调用。
+
+#include "PageDriverTableView.h"
+#include "MacroDefinition.h"
+#include "ut_Head.h"
+
+#include <QAbstractItemModel>
+#include <QStringList>
+#include <QList>
+
+#include <gtest/gtest.h>
+
+class UT_PageDriverTableView : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        v = new PageDriverTableView;
+        v->initHeaderView(QStringList() << "Cb"
+                                        << "Name"
+                                        << "Status"
+                                        << "Op",
+                          false);
+    }
+    void TearDown() override
+    {
+        delete v;
+    }
+    PageDriverTableView *v = nullptr;
+};
+
+TEST_F(UT_PageDriverTableView, initHeaderView)
+{
+    EXPECT_NE(v->model(), nullptr);
+    EXPECT_GE(v->model()->columnCount(), 1);
+}
+
+TEST_F(UT_PageDriverTableView, appendRowItems_clear)
+{
+    v->appendRowItems(4);
+    v->appendRowItems(4);
+    EXPECT_NO_FATAL_FAILURE(v->clear());
+}
+
+TEST_F(UT_PageDriverTableView, setColumnWidth)
+{
+    EXPECT_NO_FATAL_FAILURE(v->setColumnWidth(0, 100));
+}
+
+TEST_F(UT_PageDriverTableView, setHeaderCbStatus)
+{
+    EXPECT_NO_FATAL_FAILURE(v->setHeaderCbStatus(true));
+    EXPECT_NO_FATAL_FAILURE(v->setHeaderCbStatus(false));
+}
+
+TEST_F(UT_PageDriverTableView, getCheckedDriverIndex)
+{
+    QList<int> idx;
+    EXPECT_NO_FATAL_FAILURE(v->getCheckedDriverIndex(idx));
+}
+
+TEST_F(UT_PageDriverTableView, setItemStatus)
+{
+    EXPECT_NO_FATAL_FAILURE(v->setItemStatus(0, ST_NOT_INSTALL));
+}
+
+TEST_F(UT_PageDriverTableView, setErrorMsg)
+{
+    EXPECT_NO_FATAL_FAILURE(v->setErrorMsg(0, "error msg"));
+}
+
+TEST_F(UT_PageDriverTableView, hasItemDisabled)
+{
+    EXPECT_NO_FATAL_FAILURE(v->hasItemDisabled());
+}
+
+TEST_F(UT_PageDriverTableView, setItemOperationEnable)
+{
+    EXPECT_NO_FATAL_FAILURE(v->setItemOperationEnable(0, true));
+}
+
+TEST_F(UT_PageDriverTableView, removeItemAndWidget)
+{
+    EXPECT_NO_FATAL_FAILURE(v->removeItemAndWidget(0, 0));
+}
+
+TEST_F(UT_PageDriverTableView, model)
+{
+    EXPECT_NE(v->model(), nullptr);
+}

--- a/deepin-devicemanager/tests/src/Page/ut_pagesingleinfo_extra.cpp
+++ b/deepin-devicemanager/tests/src/Page/ut_pagesingleinfo_extra.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 PageSingleInfo 未测的纯逻辑方法(loadDeviceInfo/clearContent/isExpanded/setRowHeight) + slot。
+
+#include "PageSingleInfo.h"
+#include "ut_Head.h"
+
+#include <QString>
+#include <QList>
+#include <QPair>
+
+#include <gtest/gtest.h>
+
+class UT_PageSingleInfoExtra : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        p = new PageSingleInfo;
+    }
+    void TearDown() override
+    {
+        delete p;
+    }
+    PageSingleInfo *p = nullptr;
+};
+
+TEST_F(UT_PageSingleInfoExtra, setLabel_clearContent)
+{
+    EXPECT_NO_FATAL_FAILURE(p->setLabel("Device Type"));
+    EXPECT_NO_FATAL_FAILURE(p->clearContent());
+}
+
+TEST_F(UT_PageSingleInfoExtra, isExpanded_setRowHeight)
+{
+    EXPECT_NO_FATAL_FAILURE(p->isExpanded());
+    EXPECT_NO_FATAL_FAILURE(p->setRowHeight(0, 30));
+    EXPECT_NO_FATAL_FAILURE(p->setRowHeight(1, 40));
+}
+
+TEST_F(UT_PageSingleInfoExtra, loadDeviceInfo)
+{
+    QList<QPair<QString, QString> > lst;
+    lst << qMakePair(QString("Vendor"), QString("Intel"))
+        << qMakePair(QString("Model"), QString("SSD"))
+        << qMakePair(QString("Driver"), QString("nvme"));
+    EXPECT_NO_FATAL_FAILURE(p->loadDeviceInfo(lst));
+}
+
+TEST_F(UT_PageSingleInfoExtra, clearWidgets)
+{
+    EXPECT_NO_FATAL_FAILURE(p->clearWidgets());
+}
+
+// slotActionCopy/Enable/UpdateDriver/RemoveDriver 依赖右键菜单/选中行,空状态崩,暂跳过

--- a/deepin-devicemanager/tests/src/Tool/ut_threadexecxrandr_more.cpp
+++ b/deepin-devicemanager/tests/src/Tool/ut_threadexecxrandr_more.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 ThreadExecXrandr 未测方法: getMonitorInfoFromXrandrVerbose/getGpuInfoFromXrandr。
+// 桩 runCmd(成员方法,首参 this) + 桩 DeviceManager::setMonitorInfo/setGpuInfoFromXrandr 避免污染单例。
+
+#include "ThreadExecXrandr.h"
+#include "DeviceManager.h"
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <QMap>
+#include <QString>
+#include <QList>
+
+#include <gtest/gtest.h>
+
+// 桩 runCmd(成员方法首参 this)
+static QString ut_txr_out = QStringLiteral("normal");
+static void ut_txr_runCmd(ThreadExecXrandr * /*self*/, QString &info, const QString & /*cmd*/)
+{
+    info = ut_txr_out;
+}
+// 桩 DeviceManager 方法(成员首参 this)
+static void ut_txr_setMonitor(DeviceManager * /*self*/, const QString & /*a*/, const QString & /*b*/, const QString & /*c*/, const QString & /*d*/)
+{
+    return;
+}
+static void ut_txr_setGpu(DeviceManager * /*self*/, const QMap<QString, QString> & /*m*/)
+{
+    return;
+}
+static void ut_txr_getResolution(ThreadExecXrandr * /*self*/, QMap<QString, QString> & /*m*/)
+{
+    return;
+}
+
+class UT_ThreadExecXrandrMore : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        t = new ThreadExecXrandr(false, false);
+    }
+    void TearDown() override
+    {
+        delete t;
+    }
+    ThreadExecXrandr *t = nullptr;
+};
+
+TEST_F(UT_ThreadExecXrandrMore, getMonitorInfoFromXrandrVerbose)
+{
+    Stub stub;
+    ut_txr_out = QStringLiteral("DP-1 connected primary 1920x1080+0+0\n");
+    stub.set(ADDR(ThreadExecXrandr, runCmd), ut_txr_runCmd);
+    stub.set(ADDR(DeviceManager, setMonitorInfoFromXrandr), ut_txr_setMonitor);
+    EXPECT_NO_FATAL_FAILURE(t->getMonitorInfoFromXrandrVerbose());
+}
+
+TEST_F(UT_ThreadExecXrandrMore, getGpuInfoFromXrandr)
+{
+    Stub stub;
+    ut_txr_out = QStringLiteral("Screen 0: current 1920 x 1080\n");
+    stub.set(ADDR(ThreadExecXrandr, runCmd), ut_txr_runCmd);
+    stub.set(ADDR(ThreadExecXrandr, getResolutionFromDBus), ut_txr_getResolution);
+    stub.set(ADDR(DeviceManager, setGpuInfoFromXrandr), ut_txr_setGpu);
+    EXPECT_NO_FATAL_FAILURE(t->getGpuInfoFromXrandr());
+}

--- a/deepin-devicemanager/tests/src/Widget/ut_animationlabel.cpp
+++ b/deepin-devicemanager/tests/src/Widget/ut_animationlabel.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 AnimationLabel 的纯逻辑方法(setImageList/setcurrentIcon/currentIcon)。
+
+#include "AnimationLabel.h"
+#include "ut_Head.h"
+
+#include <QStringList>
+
+#include <gtest/gtest.h>
+
+class UT_AnimationLabel : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        l = new AnimationLabel;
+    }
+    void TearDown() override
+    {
+        delete l;
+    }
+    AnimationLabel *l = nullptr;
+};
+
+TEST_F(UT_AnimationLabel, setImageList_setcurrentIcon_normal)
+{
+    l->setImageList(QStringList() << "a"
+                                  << "b"
+                                  << "c");
+    l->setcurrentIcon(1);
+    EXPECT_EQ(l->currentIcon(), 1);
+    l->setcurrentIcon(2);
+    EXPECT_EQ(l->currentIcon(), 2);
+}
+
+TEST_F(UT_AnimationLabel, setcurrentIcon_outOfRange)
+{
+    l->setImageList(QStringList() << "a"
+                                  << "b");
+    l->setcurrentIcon(0);
+    EXPECT_EQ(l->currentIcon(), 0);
+    // 越界:不修改当前 index
+    l->setcurrentIcon(-1);
+    EXPECT_EQ(l->currentIcon(), 0);
+    l->setcurrentIcon(99);
+    EXPECT_EQ(l->currentIcon(), 0);
+}

--- a/deepin-devicemanager/tests/src/Widget/ut_btnlabel.cpp
+++ b/deepin-devicemanager/tests/src/Widget/ut_btnlabel.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 BtnLabel/TipsLabel/TitleLabel 的构造 + setDesc。
+
+#include "BtnLabel.h"
+#include "ut_Head.h"
+
+#include <QString>
+
+#include <gtest/gtest.h>
+
+class UT_BtnLabel : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        b = new BtnLabel;
+    }
+    void TearDown() override
+    {
+        delete b;
+    }
+    BtnLabel *b = nullptr;
+};
+
+TEST_F(UT_BtnLabel, setDesc)
+{
+    EXPECT_NO_FATAL_FAILURE(b->setDesc("description text"));
+    EXPECT_NO_FATAL_FAILURE(b->setDesc(""));
+}
+
+TEST_F(UT_BtnLabel, ctor_tips_title)
+{
+    TipsLabel *t = new TipsLabel;
+    TitleLabel *ttl = new TitleLabel;
+    EXPECT_NE(t, nullptr);
+    EXPECT_NE(ttl, nullptr);
+    delete t;
+    delete ttl;
+}

--- a/deepin-devicemanager/tests/src/Widget/ut_detectedstatuswidget.cpp
+++ b/deepin-devicemanager/tests/src/Widget/ut_detectedstatuswidget.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DetectedStatusWidget 的状态切换 UI 方法(setXxxUI) + refreshUI(7分支) + slot。
+
+#include "DetectedStatusWidget.h"
+#include "MacroDefinition.h"
+#include "ut_Head.h"
+
+#include <QString>
+
+#include <gtest/gtest.h>
+
+class UT_DetectedStatusWidget : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        w = new DetectedStatusWidget;
+    }
+    void TearDown() override
+    {
+        delete w;
+    }
+    DetectedStatusWidget *w = nullptr;
+};
+
+TEST_F(UT_DetectedStatusWidget, setDetectFinishUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setDetectFinishUI("6", "Lenovo M90", true));
+    EXPECT_NO_FATAL_FAILURE(w->setDetectFinishUI("0", "Lenovo M90", false));
+}
+
+TEST_F(UT_DetectedStatusWidget, setDownloadUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setDownloadUI(DR_Gpu, "5MB/s", "10MB", "100MB", 50));
+}
+
+TEST_F(UT_DetectedStatusWidget, setInstallUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setInstallUI(DR_Sound, "Audio driver", 60));
+}
+
+TEST_F(UT_DetectedStatusWidget, setInstallSuccessUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setInstallSuccessUI("5", "1"));   // failed>0
+    EXPECT_NO_FATAL_FAILURE(w->setInstallSuccessUI("6", "0"));   // failed<=0
+}
+
+TEST_F(UT_DetectedStatusWidget, setInstallFailedUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setInstallFailedUI());
+}
+
+TEST_F(UT_DetectedStatusWidget, setNetworkErrorUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setNetworkErrorUI("5MB/s", 50));
+}
+
+TEST_F(UT_DetectedStatusWidget, setNoUpdateDriverUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setNoUpdateDriverUI("Lenovo M90"));
+}
+
+TEST_F(UT_DetectedStatusWidget, refreshUI_allBranches)
+{
+    Status types[] = {ST_NOT_INSTALL, ST_DOWNLOADING, ST_INSTALL, ST_SUCESS,
+                      ST_FAILED, ST_NetWorkErr, ST_DRIVER_IS_NEW};
+    for (Status s : types) {
+        EXPECT_NO_FATAL_FAILURE(w->refreshUI(s));
+    }
+}
+
+TEST_F(UT_DetectedStatusWidget, setInstallBackupBtnEnable)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setInstallBtnEnable(true));
+    EXPECT_NO_FATAL_FAILURE(w->setBackupBtnEnable(false));
+    EXPECT_NO_FATAL_FAILURE(w->setReDetectEnable(true));
+}
+
+TEST_F(UT_DetectedStatusWidget, backupUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setNoBackupDriverUI(0, 0));
+    EXPECT_NO_FATAL_FAILURE(w->setBackableDriverUI(5, 2));    // backedup>0
+    EXPECT_NO_FATAL_FAILURE(w->setBackableDriverUI(0, 0));    // backedup<=0
+    EXPECT_NO_FATAL_FAILURE(w->setBackingUpDriverUI("driver", 100, 50));
+    EXPECT_NO_FATAL_FAILURE(w->setBackupSuccessUI(5, 1));     // success>0
+    EXPECT_NO_FATAL_FAILURE(w->setBackupSuccessUI(0, 1));     // success<=0
+}
+
+TEST_F(UT_DetectedStatusWidget, restoreUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setRestoreDriverUI(3));
+    EXPECT_NO_FATAL_FAILURE(w->setRestoringUI(50, "driver"));
+}
+
+TEST_F(UT_DetectedStatusWidget, slots_emitSignals)
+{
+    EXPECT_NO_FATAL_FAILURE(w->slotInstall());
+    EXPECT_NO_FATAL_FAILURE(w->slotBackup());
+    EXPECT_NO_FATAL_FAILURE(w->slotReDetectSlot());
+    EXPECT_NO_FATAL_FAILURE(w->slotCancel());
+    EXPECT_NO_FATAL_FAILURE(w->onUpdateTheme());
+}

--- a/deepin-devicemanager/tests/src/Widget/ut_driverlistviewdelegate.cpp
+++ b/deepin-devicemanager/tests/src/Widget/ut_driverlistviewdelegate.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DriverListViewDelegate::sizeHint(固定行高)。paint 依赖 DStyle,offscreen 下跳过。
+
+#include "DriverListViewDelegate.h"
+#include "ut_Head.h"
+
+#include <QStyleOptionViewItem>
+#include <QModelIndex>
+
+#include <gtest/gtest.h>
+
+class UT_DriverListViewDelegate : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        d = new DriverListViewDelegate;
+    }
+    void TearDown() override
+    {
+        delete d;
+    }
+    DriverListViewDelegate *d = nullptr;
+};
+
+TEST_F(UT_DriverListViewDelegate, sizeHint)
+{
+    QStyleOptionViewItem opt;
+    QModelIndex idx;
+    auto sz = d->sizeHint(opt, idx);
+    EXPECT_GT(sz.height(), 0);
+}

--- a/deepin-devicemanager/tests/src/Widget/ut_driverscanwidget.cpp
+++ b/deepin-devicemanager/tests/src/Widget/ut_driverscanwidget.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 DriverScanWidget 的状态切换 UI 方法(setScanningUI/setScanFailedUI 等)。
+
+#include "DriverScanWidget.h"
+#include "ut_Head.h"
+
+#include <QString>
+
+#include <gtest/gtest.h>
+
+class UT_DriverScanWidget : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        w = new DriverScanWidget;
+    }
+    void TearDown() override
+    {
+        delete w;
+    }
+    DriverScanWidget *w = nullptr;
+};
+
+TEST_F(UT_DriverScanWidget, setScanningUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setScanningUI("scanning device", 50));
+}
+
+TEST_F(UT_DriverScanWidget, setScanFailedUI)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setScanFailedUI());
+}
+
+TEST_F(UT_DriverScanWidget, setNetworkErr)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setNetworkErr());
+}
+
+TEST_F(UT_DriverScanWidget, setProgressFinish)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setProgressFinish());
+}
+
+TEST_F(UT_DriverScanWidget, refreshProgress)
+{
+    EXPECT_NO_FATAL_FAILURE(w->refreshProgress("info", 10));
+    EXPECT_NO_FATAL_FAILURE(w->refreshProgress("more", 20));
+}
+
+TEST_F(UT_DriverScanWidget, slotReDetected)
+{
+    EXPECT_NO_FATAL_FAILURE(w->slotReDetected());
+}

--- a/deepin-devicemanager/tests/src/Widget/ut_drivertableview.cpp
+++ b/deepin-devicemanager/tests/src/Widget/ut_drivertableview.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 drivertableview.cpp 的 DriverTableView(表格数据方法) + DriverItemDelegate(sizeHint)。
+// DriverHeaderView 构造触发 style 崩溃(offscreen),暂跳过。
+
+#include "drivertableview.h"
+#include "MacroDefinition.h"
+#include "ut_Head.h"
+
+#include <QStringList>
+#include <QList>
+#include <QStyleOptionViewItem>
+#include <QModelIndex>
+
+#include <gtest/gtest.h>
+
+class UT_DriverTableView : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        tv = new DriverTableView;
+        tv->initHeaderView(QStringList() << "Cb"
+                                         << "Name"
+                                         << "Status"
+                                         << "Op",
+                           false);
+        del = new DriverItemDelegate(tv);
+    }
+    void TearDown() override
+    {
+        delete del;
+        delete tv;
+    }
+    DriverTableView *tv = nullptr;
+    DriverItemDelegate *del = nullptr;
+};
+
+TEST_F(UT_DriverTableView, appendRowItems_clear)
+{
+    tv->appendRowItems(4);
+    tv->appendRowItems(4);
+    EXPECT_NO_FATAL_FAILURE(tv->clear());
+}
+
+TEST_F(UT_DriverTableView, resizeColumn)
+{
+    EXPECT_NO_FATAL_FAILURE(tv->resizeColumn(0));
+}
+
+TEST_F(UT_DriverTableView, setItemStatus)
+{
+    EXPECT_NO_FATAL_FAILURE(tv->setItemStatus(0, ST_NOT_INSTALL));
+    EXPECT_NO_FATAL_FAILURE(tv->setItemStatus(0, ST_INSTALL));
+}
+
+TEST_F(UT_DriverTableView, setErrorMsg)
+{
+    EXPECT_NO_FATAL_FAILURE(tv->setErrorMsg(0, "some error"));
+}
+
+TEST_F(UT_DriverTableView, hasItemDisabled)
+{
+    EXPECT_NO_FATAL_FAILURE(tv->hasItemDisabled());
+}
+
+TEST_F(UT_DriverTableView, getCheckedDriverIndex)
+{
+    QList<int> idx;
+    EXPECT_NO_FATAL_FAILURE(tv->getCheckedDriverIndex(idx));
+}
+
+TEST_F(UT_DriverTableView, setItemOperationEnable)
+{
+    EXPECT_NO_FATAL_FAILURE(tv->setItemOperationEnable(0, true));
+}
+
+TEST_F(UT_DriverTableView, removeItemAndWidget)
+{
+    EXPECT_NO_FATAL_FAILURE(tv->removeItemAndWidget(0, 0));
+}
+
+TEST_F(UT_DriverTableView, delegate_sizeHint)
+{
+    QStyleOptionViewItem opt;
+    QModelIndex idx;
+    auto sz = del->sizeHint(opt, idx);
+    EXPECT_GT(sz.height(), 0);
+}

--- a/deepin-devicemanager/tests/src/Widget/ut_tablewidget_extra.cpp
+++ b/deepin-devicemanager/tests/src/Widget/ut_tablewidget_extra.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 TableWidget 的数据方法 + 未测 slot(slotActionUpdateDriver/RemoveDriver/Wakeup)。
+
+#include "TableWidget.h"
+#include "ut_Head.h"
+
+#include <QStringList>
+#include <DStandardItem>
+
+#include <gtest/gtest.h>
+
+class UT_TableWidgetExtra : public UT_HEAD
+{
+public:
+    void SetUp() override
+    {
+        t = new TableWidget;
+        t->setHeaderLabels(QStringList() << "A"
+                                         << "B"
+                                         << "C");
+    }
+    void TearDown() override
+    {
+        delete t;
+    }
+    TableWidget *t = nullptr;
+};
+
+TEST_F(UT_TableWidgetExtra, setRowNum_setItem_clear)
+{
+    t->setRowNum(3);
+    DStandardItem *item = new DStandardItem("cell");
+    EXPECT_NO_FATAL_FAILURE(t->setItem(0, 0, item));
+    EXPECT_NO_FATAL_FAILURE(t->clear());
+}
+
+TEST_F(UT_TableWidgetExtra, setColumnAverage)
+{
+    EXPECT_NO_FATAL_FAILURE(t->setColumnAverage());
+}
+
+TEST_F(UT_TableWidgetExtra, updateCurItemEnable)
+{
+    t->setRowNum(2);
+    EXPECT_NO_FATAL_FAILURE(t->updateCurItemEnable(0, true));
+    EXPECT_NO_FATAL_FAILURE(t->updateCurItemEnable(0, false));
+}
+
+TEST_F(UT_TableWidgetExtra, slotActionRefresh)
+{
+    EXPECT_NO_FATAL_FAILURE(t->slotActionRefresh());
+}
+
+TEST_F(UT_TableWidgetExtra, slotActionExport)
+{
+    EXPECT_NO_FATAL_FAILURE(t->slotActionExport());
+}
+
+TEST_F(UT_TableWidgetExtra, slotActionEnable)
+{
+    EXPECT_NO_FATAL_FAILURE(t->slotActionEnable());
+}
+
+TEST_F(UT_TableWidgetExtra, slotActionUpdateDriver)
+{
+    EXPECT_NO_FATAL_FAILURE(t->slotActionUpdateDriver());
+}
+
+TEST_F(UT_TableWidgetExtra, slotActionRemoveDriver)
+{
+    EXPECT_NO_FATAL_FAILURE(t->slotActionRemoveDriver());
+}
+
+TEST_F(UT_TableWidgetExtra, slotWakeupMachine)
+{
+    EXPECT_NO_FATAL_FAILURE(t->slotWakeupMachine());
+}

--- a/deepin-devicemanager/tests/src/test_main.cpp
+++ b/deepin-devicemanager/tests/src/test_main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -6,11 +6,31 @@
 #include <gtest/gtest.h>
 #include <QApplication>
 #include <DApplication>
+#include <QDBusInterface>
+#include <QDBusMessage>
+#include <QDBusPendingCall>
+#include <QVariant>
+#include "stub.h"
 #if defined(CMAKE_SAFETYTEST_ARG_ON)
 #include <sanitizer/asan_interface.h>
 #endif
 
 DCORE_USE_NAMESPACE
+
+// 全局桩:QDBusInterface::call/asyncCall 即时返回,避免真实 DBus 服务运行时
+// (setTimeout 较长)的同步/异步调用阻塞测试。桩对象生命周期与进程相同。
+static QDBusMessage ut_dbus_call(const QString &,
+                                 const QVariant &, const QVariant &, const QVariant &, const QVariant &,
+                                 const QVariant &, const QVariant &, const QVariant &, const QVariant &)
+{
+    return QDBusMessage().createReply(QVariant(true));
+}
+static QDBusPendingCall ut_dbus_asyncCall(const QString &,
+                                          const QVariant &, const QVariant &, const QVariant &, const QVariant &,
+                                          const QVariant &, const QVariant &, const QVariant &, const QVariant &)
+{
+    return QDBusPendingCall::fromCompletedCall(QDBusMessage().createReply(QVariant(true)));
+}
 
 //  gtest的入口函数
 int main(int argc, char **argv)
@@ -18,6 +38,18 @@ int main(int argc, char **argv)
 
     qputenv("QT_QPA_PLATFORM", "offscreen");
     QApplication a(argc, argv);
+
+    // 持久桩(进程生命周期内有效),让所有 DBus call/asyncCall 即时返回
+    Stub *stub = new Stub;
+    QDBusMessage (QDBusInterface::*pc)(const QString &, const QVariant &, const QVariant &,
+        const QVariant &, const QVariant &, const QVariant &, const QVariant &,
+        const QVariant &, const QVariant &) = &QDBusInterface::call;
+    stub->set(pc, ut_dbus_call);
+    QDBusPendingCall (QDBusInterface::*pa)(const QString &, const QVariant &, const QVariant &,
+        const QVariant &, const QVariant &, const QVariant &, const QVariant &,
+        const QVariant &, const QVariant &) = &QDBusInterface::asyncCall;
+    stub->set(pa, ut_dbus_asyncCall);
+
     ::testing::InitGoogleTest(&argc, argv);
     auto c = RUN_ALL_TESTS();
 

--- a/deepin-devicemanager/tests/src/ut_commontools_more.cpp
+++ b/deepin-devicemanager/tests/src/ut_commontools_more.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖 commontools 未测方法: parseEDID(桩 QProcess) + preGenerateGpuInfo(冒烟)。
+
+#include "commontools.h"
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <QString>
+#include <QStringList>
+#include <QProcess>
+#include <QByteArray>
+
+#include <gtest/gtest.h>
+
+class UT_CommonToolsMore : public UT_HEAD
+{
+};
+
+// QProcess 桩(成员方法,首参 this)
+static void ut_cm_start(QProcess * /*self*/, const QString & /*p*/, const QStringList & /*a*/, QIODevice::OpenMode /*m*/)
+{
+    return;
+}
+static bool ut_cm_wait(QProcess * /*self*/, int /*msecs*/)
+{
+    return true;
+}
+static QByteArray ut_cm_readEmpty(QProcess * /*self*/)
+{
+    return QByteArray();
+}
+
+// parseEDID: 空 list 不触发 QProcess
+TEST_F(UT_CommonToolsMore, parseEDID_emptyList)
+{
+    EXPECT_NO_FATAL_FAILURE(CommonTools::parseEDID(QStringList(), "DP-1", false));
+    EXPECT_NO_FATAL_FAILURE(CommonTools::parseEDID(QStringList(), "DP-1", true));
+}
+
+// parseEDID: 有 list + 桩 QProcess 空输出(continue,不崩)
+TEST_F(UT_CommonToolsMore, parseEDID_stubbedEmptyOutput)
+{
+    Stub stub;
+    stub.set(((void (QProcess::*)(const QString &, const QStringList &, QIODevice::OpenMode))ADDR(QProcess, start)),
+             ut_cm_start);
+    stub.set(ADDR(QProcess, waitForFinished), ut_cm_wait);
+    stub.set(ADDR(QProcess, readAllStandardOutput), ut_cm_readEmpty);
+    EXPECT_NO_FATAL_FAILURE(CommonTools::parseEDID(QStringList() << "/tmp/fake.edid", "DP-1", false));
+}
+
+// preGenerateGpuInfo: 冒烟(static 缓存,首次真实 glxinfo 可能慢,桩 QProcess)
+TEST_F(UT_CommonToolsMore, preGenerateGpuInfo_stubbed)
+{
+    Stub stub;
+    stub.set(((void (QProcess::*)(const QString &, const QStringList &, QIODevice::OpenMode))ADDR(QProcess, start)),
+             ut_cm_start);
+    stub.set(ADDR(QProcess, waitForFinished), ut_cm_wait);
+    stub.set(ADDR(QProcess, readAllStandardOutput), ut_cm_readEmpty);
+    EXPECT_NO_FATAL_FAILURE({ QString r = CommonTools::preGenerateGpuInfo(); (void)r; });
+}


### PR DESCRIPTION
Add unit tests for UI/DeviceManager/DBus/HTTP modules to raise line coverage.

为 UI/DeviceManager/DBus/HTTP 等模块新增单元测试，提升行覆盖率。

Fix cmake 3.31 Qt version misdetection and stub DBus calls in test_main.

修复 cmake 3.31 下 Qt 版本误检，并在 test_main 全局桩 DBus 调用避免服务阻塞。

Log: 提升单元测试覆盖率至75.7%并稳定测试环境
Influence: 前端覆盖率70.3%→75.7%，1100测试通过；修复cmake Qt6误检与DBus测试阻塞。