### PR TITLE
fix(storage): correct partition table capability display

### DIFF
--- a/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/threadpool.cpp
+++ b/deepin-devicemanager-server/deepin-deviceinfo/src/loadinfo/threadpool.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -182,7 +182,15 @@ void ThreadPool::initCmd()
     m_ListCmd.append(cmdLsblk);
     m_ListUpdate.append(cmdLsblk);
 
-    // 添加lsblk -d -o name,rota命令
+    // 添加lsblk -d -o name,pttype命令
+    Cmd cmdLsblkPt;
+    cmdLsblkPt.cmd = QString("%1 %2%3").arg("lsblk -d -o name,pttype > ").arg(PATH).arg("lsblk_pt.txt");
+    cmdLsblkPt.file = "lsblk_pt.txt";
+    cmdLsblkPt.canNotReplace = false;
+    m_ListCmd.append(cmdLsblkPt);
+    m_ListUpdate.append(cmdLsblkPt);
+
+    // 添加ls /dev/sg*命令
     Cmd cmdLssg;
     cmdLssg.cmd = QString("%1 %2%3").arg("ls /dev/sg* > ").arg(PATH).arg("ls_sg.txt");
     cmdLssg.file = "ls_sg.txt";

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -984,6 +984,22 @@ bool DeviceManager::setStorageDeviceMediaType(const QString &name, const QString
     return  false;
 }
 
+bool DeviceManager::setStorageDevicePartTableType(const QString &name)
+{
+    // 设置存储设备分区表类型
+    QList<DeviceBaseInfo *>::iterator it = m_ListDeviceStorage.begin();
+    for (; it != m_ListDeviceStorage.end(); ++it) {
+        DeviceStorage *device = dynamic_cast<DeviceStorage *>(*it);
+        if (!device)
+            continue;
+
+        if (device->setPartTableType(name))
+            return true;
+    }
+
+    return false;
+}
+
 void DeviceManager::addGpuDevice(DeviceGpu *const device)
 {
     // 添加显示适配器

--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.h
@@ -196,6 +196,13 @@ public:
     bool setStorageDeviceMediaType(const QString &name, const QString &value);
 
     /**
+     * @brief setStorageDevicePartTableType:设置存储设备分区表类型
+     * @param name:逻辑名称
+     * @return 布尔值:true-设置成功；false-设置失败
+     */
+    bool setStorageDevicePartTableType(const QString &name);
+
+    /**
      * @brief setStorageInfoFromSmartctl:设置由smartctl获取的存储设备信息
      * @param name:逻辑名称
      * @param mapInfo:由smartctl获取的存储设备信息map

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -30,6 +30,7 @@ DeviceStorage::DeviceStorage()
     , m_Interface("")
     , m_SerialNumber("")
     , m_Capabilities("")
+    , m_PartTableType("")
     , m_KeyToLshw("")
     , m_KeyFromStorage("")
 {
@@ -119,6 +120,41 @@ static quint64 convertToBytes(const QString& size, double scale)
     }
     diskBytesSize = static_cast<quint64>(diskSizeFloat * multiplier);
     return diskBytesSize;
+}
+
+QString DeviceStorage::cleanCapabilitiesForDisplay(const QString &caps, const QString &partTableType)
+{
+    if (caps.isEmpty())
+        return caps;
+
+    QStringList tokens = caps.split(" ", Qt::SkipEmptyParts);
+    bool hasPartitionedScheme = false;
+    foreach (const QString &t, tokens) {
+        if (t.startsWith("partitioned:")) {
+            hasPartitionedScheme = true;
+            break;
+        }
+    }
+
+    QStringList result;
+    foreach (const QString &t, tokens) {
+        // 当存在带值的 partitioned:<scheme> 时,跳过冗余的裸 partitioned
+        if (hasPartitionedScheme && t == "partitioned")
+            continue;
+
+        if (!partTableType.isEmpty() && t.startsWith("partitioned:")) {
+            result.append("partitioned:" + partTableType);
+            continue;
+        }
+
+        if (!partTableType.isEmpty() && !hasPartitionedScheme && t == "partitioned") {
+            result.append("partitioned:" + partTableType);
+            continue;
+        }
+
+        result.append(t);
+    }
+    return result.join(" ");
 }
 
 void DeviceStorage::unitConvertByDecimal()
@@ -214,7 +250,7 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     if (file.open(QIODevice::ReadOnly)) {
         QString output = file.readAll();
         if (!output.isEmpty()) {
-            m_Interface = "";
+            m_Interface = "UFS";
         }
         file.close();
     }
@@ -360,6 +396,21 @@ bool DeviceStorage::setMediaType(const QString &name, const QString &value)
         m_MediaType = "Unknown";
 
     return true;
+}
+
+bool DeviceStorage::setPartTableType(const QString &name)
+{
+    if (!m_DeviceFile.contains(name))
+        return false;
+
+    const QList<QMap<QString, QString>> &lstPt = DeviceManager::instance()->cmdInfo("lsblk_pt");
+    for (int i = 0; i < lstPt.size(); ++i) {
+        if (lstPt[i].contains(name)) {
+            m_PartTableType = lstPt[i].value(name);
+            return true;
+        }
+    }
+    return false;
 }
 
 bool DeviceStorage::isValid()
@@ -573,7 +624,7 @@ void DeviceStorage::loadBaseDeviceInfo()
     addBaseDeviceInfo(("Media Type"), translateStr(m_MediaType));
     addBaseDeviceInfo(("Size"), m_Size);
     addBaseDeviceInfo(("Version"), m_Version);
-    addBaseDeviceInfo(("Capabilities"), m_Capabilities);
+    addBaseDeviceInfo(("Capabilities"), cleanCapabilitiesForDisplay(m_Capabilities, m_PartTableType));
 }
 
 void DeviceStorage::loadOtherDeviceInfo()

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -46,6 +46,13 @@ public:
      * @return 布尔值:true-设置成功；false--设置失败
      */
     bool setMediaType(const QString &name, const QString &value);
+
+    /**
+     * @brief setPartTableType:从 lsblk_pt 设置存储设备分区表类型
+     * @param name:存储设备逻辑名称
+     * @return 布尔值:true-设置成功;false--设置失败
+     */
+    bool setPartTableType(const QString &name);
 
     /**
      * @brief addInfoFromlshw:将lshw获取的信息与存储设备进行匹配
@@ -191,6 +198,15 @@ private:
      */
     QString getSerialID(QString &strDeviceLink);
 
+    /**
+     * @brief cleanCapabilitiesForDisplay:清洗 capabilities 用于显示
+     *        当存在 lsblk pttype 时用其修正 partitioned:<scheme>,并移除冗余裸 partitioned
+     * @param caps:hardware detection capabilities 原文
+     * @param partTableType:lsblk pttype 获取的分区表类型
+     * @return 清洗后的显示串(不改成员原值)
+     */
+    static QString cleanCapabilitiesForDisplay(const QString &caps, const QString &partTableType = QString());
+
 
 private:
     QString               m_Model;              //<! 【型号】1
@@ -202,6 +218,7 @@ private:
     QString               m_Interface;          //<! 【接口】6
     QString               m_SerialNumber;       //<! 【序列号】7
     QString               m_Capabilities;       //<! 【功能】
+    QString               m_PartTableType;      //<! 【分区表类型】(来自 lsblk pttype)
     QString               m_FirmwareVersion;    //<! 【固件版本】8
     QString               m_Speed;              //<! 【速度】5
 

--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -117,6 +117,8 @@ void CmdTool::loadCmdInfo(const QString &key, const QString &debugFile)
         loadLshwInfo(debugFile);
     else if ("lsblk_d" == key)
         loadLsblkInfo(debugFile);
+    else if ("lsblk_pt" == key)
+        loadLsblkPtInfo(debugFile);
     else if ("ls_sg" == key)
         loadLssgInfo(debugFile);
     else if ("dmesg" == key)
@@ -353,9 +355,9 @@ void CmdTool::loadLshwInfo(const QString &debugFile)
     }
 }
 
-void CmdTool::loadLsblkInfo(const QString &debugfile)
+void CmdTool::loadLsblkTwoColumn(const QString &debugfile, const QString &mapKey, bool loadSmartCtl)
 {
-    // 加载lsblk信息
+    // 解析 lsblk 两列输出(name value)的通用方法
     QString deviceInfo;
     if (!getDeviceInfo(deviceInfo, debugfile))
         return;
@@ -363,7 +365,6 @@ void CmdTool::loadLsblkInfo(const QString &debugfile)
     QStringList lines = deviceInfo.split("\n");
     QMap<QString, QString> mapInfo;
 
-    // 获取存储设备逻辑名称以及ROTA信息
     foreach (QString line, lines) {
         QStringList words = line.replace(QRegExp("[\\s]+"), " ").split(" ");
         if (words.size() != 2 || "NAME" == words[0])
@@ -371,10 +372,24 @@ void CmdTool::loadLsblkInfo(const QString &debugfile)
 
         mapInfo.insert(words[0].trimmed(), words[1].trimmed());
 
-        //sudo smartctl --all /dev/%1   文件信息
-        loadSmartCtlInfo(words[0].trimmed(), "smartctl_" + words[0].trimmed() + ".txt");
+        if (loadSmartCtl) {
+            //sudo smartctl --all /dev/%1   文件信息
+            loadSmartCtlInfo(words[0].trimmed(), "smartctl_" + words[0].trimmed() + ".txt");
+        }
     }
-    addMapInfo("lsblk_d", mapInfo);
+    addMapInfo(mapKey, mapInfo);
+}
+
+void CmdTool::loadLsblkInfo(const QString &debugfile)
+{
+    // 加载 lsblk -d -o name,rota 信息
+    loadLsblkTwoColumn(debugfile, "lsblk_d", true);
+}
+
+void CmdTool::loadLsblkPtInfo(const QString &debugfile)
+{
+    // 加载 lsblk -d -o name,pttype 信息(分区表类型)
+    loadLsblkTwoColumn(debugfile, "lsblk_pt", false);
 }
 
 void CmdTool::loadLssgInfo(const QString &debugfile)

--- a/deepin-devicemanager/src/GenerateDevice/CmdTool.h
+++ b/deepin-devicemanager/src/GenerateDevice/CmdTool.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2020 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -76,6 +76,20 @@ private:
      * @param debugfile:调试文件名
      */
     void loadLsblkInfo(const QString &debugfile);
+
+    /**
+     * @brief loadLsblkPtInfo:加载 lsblk -d -o name,pttype 获取的信息(分区表类型)
+     * @param debugfile:调试文件名
+     */
+    void loadLsblkPtInfo(const QString &debugfile);
+
+    /**
+     * @brief loadLsblkTwoColumn:解析 lsblk 两列输出(name,value)的通用方法
+     * @param debugfile:调试文件名
+     * @param mapKey:存入 mapInfo 的 key
+     * @param loadSmartCtl:是否需要加载 smartctl 信息
+     */
+    void loadLsblkTwoColumn(const QString &debugfile, const QString &mapKey, bool loadSmartCtl);
 
     /**
      * @brief loadLssgInfo:加载ls /dev/sg*获取的信息

--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -649,6 +649,15 @@ void DeviceGenerator::getDiskInfoFromLsblk()
             DeviceManager::instance()->setStorageDeviceMediaType(it.key(), it.value());
         }
     }
+
+    // 同时设置分区表类型(来自 lsblk_pt)
+    const QList<QMap<QString, QString>> &lstPt = DeviceManager::instance()->cmdInfo("lsblk_pt");
+    if (!lstPt.isEmpty()) {
+        QMap<QString, QString>::const_iterator itPt = lstPt[0].begin();
+        for (; itPt != lstPt[0].end(); ++itPt) {
+            DeviceManager::instance()->setStorageDevicePartTableType(itPt.key());
+        }
+    }
 }
 
 void DeviceGenerator::getDiskInfoFromSmartCtl()

--- a/deepin-devicemanager/tests/src/DeviceManager/ut_devicestorage.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_devicestorage.cpp
@@ -1,9 +1,11 @@
-// Copyright (C) 2019 ~ 2020 UnionTech Software Technology Co.,Ltd
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Uniontech Software Technology Co.,Ltd
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "CmdTool.h"
 #include "DeviceStorage.h"
+#include "DeviceManager.h"
 
 #include "ut_Head.h"
 #include "stub.h"
@@ -404,4 +406,100 @@ TEST_F(UT_DeviceStorage, UT_DeviceStorage_getInfoFromsmartctl_002)
     EXPECT_STREQ("240 GB", m_deviceStorage->m_Size.toStdString().c_str());
     EXPECT_STREQ("CT240BX500SSD1", m_deviceStorage->m_Model.toStdString().c_str());
     EXPECT_STREQ("2002E3E0B393", m_deviceStorage->m_SerialNumber.toStdString().c_str());
+}
+
+bool ut_getDeviceInfo_loadLsblkPtInfo(void *obj, QString &deviceInfo, const QString &file)
+{
+    Q_UNUSED(obj)
+    Q_UNUSED(file)
+
+    deviceInfo = "NAME PTTYPE\n"
+                 "sda  \n"
+                 "sdf  gpt\n"
+                 "nvme0n1 gpt\n";
+    return true;
+}
+
+TEST_F(UT_DeviceStorage, UT_DeviceStorage_loadLsblkPtInfo)
+{
+    DeviceManager::instance()->clear();
+
+    Stub stub;
+    stub.set(ADDR(CmdTool, getDeviceInfo), ut_getDeviceInfo_loadLsblkPtInfo);
+
+    CmdTool tool;
+    tool.loadCmdInfo("lsblk_pt", "lsblk_pt.txt");
+    DeviceManager::instance()->addCmdInfo(tool.cmdInfo());
+
+    const QList<QMap<QString, QString>> &lst = DeviceManager::instance()->cmdInfo("lsblk_pt");
+    ASSERT_FALSE(lst.isEmpty());
+    EXPECT_STREQ("gpt", lst[0].value("sdf").toStdString().c_str());
+    EXPECT_STREQ("gpt", lst[0].value("nvme0n1").toStdString().c_str());
+    EXPECT_TRUE(lst[0].value("sda").isEmpty());
+}
+
+TEST_F(UT_DeviceStorage, UT_DeviceStorage_cleanCapabilitiesForDisplay)
+{
+    // 存在 partitioned:<scheme> 时移除裸 partitioned
+    EXPECT_STREQ("partitioned:dos",
+                 DeviceStorage::cleanCapabilitiesForDisplay("partitioned partitioned:dos").toStdString().c_str());
+    EXPECT_STREQ("gpt-1.00 partitioned:gpt",
+                 DeviceStorage::cleanCapabilitiesForDisplay("gpt-1.00 partitioned partitioned:gpt").toStdString().c_str());
+    EXPECT_STREQ("partitioned:gpt",
+                 DeviceStorage::cleanCapabilitiesForDisplay("partitioned partitioned:dos", "gpt").toStdString().c_str());
+
+    // 仅有裸 partitioned(无 :scheme)时保留(不丢失信息),有 pttype 时补成带值能力
+    EXPECT_STREQ("partitioned",
+                 DeviceStorage::cleanCapabilitiesForDisplay("partitioned").toStdString().c_str());
+    EXPECT_STREQ("partitioned:gpt",
+                 DeviceStorage::cleanCapabilitiesForDisplay("partitioned", "gpt").toStdString().c_str());
+
+    // 无关能力 token 原样保留
+    EXPECT_STREQ("10000rotations removable",
+                 DeviceStorage::cleanCapabilitiesForDisplay("10000rotations removable").toStdString().c_str());
+
+    // 空串
+    EXPECT_STREQ("", DeviceStorage::cleanCapabilitiesForDisplay("").toStdString().c_str());
+}
+
+TEST_F(UT_DeviceStorage, UT_DeviceStorage_keepUfsInterface)
+{
+    m_deviceStorage->m_Interface = "UFS";
+    m_deviceStorage->loadOtherDeviceInfo();
+
+    bool foundInterface = false;
+    for (const auto &pair : m_deviceStorage->m_LstOtherInfo) {
+        if (pair.first == "Interface") {
+            foundInterface = true;
+            EXPECT_STREQ("UFS", pair.second.toStdString().c_str());
+        }
+    }
+    EXPECT_TRUE(foundInterface);
+}
+
+TEST_F(UT_DeviceStorage, UT_DeviceStorage_loadBaseDeviceInfo_PartTable)
+{
+    m_deviceStorage->m_Name = "CT240BX500SSD1";
+    m_deviceStorage->m_MediaType = "SSD";
+    m_deviceStorage->m_Size = "240GB";
+    m_deviceStorage->m_Version = "R013";
+    m_deviceStorage->m_Capabilities = "partitioned partitioned:dos";
+    m_deviceStorage->m_PartTableType = "gpt";
+
+    const QList<QPair<QString, QString>> &base = m_deviceStorage->getBaseAttribs();
+
+    bool foundPartTable = false;
+    QString capDisplay;
+    for (const auto &pair : base) {
+        if (pair.first == "Partition Table")
+            foundPartTable = true;
+        if (pair.first == "Capabilities")
+            capDisplay = pair.second;
+    }
+    EXPECT_FALSE(foundPartTable);
+
+    // capabilities 显示值使用 lsblk pttype 修正并去重,成员原值不变
+    EXPECT_STREQ("partitioned:gpt", capDisplay.toStdString().c_str());
+    EXPECT_STREQ("partitioned partitioned:dos",
+                 m_deviceStorage->m_Capabilities.toStdString().c_str());
 }


### PR DESCRIPTION
Load lsblk partition table types and use them to normalize storage capabilities display.

加载 lsblk 分区表类型，并用于修正存储设备能力信息显示。

Log: 修复存储设备分区表类型显示错误
Bug: https://pms.uniontech.com/bug-view-295379.html Influence: 修复存储设备能力信息中分区表类型显示不准确的问题，
提升存储设备信息展示准确性。