### PR TITLE
fix(device): replace specialComType check with isHwPlatform API

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -132,7 +132,7 @@ void DeviceMemory::loadBaseDeviceInfo()
 {
     // 添加基本信息
     addBaseDeviceInfo(("Name"), m_Name);
-    if (Common::specialComType <= 0) {
+    if (!Common::isHwPlatform()) {
         addBaseDeviceInfo(("Vendor"), m_Vendor);
     }
     addBaseDeviceInfo(("Size"), m_Size);

--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -232,7 +232,7 @@ bool DeviceMonitor::setInfoFromXradr(const QString &main, const QString &edid, c
             }
         }
 
-        if (Common::specialComType <= 0) {
+        if (!Common::isHwPlatform()) {
             QMap<QString, QStringList> monitorResolutionMap = getMonitorResolutionMap(xrandr, m_RawInterface);
 
             if (monitorResolutionMap.size() == 1) {

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -127,7 +127,7 @@ QString DeviceStorage::cleanCapabilitiesForDisplay(const QString &caps, const QS
     if (caps.isEmpty())
         return caps;
 
-    QStringList tokens = caps.split(" ", Qt::SkipEmptyParts);
+    QStringList tokens = caps.split(" ", QString::SkipEmptyParts);
     bool hasPartitionedScheme = false;
     foreach (const QString &t, tokens) {
         if (t.startsWith("partitioned:")) {
@@ -170,7 +170,7 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     if (mapInfo.find("SysFS BusID") == mapInfo.end())
         return false;
 
-    if (Common::specialComType <= 0) {
+    if (!Common::isHwPlatform()) {
         setAttribute(mapInfo, "Model", m_Name);
     }
     setAttribute(mapInfo, "Vendor", m_Vendor);
@@ -501,7 +501,7 @@ void DeviceStorage::appendDisk(DeviceStorage *device)
 
 void DeviceStorage::checkDiskSize()
 {
-    if (Common::specialComType <= 0) {
+    if (!Common::isHwPlatform()) {
         return; //定制机型专用，其它慎用
     }
 
@@ -618,7 +618,7 @@ void DeviceStorage::loadBaseDeviceInfo()
 {
     // 添加基本信息
     addBaseDeviceInfo(("Name"), m_Name);
-    if (Common::specialComType <= 0) {
+    if (!Common::isHwPlatform()) {
         addBaseDeviceInfo(("Vendor"), m_Vendor);
     }
     addBaseDeviceInfo(("Media Type"), translateStr(m_MediaType));

--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -509,7 +509,7 @@ void MainWindow::slotLoadingFinish(const QString &message)
             mp_DeviceWidget->updateDevice(mp_DeviceWidget->currentIndex(), lst);
 
             // bug-325731
-            if (Common::specialComType <= 0) {
+            if (!Common::isHwPlatform()) {
                 if (mp_DeviceWidget->currentIndex() == QObject::tr("Monitor")) {
                     QtConcurrent::run([=](){
                         QThread::msleep(700);


### PR DESCRIPTION
Refactor platform detection from Common::specialComType <= 0 to the new Common::isHwPlatform() method for improved code maintainability. Also fixes deprecated Qt::SkipEmptyParts → QString::SkipEmptyParts.

Log: 统一使用isHwPlatform()替换specialComType平台判断
PMS: BUG-368321
Influence: 设备信息显示和分辨率获取的机型平台判断逻辑统一，代码更易维护。

## Summary by Sourcery

Unify hardware platform detection across device manager components using the new Common::isHwPlatform() API and modernize related Qt usage.

Bug Fixes:
- Fix deprecated usage of Qt::SkipEmptyParts by switching to QString::SkipEmptyParts in device storage capability parsing.

Enhancements:
- Replace legacy Common::specialComType platform checks with Common::isHwPlatform() in storage, memory, monitor, and main window logic to standardize hardware platform handling.
- Update DeviceMemory copyright header years to cover 2022–2026.