### PR TITLE
feat(storage): add USB interface detection

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -187,6 +187,12 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     if (exp.indexIn(m_Vendor) != -1)
         m_Vendor = "";
 
+    if (mapInfo.contains("Driver Modules")) {
+        if (mapInfo.value("Driver Modules").contains("usb_storage", Qt::CaseInsensitive)) {
+            m_Interface = "USB";
+        }
+    }
+
     setAttribute(mapInfo, "Attached to", m_Interface);
     QRegExp re(".*\\((.*)\\).*");
     if (re.exactMatch(m_Interface)) {


### PR DESCRIPTION
Add logic to detect USB storage devices by checking driver modules.

添加USB存储设备接口检测逻辑，通过检查驱动模块识别USB设备。

Log: 添加USB接口检测
PMS: BUG-368469
Influence: 能够正确识别USB存储设备的接口类型，提升设备信息显示的准确性。

## Summary by Sourcery

New Features:
- Identify USB storage devices by inspecting the 'Driver Modules' field and setting the storage interface type to USB accordingly.