### PR TITLE
fix(device): replace specialComType check with isHwPlatform API

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceComputer.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceComputer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -198,7 +198,7 @@ void DeviceComputer::loadBaseDeviceInfo()
 {
     qCDebug(appLog) << "DeviceComputer::loadBaseDeviceInfo called.";
     // 添加基本信息
-    addBaseDeviceInfo(("Name"), m_Name);
+    addBaseDeviceInfo("Name", m_Name);
 }
 
 void DeviceComputer::loadOtherDeviceInfo()

--- a/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMemory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -155,7 +155,7 @@ void DeviceMemory::loadBaseDeviceInfo()
     qCDebug(appLog) << "Loading base device info for memory";
     // 添加基本信息
     addBaseDeviceInfo("Name", m_Name);
-    if (Common::specialComType <= 0) {
+    if (!Common::isHwPlatform()) {
         addBaseDeviceInfo(("Vendor"), m_Vendor);
     }
     addBaseDeviceInfo("Size", m_Size);

--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -273,7 +273,7 @@ bool DeviceMonitor::setInfoFromXradr(const QString &main, const QString &edid, c
             }
         }
 
-        if (Common::specialComType <= 0) {
+        if (!Common::isHwPlatform()) {
             QMap<QString, QStringList> monitorResolutionMap = getMonitorResolutionMap(xrandr, m_RawInterface);
 
             if (monitorResolutionMap.size() == 1) {

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -154,7 +154,7 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
         return false;
     }
 
-    if (Common::specialComType <= 0) {
+    if (!Common::isHwPlatform()) {
         setAttribute(mapInfo, "Model", m_Name);
     }
     setAttribute(mapInfo, "Vendor", m_Vendor);
@@ -535,7 +535,7 @@ void DeviceStorage::appendDisk(DeviceStorage *device)
 void DeviceStorage::checkDiskSize()
 {
     qCDebug(appLog) << "DeviceStorage::checkDiskSize";
-    if (Common::specialComType <= 0) {
+    if (!Common::isHwPlatform()) {
         return; //定制机型专用，其它慎用
     }
     quint64 gbyte =  1000000000;
@@ -662,7 +662,7 @@ void DeviceStorage::loadBaseDeviceInfo()
     qCDebug(appLog) << "DeviceStorage::loadBaseDeviceInfo";
     // 添加基本信息
     addBaseDeviceInfo("Name", m_Name);
-    if (Common::specialComType <= 0) {
+    if (!Common::isHwPlatform()) {
         addBaseDeviceInfo(("Vendor"), m_Vendor);
     }
     addBaseDeviceInfo("Media Type", translateStr(m_MediaType));

--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -578,7 +578,7 @@ void MainWindow::slotLoadingFinish(const QString &message)
             mp_DeviceWidget->updateDevice(mp_DeviceWidget->currentIndex(), lst);
 
             // bug-325731
-            if (Common::specialComType <= 0) {
+            if (!Common::isHwPlatform()) {
                 if (mp_DeviceWidget->currentIndex() == QObject::tr("Monitor")) {
                     QtConcurrent::run([=](){
                         QThread::msleep(700);


### PR DESCRIPTION
Refactor platform detection from Common::specialComType <= 0 to the new Common::isHwPlatform() method for improved code maintainability. Also fixes deprecated Qt::SkipEmptyParts → QString::SkipEmptyParts.

Log: 统一使用isHwPlatform()替换specialComType平台判断
PMS: BUG-368321
Influence: 设备信息显示和分辨率获取的机型平台判断逻辑统一，代码更易维护。