### PR TITLE
fix(device): remove redundant loop in network device generation

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -353,21 +353,20 @@ void DeviceGenerator::generatorNetworkDevice()
             continue;
 
         const QString &logicalNameLshw =  (*it)["logical name"];
-        for (QList<DeviceNetwork *>::iterator itDevice = lstDevice.begin(); itDevice != lstDevice.end(); ++itDevice) {
-            const QString &macAddressLshw =  (*it)["serial"];
-            if (!isValidLogicalName(logicalNameLshw))
-                continue;
-            if (!isValidMAC(macAddressLshw))
-                continue;
-            if (logicalNameLshw.contains("wlan", Qt::CaseInsensitive) && hasWlan) //common sense: one PC only have 1 wlan device
-                continue;
+        
+        const QString &macAddressLshw =  (*it)["serial"];
+        if (!isValidLogicalName(logicalNameLshw))
+            continue;
+        if (!isValidMAC(macAddressLshw))
+            continue;
+        if (logicalNameLshw.contains("wlan", Qt::CaseInsensitive) && hasWlan) //common sense: one PC only have 1 wlan device
+            continue;
 
-            DeviceNetwork *device = new DeviceNetwork();
-            device->setInfoFromLshw(*it);
-            lstDevice.append(device);
-            if (logicalNameLshw.contains("wlan", Qt::CaseInsensitive))
-                hasWlan = true;
-        }
+        DeviceNetwork *device = new DeviceNetwork();
+        device->setInfoFromLshw(*it);
+        lstDevice.append(device);
+        if (logicalNameLshw.contains("wlan", Qt::CaseInsensitive))
+            hasWlan = true;
     }
 
     const QList<QMap<QString, QString>> &lstHWInfo = DeviceManager::instance()->cmdInfo("hwinfo_network");


### PR DESCRIPTION
Remove the outer loop iterating lstDevice in generatorNetworkDevice, as inner operations do not depend on the loop variable, fixing incorrect network device filtering.

移除generatorNetworkDevice中遍历lstDevice的多余外层循环，内层操作
不依赖循环变量，修复网络设备过滤异常的问题。

Log: 修复网络设备生成中循环冗余导致的过滤异常
PMS: BUG-369057
Influence: 修复后网络设备列表生成逻辑正确，避免无线网卡等设备被错误过滤。

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect network device filtering that could wrongly exclude interfaces such as wireless adapters by eliminating an unnecessary iteration over the existing device list.