### PR TITLE
feat(storage): add MMC storage vendor identification via sysfs

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -20,6 +20,41 @@ using namespace DDLog;
 #define DISK_SCALE_1024 1024
 #define DISK_SCALE_1000 1000
 
+// MANFID: 十六进制字符串 -> 厂商名
+static const QMap<QString, QString> MANFID_TABLE = {
+    {"000001", "Panasonic"},
+    {"000002", "Toshiba"},
+    {"000003", "SanDisk"},
+    {"00001b", "Samsung"},
+    {"00001d", "ADATA"},
+    {"000027", "Phison"},
+    {"000028", "Lexar"},
+    {"000031", "Silicon Power"},
+    {"000041", "Kingston"},
+    {"000074", "Transcend Information"},
+    {"000076", "Patriot Memory"},
+    {"000082", "Sony"},
+    {"00009c", "Angelbird / Hoodman"}
+};
+
+// OEMID: 十六进制字符串 -> 厂商名
+static const QMap<QString, QString> OEMID_TABLE = {
+    {"3432", "Kingston"},
+    {"4144", "ADATA"},
+    {"4245", "Lexar / Angelbird / Hoodman"},
+    {"4a45", "Transcend Information"},
+    {"4a54", "Sony"},
+    {"4a60", "Transcend Information"},
+    {"5041", "Panasonic"},
+    {"5048", "Phison"},
+    {"5054", "SanDisk"},
+    {"5344", "SanDisk"},
+    {"534d", "Samsung"},
+    {"534f", "Angelbird / Hoodman"},
+    {"5350", "Silicon Power"},
+    {"544d", "Toshiba"}
+};
+
 DeviceStorage::DeviceStorage()
     : DeviceBaseInfo()
     , m_Model("")
@@ -274,6 +309,35 @@ bool DeviceStorage::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
     setAttribute(mapInfo, "Module Alias", m_Modalias);
     setAttribute(mapInfo, "VID_PID", m_VID_PID);
     m_PhysID = m_VID_PID;
+
+    if (m_Driver.contains("mmcblk")) {
+        QString sysfsDeviceLink = mapInfo.value("SysFS Device Link");
+
+        if (!sysfsDeviceLink.isEmpty())
+        {
+            if (!sysfsDeviceLink.startsWith("/sys/"))
+            {
+                sysfsDeviceLink = "/sys" + sysfsDeviceLink;
+            }
+
+            QString err;
+            QString name = Common::safeReadSysFsFile(sysfsDeviceLink, "name", err);
+            if (err.isEmpty())
+                m_Name = name;
+
+            QString manfIdRaw = Common::safeReadSysFsFile(sysfsDeviceLink, "manfid", err);
+            if (err.isEmpty()) {
+                m_Vendor = getManfName(manfIdRaw);
+            }
+
+            QString oemIdRaw = Common::safeReadSysFsFile(sysfsDeviceLink, "oemid", err);
+            if (err.isEmpty()) {
+                if (m_Vendor.isEmpty()) {
+                    m_Vendor = getOemName(oemIdRaw);
+                }
+            }
+        }
+    }
 
     getOtherMapInfo(mapInfo);
     return true;
@@ -843,4 +907,20 @@ void DeviceStorage::getInfoFromsmartctl(const QMap<QString, QString> &mapInfo)
         qCDebug(appLog) << "DeviceStorage::getInfoFromsmartctl, name starts with RS and vendor is empty";
         m_Vendor = "Longsys";
     }
+}
+
+// 通过manfid获取厂商名称
+QString DeviceStorage::getManfName(const QString &rawManfId)
+{
+    QString cleanId = rawManfId.trimmed().toLower();
+    cleanId.remove("0x"); // 去除0x前缀
+    return MANFID_TABLE.value(cleanId, rawManfId);
+}
+
+// 通过oemid获取厂商名称
+QString DeviceStorage::getOemName(const QString &rawOemId)
+{
+    QString cleanId = rawOemId.trimmed().toLower();
+    cleanId.remove("0x");
+    return OEMID_TABLE.value(cleanId, rawOemId);
 }

--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.h
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.h
@@ -156,6 +156,8 @@ public:
 
     const QString &mediaType() const;
 
+    QString getManfName(const QString &rawManfId);
+    QString getOemName(const QString &rawOemId);
 protected:
 
     /**

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -15,6 +15,8 @@
 #include <QMap>
 #include <QProcess>
 #include <QFile>
+#include <QFileInfo>
+#include <QDir>
 #include <QLoggingCategory>
 #include <QRegularExpression>
 
@@ -404,4 +406,58 @@ int Common::parseSharedCpuCount(const QString &sharedCpuList)
         }
     }
     return count;
+}
+
+/**
+ * 安全读取sysfs下指定文件内容
+ * @param baseDir 根目录 /sys/xxx/mmc0:0001
+ * @param fileName 待读取的文件名
+ * @return 文件原始字符串（去换行空格）
+ */
+QString Common::safeReadSysFsFile(const QString &baseDir, const QString &fileName, QString &errOut)
+{
+    errOut.clear();
+
+    if (!baseDir.startsWith("/sys/") && baseDir != "/sys") {
+        errOut = QString("baseDir not under /sys: %1").arg(baseDir);
+        return "";
+    }
+    if (baseDir.contains("..")) {
+        errOut = QString("Path traversal detected in baseDir: %1").arg(baseDir);
+        return "";
+    }
+
+    if (fileName.contains('/') || fileName.contains("..") || fileName.contains('\\')) {
+        errOut = QString("Path traversal detected in fileName: %1").arg(fileName);
+        return "";
+    }
+
+    QFileInfo fullPathInfo(QDir(baseDir), fileName);
+    QString fullPath = fullPathInfo.canonicalFilePath();
+
+    if (!fullPath.startsWith("/sys/"))
+    {
+        errOut = QString("Path escape to non-sys dir: %1").arg(fullPath);
+        return "";
+    }
+
+    if (!fullPathInfo.isFile())
+    {
+        errOut = QString("Not a regular file: %1").arg(fullPath);
+        return "";
+    }
+
+    QFile file(fullPath);
+    if (!file.open(QIODevice::ReadOnly))
+    {
+        errOut = QString("Open failed: %1, err=%2").arg(fullPath, file.errorString());
+        return "";
+    }
+
+    const qint64 MAX_READ_LEN = 64;
+    QByteArray rawData = file.read(MAX_READ_LEN);
+    file.close();
+
+    QString content = QString::fromUtf8(rawData).trimmed();
+    return content;
 }

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -53,5 +53,14 @@ public:
     static QString formatTotalCache(const QString& perThreadCache, int coreCount);
 
     static int parseSharedCpuCount(const QString &sharedCpuList);
+
+    /**
+     * @brief safeReadSysFsFile: 安全读取 sysfs 下指定文件内容
+     * @param baseDir 根目录，如 /sys/devices/xxx/mmc0:0001
+     * @param fileName 待读取的文件名（禁止包含路径分隔符）
+     * @param errOut 错误输出参数，成功时为空
+     * @return 文件内容（去换行空格），失败返回空字符串
+     */
+    static QString safeReadSysFsFile(const QString &baseDir, const QString &fileName, QString &errOut);
 };
 #endif // COMMONFUNCTION_H


### PR DESCRIPTION
Read manfid/oemid/name from sysfs for MMC storage devices and resolve vendor names using MANFID/OEMID lookup tables. Add safeReadSysFsFile() utility with path traversal protection.

Log: 添加MMC存储设备厂商识别功能，通过sysfs读取manfid/oemid识别厂商
PMS: BUG-368319
Influence: MMC/eMMC存储设备的厂商信息不再为空，可正确显示对应厂商名称