### PR TITLE
fix(monitor): add support for kSpecialType10 computer type

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
@@ -123,7 +123,8 @@ void DeviceCpu::setCpuInfo(const QMap<QString, QString> &mapLscpu, const QMap<QS
         m_MaxFrequency = m_MaxFrequency.replace(CPU_MAXFREQ_TYPE5_7_OLD, CPU_MAXFREQ_TYPE5_7_NEW);
     }
 
-    if (Common::specialComType == Common::kSpecialType9) {
+    if (Common::specialComType == Common::kSpecialType9 ||
+        Common::specialComType == Common::kSpecialType10) {
         m_Frequency = m_Frequency.replace(CPU_FREQ_TYPE9_OLD, CPU_FREQ_TYPE9_NEW);
         m_MaxFrequency = m_MaxFrequency.replace(CPU_MAXFREQ_TYPE9_OLD, CPU_MAXFREQ_TYPE9_NEW);
     }

--- a/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceMonitor.cpp
@@ -303,7 +303,8 @@ const QString DeviceMonitor::getOverviewInfo()
     if (Common::isShowScreenSize()) {
         if (Common::specialComType == Common::kSpecialType6 ||
             Common::specialComType == Common::kSpecialType7 ||
-            Common::specialComType == Common::kSpecialType9) {
+            Common::specialComType == Common::kSpecialType9 ||
+            Common::specialComType == Common::kSpecialType10) {
             ov = QString("(%1)").arg(m_ScreenSize);
         } else {
             ov = QString("%1(%2)").arg(m_Name).arg(m_ScreenSize);
@@ -311,7 +312,8 @@ const QString DeviceMonitor::getOverviewInfo()
     } else {
         if (Common::specialComType == Common::kSpecialType6 ||
             Common::specialComType == Common::kSpecialType7 ||
-            Common::specialComType == Common::kSpecialType9) {
+            Common::specialComType == Common::kSpecialType9 ||
+            Common::specialComType == Common::kSpecialType10) {
             ov = "";
         } else {
             ov = QString("%1").arg(m_Name);
@@ -331,7 +333,8 @@ void DeviceMonitor::loadBaseDeviceInfo()
     if (Common::specialComType != Common::kSpecialType5 &&
         Common::specialComType != Common::kSpecialType6 &&
         Common::specialComType != Common::kSpecialType7 &&
-        Common::specialComType != Common::kSpecialType9) {
+        Common::specialComType != Common::kSpecialType9 &&
+        Common::specialComType != Common::kSpecialType10) {
         addBaseDeviceInfo(("Name"), m_Name);
         addBaseDeviceInfo(("Vendor"), m_Vendor);
         addBaseDeviceInfo(("Type"), m_Model);
@@ -415,15 +418,17 @@ bool DeviceMonitor::setMainInfoFromXrandr(const QString &info, const QString &ra
             }
             if (Common::specialComType == Common::kSpecialType1 ||
                     Common::specialComType == Common::kSpecialType5 ||
-                    Common::specialComType == Common::kSpecialType6  ||
+                    Common::specialComType == Common::kSpecialType6 ||
                     Common::specialComType == Common::kSpecialType7 ||
-                    Common::specialComType == Common::kSpecialType9) {
+                    Common::specialComType == Common::kSpecialType9 ||
+                    Common::specialComType == Common::kSpecialType10) {
                 m_RefreshRate = QString("%1").arg(curRate);
             }
             if (Common::specialComType == Common::kSpecialType5 ||
                 Common::specialComType == Common::kSpecialType6 ||
                 Common::specialComType == Common::kSpecialType7 ||
-                Common::specialComType == Common::kSpecialType9) {
+                Common::specialComType == Common::kSpecialType9 ||
+                Common::specialComType == Common::kSpecialType10) {
                 m_CurrentResolution = QString("%1").arg(reScreenSize.cap(1)).replace("x", "×", Qt::CaseInsensitive);
             } else {
                 m_CurrentResolution = QString("%1 @%2").arg(reScreenSize.cap(1)).arg(curRate).replace("x", "×", Qt::CaseInsensitive);

--- a/deepin-devicemanager/src/Tool/EDIDParser.cpp
+++ b/deepin-devicemanager/src/Tool/EDIDParser.cpp
@@ -205,9 +205,12 @@ void EDIDParser::parseScreenSize()
         }
     }
 
-    if (Common::specialComType == Common::kSpecialType7){ // sepcial task:378963
-        m_Width = 296;
-        m_Height = 197;
+    if (Common::specialComType == Common::kSpecialType7 ||
+        Common::specialComType == Common::kSpecialType10) { // special task:378963
+        if (m_Width == 300 && m_Height == 200) {
+            m_Width = 296;
+            m_Height = 197;
+        }
     }
     double inch = sqrt((m_Width / 2.54) * (m_Width / 2.54) + (m_Height / 2.54) * (m_Height / 2.54))/10;
     m_ScreenSize = QString("%1 %2(%3mm×%4mm)")

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -26,7 +26,8 @@ public:
         kSpecialType6,
         kSpecialType7,
         kSpecialType8,
-        kSpecialType9
+        kSpecialType9,
+        kSpecialType10
     };
 
     enum SpecialCpuType {


### PR DESCRIPTION
Add support for kSpecialType10 in CPU frequency display, monitor overview info, and EDID parsing. Fix syntax error in height comparison.

添加 kSpecialType10 计算机类型支持，涵盖 CPU 频率显示、显示器概览信息和 EDID 解析。修复高度比较语法错误。

Log: 添加 kSpecialType10 计算机类型支持
PMS: BUG-369547
Influence: kSpecialType10 计算机类型的 CPU 频率显示和显示器信息解析逻辑正确，修复了 EDIDParser 的语法错误。