### PR TITLE
fix(camera): display FHD Camera in image device details

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceImage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceImage.cpp
@@ -9,18 +9,6 @@
 #include "DBusInterface.h"
 #include "commonfunction.h"
 
-namespace {
-constexpr auto kFhdCameraName = "FHD Camera";
-
-void setSpecialCameraName(QString &name)
-{
-    if (Common::specialComType == Common::kSpecialType9
-        || Common::specialComType == Common::kSpecialType10) {
-        name = kFhdCameraName;
-    }
-}
-}
-
 DeviceImage::DeviceImage()
     : DeviceBaseInfo()
     , m_Model("")
@@ -40,7 +28,6 @@ void DeviceImage::setInfoFromLshw(const QMap<QString, QString> &mapInfo)
         return;
 
     setAttribute(mapInfo, "product", m_Name, false);
-    setSpecialCameraName(m_Name);
     setAttribute(mapInfo, "vendor", m_Vendor);
     setAttribute(mapInfo, "version", m_Version);
     setAttribute(mapInfo, "bus info", m_BusInfo);
@@ -76,7 +63,6 @@ void DeviceImage::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
     if (mapInfo.find("unique_id") != mapInfo.end()) {
         m_UniqueID = mapInfo["unique_id"];
         m_Name = mapInfo["name"];
-        setSpecialCameraName(m_Name);
         m_SysPath = mapInfo["path"];
         m_HardwareClass = mapInfo["Hardware Class"];
         m_Enable = false;
@@ -95,7 +81,6 @@ void DeviceImage::setInfoFromHwinfo(const QMap<QString, QString> &mapInfo)
         m_SerialID = m_UniqueID;
     setAttribute(mapInfo, "SysFS ID", m_SysPath);
     setAttribute(mapInfo, "Device", m_Name);
-    setSpecialCameraName(m_Name);
     setAttribute(mapInfo, "Vendor", m_Vendor);
     setAttribute(mapInfo, "Model", m_Model);
     setAttribute(mapInfo, "Revision", m_Version);
@@ -177,7 +162,9 @@ void DeviceImage::initFilterKey()
 void DeviceImage::loadBaseDeviceInfo()
 {
     // 添加基本信息
-    addBaseDeviceInfo(("Name"), m_Name);
+    const bool isFhdCamera = Common::specialComType == Common::kSpecialType9
+        || Common::specialComType == Common::kSpecialType10;
+    addBaseDeviceInfo(("Name"), isFhdCamera ? "FHD Camera" : m_Name);
     addBaseDeviceInfo(("Vendor"), m_Vendor);
     addBaseDeviceInfo(("Version"), m_Version);
     addBaseDeviceInfo(("Model"), m_Model);


### PR DESCRIPTION
Show FHD Camera only in the image device Name field for special types.
特殊机型的图像设备详情名称字段显示为FHD Camera。

Log：修复特殊机型图像设备名称显示
Task: https://pms.uniontech.com/task-view-392807.html
Influence:Flemingz和Flemingzs机型的图像设备详情名称显示为FHD Camera。