### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/deepin-devicemanager/assets/deepin-devicemanager.desktop
+++ b/deepin-devicemanager/assets/deepin-devicemanager.desktop
@@ -112,7 +112,7 @@ Name[sr]=Дипин Управник Уређаја
 Name[tr]=Deepin Aygıt Yöneticisi
 Name[ug]=ئۈسكۈنە باشقۇرغۇچ Deepin
 Name[uk]=Керування пристроями Deepin
-Name[zh_CN]=深度设备管理器
-Name[zh_HK]=Deepin 設備管理器
-Name[zh_TW]=Deepin 裝置管理器
+Name[zh_CN]=设备管理器
+Name[zh_HK]=設備管理器
+Name[zh_TW]=裝置管理器
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Enhancements:
- Standardize zh_CN/zh_HK/zh_TW Name and Comment translations in the desktop file by removing "深度"/"deepin" branding prefixes.