### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/deepin-devicemanager/assets/deepin-devicemanager.desktop
+++ b/deepin-devicemanager/assets/deepin-devicemanager.desktop
@@ -10,6 +10,7 @@ Terminal=false
 Type=Application
 X-Ayatana-Desktop-Shortcuts=deepin-devicemanager
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Mark deepin-devicemanager as a singleton application via its desktop file to enable correct handling by the application manager and Treeland.

New Features:
- Mark the deepin-devicemanager application as a singleton so the environment can treat it accordingly.

Enhancements:
- Update the desktop entry metadata to allow the application manager and Treeland to skip splash screens for singleton apps.