### PR TITLE
chore(ci): update actions/checkout to v7 and enable unsafe PR checkout

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update GitHub Actions checkout action from v2 to v7 for latest features. Add allow-unsafe-pr-checkout option for PR workflow compatibility.

更新 GitHub Actions checkout 到 v7 版本，启用 unsafe PR checkout 选项以提升 PR 工作流兼容性。

Log: 更新 cppcheck CI 工作流配置
Influence: CI 工作流使用最新的 checkout action，提升 PR 检测稳定性。