### PR TITLE
fix: add non-USB keyboard directly without VID/PID check

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceManager.cpp
@@ -1527,9 +1527,19 @@ void DeviceManager::addKeyboardDevice(DeviceInput *const device)
 
     QString vid = device->getVID();
     QString pid = device->getPID();
+    QString interface = device->getInterface();
+
+    // 仅USB键盘具备有效的VID/PID,需要通过lsusb校验以过滤无效/幽灵USB设备。
+    // PS/2、I2C、蓝牙等内置键盘没有VID/PID(hwinfo中为 "Vendor: 0xNNNN" 单段格式,
+    // 无法解析出VID/PID),应直接添加,避免被误删导致键盘无法显示。
+    if (!interface.contains("USB", Qt::CaseInsensitive)) {
+        m_ListDeviceKeyboard.append(device);
+        qCDebug(appLog) << "Non-USB keyboard added directly, interface:" << interface;
+        return;
+    }
 
     if (vid.isEmpty() || pid.isEmpty()) {
-        qCDebug(appLog) << "VID or PID is empty, adding keyboard device without verification";
+        qCDebug(appLog) << "USB keyboard VID or PID is empty, device not added";
         device->deleteLater();
         return;
     }


### PR DESCRIPTION
PS/2 and I2C keyboards in hwinfo use single-token Vendor/Device format (e.g. "Vendor: 0x0001") which cannot be parsed into VID/PID, causing addKeyboardDevice to drop them. Gate the VID/PID+lsusb verification to USB keyboards only; non-USB keyboards are appended directly.

PS/2、I2C 等内置键盘的 hwinfo 信息为 "Vendor: 0xNNNN" 单段格式，
无法解析出 VID/PID，导致 addKeyboardDevice 误删除。将 VID/PID+lsusb 校验限定为仅 USB 键盘，非 USB 键盘直接添加。

Log: 修复非USB键盘因缺少VID/PID无法显示的问题
PMS: BUG-368071
Influence: PS/2、I2C、蓝牙等内置键盘现在能正常显示在设备管理器中

## Summary by Sourcery

Bug Fixes:
- Prevent PS/2, I2C, Bluetooth and other non-USB keyboards from being incorrectly dropped due to missing VID/PID, allowing them to appear correctly in the device manager.