### PR TITLE
fix(gpu): fix GPU VRAM size parsing failure on multi-line gpu-info

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceGpu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -192,14 +192,14 @@ bool DeviceGpu::setHwinfoInfo(const QMap<QString, QString> &mapInfo)
         if (file.open(QIODevice::ReadOnly)) {
             qCDebug(appLog) << "gpu-info file opened successfully.";
             QString allStr(file.readAll());
-            QStringList items = allStr.split("\n\n");
+            QStringList items = allStr.split("\n");
             file.close();
             foreach (const QString &item, items) {
                 if (item.isEmpty()) {
                     // qCDebug(appLog) << "Skipping empty item in gpu-info.";
                     continue;
                 }
-                QStringList tmpItems = allStr.split(":", QT_SKIP_EMPTY_PARTS);
+                QStringList tmpItems = item.split(":", QT_SKIP_EMPTY_PARTS);
                 if (tmpItems.size() != 2) {
                     // qCDebug(appLog) << "Skipping item with incorrect size in gpu-info: " << item;
                     continue;


### PR DESCRIPTION
Split gpu-info by single "\n" and parse each line separately instead of splitting the whole content by "\n\n" and ":" on the entire string.

修复多行gpu-info文件显存大小解析失败的问题，改为逐行分割解析。

Log: 修复显存大小解析失败问题
PMS: BUG-372403
Influence: 修复后含多行的gpu-info文件能正确解析显存大小并显示。

## Summary by Sourcery

Fix GPU VRAM size parsing from multi-line gpu-info files by parsing each line separately.

Bug Fixes:
- Correct gpu-info parsing logic so VRAM size is properly extracted when the file contains multiple lines.

Enhancements:
- Update SPDX copyright header years for DeviceGpu.cpp.