### PR TITLE
fix(storage): widen disk size matching tolerance to ±2 GB

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -577,13 +577,13 @@ void DeviceStorage::checkDiskSize()
 
     quint64 gbyte =  1000000000;
 //    if (m_Interface.contains("UFS", Qt::CaseInsensitive)) { // TODO Ignore ufs disk
-    if (m_SizeBytes > 255*gbyte && m_SizeBytes < 257*gbyte) {
+    if (m_SizeBytes > 254*gbyte && m_SizeBytes < 258*gbyte) {
         m_Size = "256 GB";
-    } else if (m_SizeBytes > 511*gbyte && m_SizeBytes < 513*gbyte) {
+    } else if (m_SizeBytes > 510*gbyte && m_SizeBytes < 514*gbyte) {
         m_Size = "512 GB";
-    } else if (m_SizeBytes > 999*gbyte && m_SizeBytes < 1025*gbyte) {
+    } else if (m_SizeBytes > 998*gbyte && m_SizeBytes < 1026*gbyte) {
         m_Size = "1 TB";
-    } else if (m_SizeBytes > 1999*gbyte && m_SizeBytes < 2049*gbyte) {
+    } else if (m_SizeBytes > 1998*gbyte && m_SizeBytes < 2050*gbyte) {
         m_Size = "2 TB";
     }
 //    }


### PR DESCRIPTION
Adjust the nominal disk capacity boundaries in checkDiskSize() from ±1 GB to ±2 GB so that storage devices whose reported byte count deviates slightly more from the nominal value are still matched to the standard 256 GB / 512 GB / 1 TB / 2 TB labels.

将 checkDiskSize() 中磁盘容量匹配的上下限容差从 ±1 GB 调整为
±2 GB，使上报字节数偏离标称值稍大的存储设备仍能匹配到标准的
256 GB / 512 GB / 1 TB / 2 TB 标签。

Log: 调整磁盘容量匹配上下限至±2GB
PMS: 372871
Influence: checkDiskSize 的容量匹配逻辑，影响定制机型存储设备的容量显示规范化

## Summary by Sourcery

Bug Fixes:
- Adjust disk capacity matching tolerance from approximately ±1 GB to ±2 GB when mapping raw byte sizes to 256 GB, 512 GB, 1 TB, and 2 TB labels to better handle devices with larger nominal deviations.