### PR TITLE
fix(cpu): format CPU frequency range with two decimals

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp
@@ -303,9 +303,9 @@ void DeviceCpu::setInfoFromLscpu(const QMap<QString, QString> &mapInfo)
         // 如果最大最小频率相等则不显示范围
         if (fabs(minHz - maxHz) < 0.001) {
             m_FrequencyIsRange = false;
-            m_Frequency = maxHz > 1 ? QString("%1 GHz").arg(maxHz) : QString("%1 MHz").arg(maxHz * 1000);
+            m_Frequency = maxHz > 1 ? QString("%1 GHz").arg(maxHz, 0, 'f', 2) : QString("%1 MHz").arg(maxHz * 1000, 0, 'f', 2);
         } else {
-            m_Frequency = QString("%1-%2 GHz").arg(minHz).arg(maxHz);
+            m_Frequency = QString("%1-%2 GHz").arg(minHz, 0, 'f', 2).arg(maxHz, 0, 'f', 2);
         }
     } else if (mapInfo.find("CPU MHz") != mapInfo.end()) {
         QString maxS = mapInfo["CPU MHz"];

--- a/deepin-devicemanager/tests/src/DeviceManager/ut_devicecpu.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_devicecpu.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2019 ~ 2020 UnionTech Software Technology Co.,Ltd
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -263,7 +262,7 @@ TEST_F(UT_DeviceCpu, UT_DeviceCpu_setInfoFromLscpu_002)
     EXPECT_STREQ("VT-x", m_deviceCpu->m_HardwareVirtual.toStdString().c_str());
     EXPECT_STREQ("0", m_deviceCpu->m_PhysicalID.toStdString().c_str());
     EXPECT_STREQ("0", m_deviceCpu->m_CoreID.toStdString().c_str());
-    EXPECT_STREQ("0.8-4.2 GHz", m_deviceCpu->m_Frequency.toStdString().c_str());
+    EXPECT_STREQ("0.80-4.20 GHz", m_deviceCpu->m_Frequency.toStdString().c_str());
     EXPECT_STREQ("MMX SSE SSE2 SSE3 3D Now SSE4 SSSE3 SSE4_1 SSE4_2 AMD64 EM64T ", m_deviceCpu->m_Extensions.toStdString().c_str());
     EXPECT_TRUE(m_deviceCpu->m_FrequencyIsRange);
 }
@@ -293,7 +292,7 @@ TEST_F(UT_DeviceCpu, UT_DeviceCpu_setInfoFromLscpu_003)
     EXPECT_STREQ("VT-x", m_deviceCpu->m_HardwareVirtual.toStdString().c_str());
     EXPECT_STREQ("0", m_deviceCpu->m_PhysicalID.toStdString().c_str());
     EXPECT_STREQ("0", m_deviceCpu->m_CoreID.toStdString().c_str());
-    EXPECT_STREQ("800 MHz", m_deviceCpu->m_Frequency.toStdString().c_str());
+    EXPECT_STREQ("800.00 MHz", m_deviceCpu->m_Frequency.toStdString().c_str());
     EXPECT_STREQ("MMX SSE SSE2 SSE3 3D Now SSE4 SSSE3 SSE4_1 SSE4_2 AMD64 EM64T ", m_deviceCpu->m_Extensions.toStdString().c_str());
     EXPECT_FALSE(m_deviceCpu->m_FrequencyIsRange);
 }


### PR DESCRIPTION
## 根因分析

`DeviceCpu::setInfoFromLscpu`（`deepin-devicemanager/src/DeviceManager/DeviceCpu.cpp:306/308`）用 `QString::arg(double)` 的默认 `'g'`（6 位有效数字）格式显示由 MHz 换算得到的 GHz 值。兆芯 7000 等机型 lscpu 的 `CPU min/max MHz` 为非整数值，换算后两端按"有效数字"输出，小数位数不一致（如 `1.59997-2.8 GHz`），即 bug 所述"频率信息显示不统一"。`m_Frequency` 经概览表"频率"列（`:453`）与详情"Max Speed"（`:406`）两处展示，故界面可见。

关键证据：
1. `DeviceCpu.cpp:308` `QString("%1-%2 GHz").arg(minHz).arg(maxHz)` —— 默认 `'g'` 按有效数字输出，非整数 MHz 时两端小数位数不同。
2. `:453` / `:406` —— `m_Frequency` 写入概览表"频率"列与详情"Max Speed"，即用户所见。
3. 演算验证：1.599975 → `'g'6`="1.59997" vs `'f'2`="1.60"；2.8 → "2.8" vs "2.80"。

## 修复方案

将三处 `arg(double)` 改为 `arg(double, 0, 'f', 2)`（定点两位小数），频率范围统一为 `1.60-2.80 GHz`，直接消除小数位数不一致的根因。覆盖单值 GHz / 单值 MHz / 范围三种取值，不改变分支逻辑与阈值，改动最小。同步更新既有单测 `UT_DeviceCpu_setInfoFromLscpu_002`/`_003` 两条 `m_Frequency` 断言为新格式（`0.80-4.20 GHz` / `800.00 MHz`）。

## 改动安全评估

中风险：仅改输出格式与对应单测断言，函数签名不变，无生产调用方回归；历史提交 `fe4b2f678a`（修复"最大频率不显示单位"）的单位后缀被完整保留，不回滚。`UT_DeviceCpu_setInfoFromLscpu_002`/`_003`（`tests/src/DeviceManager/ut_devicecpu.cpp:266/296`）的两条断言已同步更新为新格式，与修复后的生产行为一致；其余单测断言（`4085.639 MHz`、`8300 MHz`）走未被改动的分支，无需调整。
