### PR TITLE
fix: fix missing wake option for PS/2 keyboard in device manager

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -505,7 +505,7 @@ QString DeviceInput::wakeupPath()
         return "";
     }
 
-    if (m_Name.contains("PS/2")) {
+    if (m_Name.contains("PS/2") || m_Interface.contains("PS/2")) {
         return "/proc/acpi/wakeup";
     } else {
         return QString("/sys") + m_SysPath.left(index) + QString("/power/wakeup");


### PR DESCRIPTION
## 根因分析

**结论：强根因**

`DeviceInput::wakeupPath()` (`DeviceInput.cpp:508`) 中 PS/2 设备判断条件与同文件的 `isWakeupMachine()` (`:484`) 不一致。`wakeupPath()` 仅判断 `m_Name.contains("PS/2")`，而 `isWakeupMachine()` 正确使用了 `m_Name.contains("PS/2") || m_Interface.contains("PS/2")`。

L420 内置 PS/2 键盘名称为 "AT Translated Set 2 keyboard"（不含 "PS/2" 字符串），导致 `wakeupPath()` 返回错误的 sysfs 路径 `/sys/.../power/wakeup`（该路径在 PS/2 设备上不存在），使 `canWakeupMachine()` 中 `QFile::open()` 失败返回 `false`，右键菜单中"允许唤起电脑"选项因此被禁用。

关键证据：
- `DeviceInput.cpp:508` — `wakeupPath()` 仅判断 `m_Name`
- `DeviceInput.cpp:484` — `isWakeupMachine()` 判断 `m_Name || m_Interface`
- `DBusWakeupInterface.cpp:50` 注释明确：PS/2 设备只能通过 ACPI 接口控制，无 sysfs wakeup 节点

## 修复方案

在 `wakeupPath()` 的 PS/2 判断中增加 `m_Interface.contains("PS/2")`，与 `isWakeupMachine()` 逻辑对齐：

```cpp
// 修改前
if (m_Name.contains("PS/2")) {

// 修改后
if (m_Name.contains("PS/2") || m_Interface.contains("PS/2")) {
```

## 改动安全评估

**低风险**。仅扩展 PS/2 判断条件，函数签名不变。所有调用者（`canWakeupMachine()`、`isWakeupMachine()`、`PageMultiInfo::getTableListInfo()`）均受益或不受影响，无历史回归风险。

## Summary by Sourcery

Fix PS/2 keyboard wakeup detection so the device-manager wake option is available for supported keyboards.

Bug Fixes:
- Restore the device-manager wake option for PS/2 keyboards whose device name does not include “PS/2” by selecting the correct ACPI wakeup path from the interface identifier.

Chores:
- Update the copyright year range for DeviceInput.cpp.