### PR TITLE
test: 增量补全未覆盖访问器单元测试（Device vendor/DriverInfo getters，批次 2）

### DIFF
--- a/deepin-devicemanager/tests/src/DeviceManager/ut_deviceinfo_base_extra.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_deviceinfo_base_extra.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 增量补全：覆盖 DeviceBaseInfo 基类中此前未覆盖的 setEnable（基类默认实现恒返回 EDS_Success）。
+// 通过限定名调用基类版本，避免命中子类 override。
+
+#include "DevicePrint.h"
+#include "DeviceInfo.h"
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <QCoreApplication>
+
+#include <gtest/gtest.h>
+
+TEST(UT_DeviceBaseInfoExtra, SetEnable_BaseImpl_ReturnsSuccess)
+{
+    DevicePrint *d = new DevicePrint;
+    // 限定调用基类 DeviceBaseInfo::setEnable，覆盖基类默认实现
+    EnableDeviceStatus ret = d->DeviceBaseInfo::setEnable(true);
+    EXPECT_EQ(EDS_Success, ret);
+    delete d;
+}

--- a/deepin-devicemanager/tests/src/DeviceManager/ut_devicevendor_extra.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_devicevendor_extra.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 增量补全：集中覆盖各 DeviceXxx 子类的 vendor()/chip_name()/tomlname() 访问器。
+// 这些均为返回成员变量的简单 getter，利用 -fno-access-control 直接设置基类/子类
+// 受保护成员后调用 getter 校验返回值。
+
+#include "DeviceInfo.h"
+#include "DeviceAudio.h"
+#include "DeviceBios.h"
+#include "DeviceBluetooth.h"
+#include "DeviceCdrom.h"
+#include "DeviceComputer.h"
+#include "DeviceGpu.h"
+#include "DeviceImage.h"
+#include "DeviceInput.h"
+#include "DeviceMemory.h"
+#include "DeviceMonitor.h"
+#include "DeviceOtherPCI.h"
+#include "DeviceOthers.h"
+#include "DevicePower.h"
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <QCoreApplication>
+
+#include <gtest/gtest.h>
+
+// DeviceAudio::chip_name() -> m_Chip ; vendor() -> m_Vendor
+TEST(UT_DeviceVendorExtra, DeviceAudio_ChipNameAndVendor_ReturnMembers)
+{
+    DeviceAudio *d = new DeviceAudio;
+    d->m_Chip = "ALC892";
+    d->m_Vendor = "Realtek";
+    EXPECT_STREQ("ALC892", d->chip_name().toStdString().c_str());
+    EXPECT_STREQ("Realtek", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceBios::tomlname() -> m_tomlName
+TEST(UT_DeviceVendorExtra, DeviceBios_Tomlname_ReturnsMember)
+{
+    DeviceBios *d = new DeviceBios;
+    d->m_tomlName = "bios";
+    EXPECT_STREQ("bios", d->tomlname().toStdString().c_str());
+    delete d;
+}
+
+// DeviceBluetooth::vendor()
+TEST(UT_DeviceVendorExtra, DeviceBluetooth_Vendor_ReturnsMember)
+{
+    DeviceBluetooth *d = new DeviceBluetooth;
+    d->m_Vendor = "Intel";
+    EXPECT_STREQ("Intel", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceCdrom::vendor()
+TEST(UT_DeviceVendorExtra, DeviceCdrom_Vendor_ReturnsMember)
+{
+    DeviceCdrom *d = new DeviceCdrom;
+    d->m_Vendor = "ASUS";
+    EXPECT_STREQ("ASUS", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceComputer::vendor()
+TEST(UT_DeviceVendorExtra, DeviceComputer_Vendor_ReturnsMember)
+{
+    DeviceComputer *d = new DeviceComputer;
+    d->m_Vendor = "Dell";
+    EXPECT_STREQ("Dell", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceGpu::vendor()
+TEST(UT_DeviceVendorExtra, DeviceGpu_Vendor_ReturnsMember)
+{
+    DeviceGpu *d = new DeviceGpu;
+    d->m_Vendor = "NVIDIA";
+    EXPECT_STREQ("NVIDIA", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceImage::vendor()
+TEST(UT_DeviceVendorExtra, DeviceImage_Vendor_ReturnsMember)
+{
+    DeviceImage *d = new DeviceImage;
+    d->m_Vendor = "Canon";
+    EXPECT_STREQ("Canon", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceInput::vendor()
+TEST(UT_DeviceVendorExtra, DeviceInput_Vendor_ReturnsMember)
+{
+    DeviceInput *d = new DeviceInput;
+    d->m_Vendor = "Logitech";
+    EXPECT_STREQ("Logitech", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceMemory::vendor()
+TEST(UT_DeviceVendorExtra, DeviceMemory_Vendor_ReturnsMember)
+{
+    DeviceMemory *d = new DeviceMemory;
+    d->m_Vendor = "Kingston";
+    EXPECT_STREQ("Kingston", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceMonitor::vendor()
+TEST(UT_DeviceVendorExtra, DeviceMonitor_Vendor_ReturnsMember)
+{
+    DeviceMonitor *d = new DeviceMonitor;
+    d->m_Vendor = "Dell";
+    EXPECT_STREQ("Dell", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceOtherPCI::vendor()
+TEST(UT_DeviceVendorExtra, DeviceOtherPCI_Vendor_ReturnsMember)
+{
+    DeviceOtherPCI *d = new DeviceOtherPCI;
+    d->m_Vendor = "Broadcom";
+    EXPECT_STREQ("Broadcom", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DeviceOthers::vendor()
+TEST(UT_DeviceVendorExtra, DeviceOthers_Vendor_ReturnsMember)
+{
+    DeviceOthers *d = new DeviceOthers;
+    d->m_Vendor = "Other";
+    EXPECT_STREQ("Other", d->vendor().toStdString().c_str());
+    delete d;
+}
+
+// DevicePower::vendor()
+TEST(UT_DeviceVendorExtra, DevicePower_Vendor_ReturnsMember)
+{
+    DevicePower *d = new DevicePower;
+    d->m_Vendor = "APC";
+    EXPECT_STREQ("APC", d->vendor().toStdString().c_str());
+    delete d;
+}

--- a/deepin-devicemanager/tests/src/ut_driverinfo_macro_extra.cpp
+++ b/deepin-devicemanager/tests/src/ut_driverinfo_macro_extra.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 增量补全：覆盖 MacroDefinition.h 中 DriverInfo 结构体的 inline getter
+// （vendorName / modelName / driverName / backupFileName）。
+
+#include "MacroDefinition.h"
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <QCoreApplication>
+
+#include <gtest/gtest.h>
+
+TEST(UT_DriverInfoGetters, VendorName_ReturnsMember)
+{
+    DriverInfo di;
+    di.m_VendorName = "HP";
+    EXPECT_STREQ("HP", di.vendorName().toStdString().c_str());
+}
+
+TEST(UT_DriverInfoGetters, ModelName_ReturnsMember)
+{
+    DriverInfo di;
+    di.m_ModelName = "LaserJet";
+    EXPECT_STREQ("LaserJet", di.modelName().toStdString().c_str());
+}
+
+TEST(UT_DriverInfoGetters, DriverName_ReturnsMember)
+{
+    DriverInfo di;
+    di.m_DriverName = "hplip";
+    EXPECT_STREQ("hplip", di.driverName().toStdString().c_str());
+}
+
+TEST(UT_DriverInfoGetters, BackupFileName_ReturnsMember)
+{
+    DriverInfo di;
+    di.m_BackupFileName = "hplip_3.deb";
+    EXPECT_STREQ("hplip_3.deb", di.backupFileName().toStdString().c_str());
+}


### PR DESCRIPTION
## 增量补全未覆盖访问器单元测试（批次 2）

继续增量补全 GUI（deepin-devicemanager）中此前未覆盖的简单访问器函数。文件放在既有 `tests/src/` 下，构建通过 `file(GLOB_RECURSE)` 自动纳入，无需改动 CMakeLists。

### 本批次覆盖的方法
| 模块 | 类 | 新覆盖方法 |
|------|----|-----------|
| DeviceManager | DeviceAudio | `chip_name`, `vendor` |
| DeviceManager | DeviceBios | `tomlname` |
| DeviceManager | DeviceBluetooth/Cdrom/Computer/Gpu/Image/Input/Memory/Monitor/OtherPCI/Others/Power | `vendor` |
| DeviceManager | DeviceBaseInfo | `setEnable`（基类默认实现，限定名调用） |
| MacroDefinition | DriverInfo | `vendorName`, `modelName`, `driverName`, `backupFileName` |

### 构建与验证
- 编译：`make deepin-devicemanager-test` 通过
- 运行：新增 18 个用例全部通过

### 基线
- commit: `89825dcd` (2026-08-06) fix(gpu): fix GPU VRAM size parsing failure on multi-line gpu-info

> Draft PR，与批次 1（#727）文件互不重叠，无合并冲突。

## Summary by Sourcery

Add unit tests to cover previously untested accessor methods for device vendor and related getters in deepin-devicemanager.

Tests:
- Add UT_DeviceVendorExtra tests to verify vendor/chip_name/tomlname getters across multiple DeviceManager subclasses.
- Add UT_DriverInfoGetters tests to validate inline getter methods of the DriverInfo struct in MacroDefinition.
- Add UT_DeviceBaseInfoExtra test to ensure the DeviceBaseInfo::setEnable base implementation consistently returns EDS_Success.