### PR TITLE
ut: 覆盖率缺口补全单元测试（批次1）

### DIFF
--- a/deepin-devicemanager/tests/src/DeviceManager/ut_device_getters_covgap.cpp
+++ b/deepin-devicemanager/tests/src/DeviceManager/ut_device_getters_covgap.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// 覆盖率缺口补全：DeviceManager 模块下多个 Device* 类的 vendor() 等 getter
+// 此前未被任何用例调用，函数覆盖率为 0。本文件对各设备类做默认构造并调用其
+// 未覆盖的 getter：
+// - vendor() 等为 const 成员 getter，默认构造未填充硬件数据，返回空串；
+//   用例主要保证 getter 可被安全调用（函数覆盖），并验证默认语义。
+// - DeviceNetwork::canDisable/isWireless/hwAddress 与 DeviceStorage::getManfName/
+//   getOemName 含可判定的默认逻辑或查表逻辑，使用确定性断言。
+
+#include "DeviceAudio.h"
+#include "DeviceBios.h"
+#include "DeviceBluetooth.h"
+#include "DeviceCdrom.h"
+#include "DeviceComputer.h"
+#include "DeviceGpu.h"
+#include "DeviceImage.h"
+#include "DeviceInput.h"
+#include "DeviceMemory.h"
+#include "DeviceMonitor.h"
+#include "DeviceNetwork.h"
+#include "DeviceOtherPCI.h"
+#include "DeviceOthers.h"
+#include "DevicePower.h"
+#include "DevicePrint.h"
+#include "DeviceStorage.h"
+#include "DeviceInfo.h"
+#include "MacroDefinition.h"
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <gtest/gtest.h>
+
+// ---- vendor() getter 集群：默认构造后调用，验证不崩溃且返回 QString ----
+TEST(UT_Device_GettersCovGap, DeviceAudio_Vendor_DefaultCtorNoCrash)
+{
+    DeviceAudio device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceBluetooth_Vendor_DefaultCtorNoCrash)
+{
+    DeviceBluetooth device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceCdrom_Vendor_DefaultCtorNoCrash)
+{
+    DeviceCdrom device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceComputer_Vendor_DefaultCtorNoCrash)
+{
+    DeviceComputer device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceGpu_Vendor_DefaultCtorNoCrash)
+{
+    DeviceGpu device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceImage_Vendor_DefaultCtorNoCrash)
+{
+    DeviceImage device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceInput_Vendor_DefaultCtorNoCrash)
+{
+    DeviceInput device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceMemory_Vendor_DefaultCtorNoCrash)
+{
+    DeviceMemory device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceMonitor_Vendor_DefaultCtorNoCrash)
+{
+    DeviceMonitor device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceOtherPCI_Vendor_DefaultCtorNoCrash)
+{
+    DeviceOtherPCI device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceOthers_Vendor_DefaultCtorNoCrash)
+{
+    DeviceOthers device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DevicePower_Vendor_DefaultCtorNoCrash)
+{
+    DevicePower device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+TEST(UT_Device_GettersCovGap, DevicePrint_Vendor_DefaultCtorNoCrash)
+{
+    DevicePrint device;
+    EXPECT_NO_FATAL_FAILURE(device.vendor());
+}
+
+// ---- 非 vendor 的确定性 getter ----
+
+TEST(UT_Device_GettersCovGap, DeviceBios_Tomlname_DefaultCtorReturnsEmpty)
+{
+    DeviceBios device;
+    EXPECT_TRUE(device.tomlname().isEmpty());
+}
+
+TEST(UT_Device_GettersCovGap, DevicePrint_MakeAndModel_DefaultCtorReturnsEmpty)
+{
+    DevicePrint device;
+    EXPECT_TRUE(device.makeAndeModel().isEmpty());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceNetwork_Vendor_DefaultCtorReturnsEmpty)
+{
+    DeviceNetwork device;
+    EXPECT_TRUE(device.vendor().isEmpty());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceNetwork_IsWireless_DefaultCtorReturnsFalse)
+{
+    DeviceNetwork device;
+    EXPECT_FALSE(device.isWireless());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceNetwork_HwAddress_DefaultCtorReturnsEmpty)
+{
+    DeviceNetwork device;
+    EXPECT_TRUE(device.hwAddress().isEmpty());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceNetwork_CanDisable_EmptySysPathReturnsFalse)
+{
+    // canDisable: m_SysPath 为空时返回 false
+    DeviceNetwork device;
+    EXPECT_FALSE(device.canDisable());
+}
+
+TEST(UT_Device_GettersCovGap, DeviceStorage_GetManfName_KnownIdReturnsMappedVendor)
+{
+    DeviceStorage device;
+    // MANFID_TABLE 中 000001 -> Panasonic
+    EXPECT_EQ(device.getManfName("000001"), "Panasonic");
+}
+
+TEST(UT_Device_GettersCovGap, DeviceStorage_GetManfName_UnknownIdReturnsRawInput)
+{
+    DeviceStorage device;
+    // 查表未命中时返回原始输入
+    EXPECT_EQ(device.getManfName("zzz-unknown-manf"), "zzz-unknown-manf");
+}
+
+TEST(UT_Device_GettersCovGap, DeviceStorage_GetOemName_UnknownIdReturnsRawInput)
+{
+    DeviceStorage device;
+    EXPECT_EQ(device.getOemName("zzz-unknown-oem"), "zzz-unknown-oem");
+}

--- a/deepin-devicemanager/tests/src/GenerateDevice/ut_edidparser_hextobin.cpp
+++ b/deepin-devicemanager/tests/src/GenerateDevice/ut_edidparser_hextobin.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// 覆盖率缺口补全：EDIDParser::hexToBin 此前未被任何用例调用，函数覆盖率为 0。
+// 本文件补全该函数的用例，覆盖合法十六进制输入与边界输入。
+
+#include "EDIDParser.h"
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <gtest/gtest.h>
+
+// hexToBin 内部依次调用 hexToDec 与 decTobin，最终结果按 4 位对齐补零。
+TEST(UT_EDIDParser_HexToBin, HexToBin_TwoFF_ReturnsEightOnes)
+{
+    EDIDParser parser;
+    EXPECT_EQ(parser.hexToBin("FF"), "11111111");
+}
+
+TEST(UT_EDIDParser_HexToBin, HexToBin_SingleZero_ReturnsFourZeros)
+{
+    EDIDParser parser;
+    EXPECT_EQ(parser.hexToBin("0"), "0000");
+}
+
+TEST(UT_EDIDParser_HexToBin, HexToBin_SingleOne_ReturnsPaddedOne)
+{
+    EDIDParser parser;
+    EXPECT_EQ(parser.hexToBin("1"), "0001");
+}
+
+TEST(UT_EDIDParser_HexToBin, HexToBin_SingleA_ReturnsBinary1010)
+{
+    EDIDParser parser;
+    EXPECT_EQ(parser.hexToBin("A"), "1010");
+}
+
+TEST(UT_EDIDParser_HexToBin, HexToBin_EmptyInput_ReturnsFourZeros)
+{
+    EDIDParser parser;
+    EXPECT_EQ(parser.hexToBin(""), "0000");
+}

--- a/deepin-devicemanager/tests/src/Page/ut_pageinfo_packagehasinstalled.cpp
+++ b/deepin-devicemanager/tests/src/Page/ut_pageinfo_packagehasinstalled.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// 覆盖率缺口补全：PageInfo::packageHasInstalled 此前未被用例调用。
+// 该函数通过 `dpkg -s <pkg>` 判断包是否安装：已安装包 stdout 含 "installed"，
+// 不存在的包 stdout 为空（提示信息走 stderr）。PageInfo 为抽象基类，通过其派生类
+// PageMultiInfo 实例化后调用。
+
+#include "PageInfo.h"
+#include "PageMultiInfo.h"
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <gtest/gtest.h>
+
+TEST(UT_PageInfo_PackageHasInstalled, InstalledDpkgPackage_ReturnsTrue)
+{
+    PageMultiInfo *p = new PageMultiInfo;
+    PageInfo *info = dynamic_cast<PageInfo *>(p);
+    // dpkg 自身必然已安装
+    EXPECT_TRUE(info->packageHasInstalled("dpkg"));
+    delete p;
+}
+
+TEST(UT_PageInfo_PackageHasInstalled, NonExistentPackage_ReturnsFalse)
+{
+    PageMultiInfo *p = new PageMultiInfo;
+    PageInfo *info = dynamic_cast<PageInfo *>(p);
+    EXPECT_FALSE(info->packageHasInstalled("zzz-not-a-real-package-20260811"));
+    delete p;
+}

--- a/deepin-devicemanager/tests/src/Tool/ut_commontools_feedback.cpp
+++ b/deepin-devicemanager/tests/src/Tool/ut_commontools_feedback.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// 覆盖率缺口补全：CommonTools 的构造函数与静态 feedback() 此前未被用例调用。
+// - 构造函数仅做日志输出，构造对象即可覆盖。
+// - feedback() 内部构造 QDBusInterface 调用服务支持 DBus；测试环境无会话总线，
+//   QDBusInterface 无效、QDBusReply::isValid() 为 false，走 else 分支，函数体完整执行
+//   且不会阻塞或崩溃，因此可直接调用覆盖。
+
+#include "commontools.h"
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <gtest/gtest.h>
+
+TEST(UT_CommonTools_Feedback, Constructor_WithNullParent_ObjectCreated)
+{
+    CommonTools tools(nullptr);
+    EXPECT_NE(nullptr, &tools);
+}
+
+TEST(UT_CommonTools_Feedback, Constructor_WithParent_ObjectCreated)
+{
+    QObject parent;
+    CommonTools tools(&parent);
+    EXPECT_EQ(&parent, tools.parent());
+}
+
+TEST(UT_CommonTools_Feedback, Feedback_NoSessionBus_CompletesWithoutCrash)
+{
+    // 无 DBus 会话总线时，feedback 内部 DBus 调用即时返回无效应答，
+    // 函数走 false 分支正常结束。此处验证其可被安全调用。
+    EXPECT_NO_FATAL_FAILURE(CommonTools::feedback());
+}

--- a/deepin-devicemanager/tests/src/ut_driverinfo_getters.cpp
+++ b/deepin-devicemanager/tests/src/ut_driverinfo_getters.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// 覆盖率缺口补全：MacroDefinition.h 中 DriverInfo 结构的 backupFileName/modelName/
+// driverName/vendorName 四个内联 getter 此前未被调用，函数覆盖率为 0。
+// 本文件通过构造 DriverInfo 并回写成员，验证 getter 取值正确。
+
+#include "MacroDefinition.h"
+
+#include "ut_Head.h"
+#include "stub.h"
+
+#include <gtest/gtest.h>
+
+TEST(UT_DriverInfo_Getters, BackupFileName_SetValue_ReturnsSameValue)
+{
+    DriverInfo info;
+    info.m_BackupFileName = "nvidia-525-backup.deb";
+    EXPECT_EQ(info.backupFileName(), "nvidia-525-backup.deb");
+}
+
+TEST(UT_DriverInfo_Getters, ModelName_SetValue_ReturnsSameValue)
+{
+    DriverInfo info;
+    info.m_ModelName = "GeForce RTX 3060";
+    EXPECT_EQ(info.modelName(), "GeForce RTX 3060");
+}
+
+TEST(UT_DriverInfo_Getters, DriverName_SetValue_ReturnsSameValue)
+{
+    DriverInfo info;
+    info.m_DriverName = "nvidia-driver-525";
+    EXPECT_EQ(info.driverName(), "nvidia-driver-525");
+}
+
+TEST(UT_DriverInfo_Getters, VendorName_SetValue_ReturnsSameValue)
+{
+    DriverInfo info;
+    info.m_VendorName = "NVIDIA Corporation";
+    EXPECT_EQ(info.vendorName(), "NVIDIA Corporation");
+}
+
+// 默认构造后各 getter 应返回空串，验证默认值语义
+TEST(UT_DriverInfo_Getters, DefaultCtor_GettersReturnEmptyString)
+{
+    DriverInfo info;
+    EXPECT_TRUE(info.backupFileName().isEmpty());
+    EXPECT_TRUE(info.modelName().isEmpty());
+    EXPECT_TRUE(info.driverName().isEmpty());
+    EXPECT_TRUE(info.vendorName().isEmpty());
+}


### PR DESCRIPTION
## 概述

deepin-devicemanager 单元测试补全 —— 批次1（覆盖率缺口补全）。

本 PR 仅新增独立测试文件，不修改已有测试与源码；新增文件接入既有 `deepin-devicemanager/tests/src/` 目录，由 CMake 递归 glob 自动收录，无需改动共享 CMakeLists。

## 本批次覆盖的类与方法

| 类 / 文件 | 新增覆盖方法 | 说明 |
|---|---|---|
| EDIDParser | `hexToBin` | 十六进制转二进制，含合法与边界输入 |
| DriverInfo (MacroDefinition.h) | `backupFileName` / `modelName` / `driverName` / `vendorName` | 内联 getter 回写取值 |
| CommonTools | 构造函数、静态 `feedback()` | 无会话总线走 false 分支 |
| PageInfo | `packageHasInstalled` | dpkg -s 包查询 |
| DeviceAudio/Bluetooth/Cdrom/Computer/Gpu/Image/Input/Memory/Monitor/OtherPCI/Others/Power/Print | `vendor()` | 默认构造调用 getter |
| DeviceBios | `tomlname` | |
| DevicePrint | `makeAndeModel` | |
| DeviceNetwork | `vendor` / `isWireless` / `hwAddress` / `canDisable` | 含可判定默认逻辑 |
| DeviceStorage | `getManfName` / `getOemName` | 厂商 ID 查表 |

## 新增文件

- `tests/src/GenerateDevice/ut_edidparser_hextobin.cpp`
- `tests/src/ut_driverinfo_getters.cpp`
- `tests/src/Tool/ut_commontools_feedback.cpp`
- `tests/src/Page/ut_pageinfo_packagehasinstalled.cpp`
- `tests/src/DeviceManager/ut_device_getters_covgap.cpp`

## 验证

- 本地编译：Qt6 + Debug + 覆盖率（`CMAKE_COVERAGE_ARG=ON`，关闭 ASan），客户端测试目标编译链接通过。
- 本地运行：`QT_QPA_PLATFORM=offscreen`，整体 1137 用例，通过 1131，失败 6。
  - 6 项失败均为仓库既有用例，均与键盘/hwinfo/hciconfig 硬件信息相关，非本批次引入。
  - 本批次新增 37 用例全部通过。
- 函数覆盖率（lcov，仅统计 `src/`，排除 tests/3rdparty）：**87.3%(1324/1517) → 89.2%(1354/1517)**，+30 函数。
- 本批次使 8 个文件达到 100% 函数覆盖：EDIDParser.cpp / commontools.cpp / PageInfo.cpp / MacroDefinition.h / DeviceBios.cpp / DeviceNetwork.cpp / DevicePrint.cpp / DeviceStorage.cpp。

## 基线

- baseline_commit: `89825dcd`
- baseline_title: fix(gpu): fix GPU VRAM size parsing failure on multi-line gpu-info
- baseline_date: 2026-08-06

## 后续

本批次为多批次覆盖率补全的第一批。剩余约 163 个未覆盖函数（多为硬件相关 getter、虚析构、GUI 事件槽、lambdas 等）将按类/模块在后续批次与 PR 中继续补全。CI 运行中，详见检查状态。

## Summary by Sourcery

Add a first batch of unit tests to close coverage gaps in deepin-devicemanager without modifying production code.

New Features:
- Add EDIDParser::hexToBin unit tests covering normal and boundary hexadecimal inputs.
- Add unit tests for DriverInfo inline getters to verify default and assigned values.
- Add CommonTools constructor and static feedback() tests to exercise non-DBus and no-session-bus paths.
- Add PageInfo::packageHasInstalled tests via PageMultiInfo to validate dpkg-based installation detection.
- Add Device* and related getter tests (including DeviceNetwork and DeviceStorage) to cover default semantics and vendor/ID mapping logic.

Tests:
- Introduce multiple new test files under tests/src to raise overall function coverage and bring several core files to 100% coverage.