### PR TITLE
fix(storage): set disk size matching tolerance to -5% ~ +10%

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp
@@ -577,13 +577,13 @@ void DeviceStorage::checkDiskSize()
 
     quint64 gbyte =  1000000000;
 //    if (m_Interface.contains("UFS", Qt::CaseInsensitive)) { // TODO Ignore ufs disk
-    if (m_SizeBytes > 254*gbyte && m_SizeBytes < 258*gbyte) {
+    if (m_SizeBytes > 243*gbyte && m_SizeBytes < 282*gbyte) {
         m_Size = "256 GB";
-    } else if (m_SizeBytes > 510*gbyte && m_SizeBytes < 514*gbyte) {
+    } else if (m_SizeBytes > 486*gbyte && m_SizeBytes < 564*gbyte) {
         m_Size = "512 GB";
-    } else if (m_SizeBytes > 998*gbyte && m_SizeBytes < 1026*gbyte) {
+    } else if (m_SizeBytes > 950*gbyte && m_SizeBytes < 1100*gbyte) {
         m_Size = "1 TB";
-    } else if (m_SizeBytes > 1998*gbyte && m_SizeBytes < 2050*gbyte) {
+    } else if (m_SizeBytes > 1900*gbyte && m_SizeBytes < 2200*gbyte) {
         m_Size = "2 TB";
     }
 //    }


### PR DESCRIPTION
## 背景 / Background

延续 #372871（commit `dbd6782`）的工作，进一步调整 `checkDiskSize()` 中磁盘容量匹配的容差。

此前为固定 ±2 GB 容差，部分上报字节数偏离标称值更大的存储设备仍无法匹配到标准标签。本次调整为百分比容差 **-5% ~ +10%**。

## 改动 / Changes

`deepin-devicemanager/src/DeviceManager/DeviceStorage.cpp` 中 `checkDiskSize()` 四档容量匹配边界重算：

| 标称 | -5% 下限 | +10% 上限 | 边界（整数 GB） |
|------|---------|----------|----------------|
| 256 GB | 243.2 | 281.6 | 243 ~ 282 |
| 512 GB | 486.4 | 563.2 | 486 ~ 564 |
| 1 TB (1000) | 950 | 1100 | 950 ~ 1100 |
| 2 TB (2000) | 1900 | 2200 | 1900 ~ 2200 |

## 影响 / Influence

`checkDiskSize()` 的容量匹配逻辑，影响定制机型存储设备的容量显示规范化。

---

Log: 调整磁盘容量匹配容差范围为-5%~+10%
PMS: 372871

## Summary by Sourcery

Bug Fixes:
- Broaden disk size matching ranges so devices with larger byte-size deviations are correctly normalized to standard capacity labels.