### PR TITLE
fix(devicecontrol): rebind USB HID driver on device enable

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
@@ -15,6 +15,7 @@
 
 #include <QLoggingCategory>
 #include <QProcess>
+#include <QThread>
 #include <QDir>
 #include <QDBusConnection>
 #include <QFile>
@@ -332,16 +333,24 @@ bool ControlInterface::authorizedEnable(const QString &hclass, const QString &na
     }
     if (enable_device) {
         /*
-         启用的流程为：以 /devices/pci0000:00/0000:00:14.0/usb1/1-5/1-5:1.0 为例
-         第一步: 向 /sys/devices/pci0000:00/0000:00:14.0/usb1/1-5/1-5:1.0/authorized 文件中写 1
-         第二步: 向 /sys/devices/pci0000:00/0000:00:14.0/usb1/1-5/authorized 文件中写 0
-         第三步: 向 /sys/devices/pci0000:00/0000:00:14.0/usb1/1-5/authorized 文件中写 1
+         启用流程需等价于物理拔插的「断开—重连」，使 usbhid 重新绑定、
+         输入节点重建，否则鼠标启用后仍无响应（PMS 341577）。
+         以 /devices/pci0000:00/0000:00:14.0/usb1/1-5/1-5:1.0 为例
+         （path 为接口级路径 1-5:1.0，禁用时已向其 authorized 写 0）：
+         第一步: 向父设备 1-5/authorized 写 0，整设备去授权（断开等价），
+                 解绑所有接口驱动并销毁输入节点。
+         第二步: 等待内核完成去授权清理，避免与重新授权竞态导致输入
+                 设备无法恢复。
+         第三步: 向父设备 1-5/authorized 写 1，整设备重新授权（重连等价），
+                 重新枚举并探测接口驱动。
+         第四步: 向接口 1-5:1.0/authorized 写 1（禁用的直接逆操作），确保
+                 接口已授权（sysfs 条目在设备重新枚举后已重建，需重新打开）。
+         第五步: 触发 udev 重新处理该设备及其接口的 add 事件，模拟物理
+                 拔插产生的 udev 事件，确保输入设备节点被重建。
          */
-        // 第一步
-        file.write("1");
         file.close();
 
-        // 第二步
+        // 第一步：父设备去授权
         QFileInfo fi(path);
         QString pop = fi.path();
         QFile fpop("/sys" + pop + QString("/authorized"));
@@ -350,11 +359,24 @@ bool ControlInterface::authorizedEnable(const QString &hclass, const QString &na
         fpop.write("0");
         fpop.close();
 
-        // 第三步
+        // 第二步：等待去授权清理完成，避免去授权-重新授权竞态
+        QThread::msleep(100);
+
+        // 第三步：父设备重新授权
         if (!fpop.open(QIODevice::ReadWrite))
             return false;
         fpop.write("1");
         fpop.close();
+
+        // 第四步：显式重新授权接口（禁用的直接逆操作）
+        if (file.open(QIODevice::ReadWrite)) {
+            file.write("1");
+            file.close();
+        }
+
+        // 第五步：触发 udev 重新处理设备添加事件，确保输入设备节点重建
+        QProcess::execute("udevadm", QStringList() << "trigger"
+                          << "--action=add" << ("--syspath=" + QString("/sys") + pop));
 
         EnableSqlManager::getInstance()->removeDataFromAuthorizedTable(unique_id);
     } else {


### PR DESCRIPTION
# fix(devicecontrol): rebind USB HID driver on device enable

> PMS: [BUG-341577](https://pms.uniontech.com/bug-view-341577.html) · 目标分支 `develop/eagle` · 基线 `ccd4ab90`

## 问题现象

USB 鼠标在设备管理器中右键「禁用」后，右键「启用」仍无法使用，必须**物理拔插**才恢复。必现（飞腾 D3000M 平台）。

## 根因分析（强根因）

禁用后恢复 USB 鼠标的唯一代码路径是 `ControlInterface::authorizedEnable` 的启用分支（`controlinterface.cpp` 原三步序列）。该序列仅做「`/sys/.../authorized` 就地翻转」：

- 第一步给接口授权后，第二步立即对父设备去授权——**直接抹掉第一步**（整设备去授权会解绑所有接口）；
- 第二步去授权与第三步重新授权**紧邻，无 settle**；
- 全程**无显式的 HID/输入驱动重新绑定或重新探测**（无 `unbind/bind`、`udevadm trigger`）。

该就地翻转不等价于物理拔插的「断开—重连 + udev add」，usbhid 未被可靠重新绑定、输入节点未重建，故启用后鼠标无响应。

关键证据（`file:line`，基线 `develop/eagle@ccd4ab90`）：
- `controlinterface.cpp:361` — 禁用向**接口** `authorized` 写 `0`（解绑 usbhid）。
- `controlinterface.cpp:341 / 350 / 356` — 启用三步就地翻转；`:350` 抹掉 `:341`，无 settle。
- `controlinterface.cpp:365` — 启用仍 `return true`，前端据此标记「已启用」（UI 与实际不符）。
- `controlinterface.cpp:372-376` — 同文件旁证：`removeEnable` 用 `/sys/bus/pci/rescan` 做真正重新枚举，`authorizedEnable` 缺等价机制。

排除项：`:103` `sPath = path`（`480a9ef8`/Bug 316525 引入）破坏的是「换 USB 口」回查，与本 bug（同口禁用-启用）无关，为独立共存 bug，不在本次修复范围。

## 修复方案

重构 `authorizedEnable` 启用分支为「断开—重连」等价序列（仅改该函数内部，签名不变）：

1. **父设备去授权**（写 `0`）——整设备去授权，解绑所有接口驱动、销毁输入节点（断开等价）；
2. **settle**（`QThread::msleep(100)`）——等待内核完成去授权清理，避免去授权-重新授权竞态；
3. **父设备重新授权**（写 `1`）——整设备重新授权，重新枚举并探测接口驱动（重连等价）；
4. **显式重新授权接口**（写 `1`）——禁用的直接逆操作，确保接口已授权（sysfs 条目在重新枚举后重建，重新打开）；
5. **`udevadm trigger --action=add --syspath=...`**——模拟物理拔插产生的 udev add 事件，确保输入设备节点重建。

移除了被自身抹掉的旧第一步（接口写 1 被随后的父设备去授权覆盖）。

## 改动安全评估

低风险。`blame` 显示目标行全部归因于原始引入提交 `c0f83b6f`（非既有 bug 修复，无撤销风险）；`authorizedEnable` 唯一调用者是同文件 `enable()`（`:109`），签名不变、返回值语义不变，调用者不受负面影响。新增依赖为 Qt/系统标准设施（`QThread`、`udevadm`）。

## 验证建议

建议在复现机（飞腾 D3000M）验证：禁用 USB 鼠标 → 软件启用 → 滚动/点击可用（无需拔插）。可对照 `dmesg`/`udevadm monitor`/`ls /dev/input/` 确认启用后输入节点重建。

## Summary by Sourcery

Ensure USB HID devices are properly reinitialized when re-enabled via device manager by making the authorization sequence equivalent to a physical unplug-replug cycle.

Bug Fixes:
- Fix USB mouse remaining unusable after being disabled and re-enabled in the device manager by reliably rebinding HID drivers and recreating input nodes.

Enhancements:
- Refine the USB device authorization workflow to deauthorize and reauthorize the parent device with a settle delay, explicitly reauthorize the interface, and trigger udev add events so input devices are consistently restored.