### PR TITLE
fix: guard detail "More" button click against stale list access

### DIFF
--- a/deepin-devicemanager/src/Page/PageDetail.cpp
+++ b/deepin-devicemanager/src/Page/PageDetail.cpp
@@ -211,9 +211,10 @@ void PageDetail::showDeviceInfo(const QList<DeviceBaseInfo *> &lstInfo)
         connect(txtBrowser, &TextBrowser::exportInfo, this, &PageDetail::exportInfo);
         connect(txtBrowser, &TextBrowser::copyAllInfo, this, &PageDetail::slotCopyAllInfo);
         addWidgets(txtBrowser, device->enable() && device->available() && !device->getOtherTranslationAttribs().isEmpty());
-        // 当添加到最后一个设备详细信息时，隐藏分隔符
-        if (device == lstInfo.last())
-            m_ListDetailSeperator[lstInfo.size() - 1]->setVisible(false);
+        // 当添加到最后一个设备详细信息时，隐藏分隔符。用last()而非lstInfo.size()-1，
+        // 因为if(!device) continue会跳过空设备，使链表实际长度可能小于lstInfo.size()
+        if (device == lstInfo.last() && !m_ListDetailSeperator.isEmpty())
+            m_ListDetailSeperator.last()->setVisible(false);
     }
     // 刷新展示页面时,滚动条还原
     mp_ScrollArea->verticalScrollBar()->setValue(0);
@@ -360,8 +361,9 @@ void PageDetail::clearWidget()
 
     QList<DetailButton *> listDetailButton = m_ListDetailButton;
     m_ListDetailButton.clear();
-    // 清空DetailButton
+    // 清空DetailButton，先断开clicked信号，避免延迟销毁期间旧按钮仍派发点击到slotBtnClicked
     foreach (auto widget, listDetailButton) {
+        disconnect(widget, &DetailButton::clicked, this, &PageDetail::slotBtnClicked);
         widget->deleteLater();
         widget = nullptr;
     }
@@ -395,16 +397,14 @@ void PageDetail::slotBtnClicked()
     DetailButton *button = qobject_cast<DetailButton *>(sender());
     if (!button)
         return;
-    int index = 0;
-    foreach (DetailButton *b, m_ListDetailButton) {
-        if (button == b)
-            break;
-        index++;
-    }
+
+    // 按钮可能因刷新重建已移出列表（clearWidget先清链表后deleteLater），此时忽略过期点击
+    int index = m_ListDetailButton.indexOf(button);
+    if (index < 0 || index >= m_ListTextBrowser.size())
+        return;
 
     // 改变按钮的状态，展开和收起的切换
-    if (button)
-        button->updateText();
+    button->updateText();
 
     // 显示内容发生相应变化，也就是是否显示其它信息
     TextBrowser *browser = m_ListTextBrowser[index];


### PR DESCRIPTION
## 根因分析

扩展模式（≥2 显示器）下显示设备页经 `PageInfoWidget::updateTable` 选中多设备页 `PageMultiInfo → PageDetail`，其"更多"按钮 `DetailButton(tr("More"))` 的槽 `PageDetail::slotBtnClicked`（`src/Page/PageDetail.cpp:393`）用 `foreach+break` 在 `m_ListDetailButton` 查按钮下标，**未校验是否命中**即 `m_ListTextBrowser[index]`（:410）取 `TextBrowser`；命中失败时 `index==size()` 越界读得野指针 → `browser->updateShowOtherInfo()` 解引用 → SEGV。

触发机理：刷新（启动 `DBus refreshInfo`+`singleShot(2000)` / 右键刷新 / 切页 / 扩展模式显示配置变化）走 `MainWindow::refresh → DeviceWidget::clear → PageDetail::clearWidget`；`clearWidget` 自 `ae0fff23`(Bug-162167) 起为「先清空成员链表、再对副本 `deleteLater`」——成员链表已空、旧按钮延迟销毁仍存活的时间窗内，其 `clicked` 派发到 `slotBtnClicked` → 空链表越界 → SEGV。与 `core.txt` 回溯 `QAbstractButton::clicked → activate → 3 帧自身代码 → SEGV` 及"仅扩展模式 / 闪退一次 / 概率性"现象一致。

关键证据：
- `PageDetail.cpp:399-404,410` — 查找无命中校验 + 越界 `m_ListTextBrowser[index]`。
- `PageInfoWidget.cpp:56-76` — `lst.size()>=2` 且非 BIOS → `PageMultiInfo`/`PageDetail`（扩展模式专属路径，区别于单屏 `PageSingleInfo`/`DetailTreeView`）。
- `log/core.txt` — `#4 QAbstractButton::clicked → #3 activate → #0..#2 deepin-devicemanager 自身`。

## 修复方案

1. **主修复**：`slotBtnClicked` 用 `m_ListDetailButton.indexOf(button)` 替换 `foreach+break`，命中且 `index < m_ListTextBrowser.size()` 才继续，否则 `return`（忽略过期/空链表点击）。
2. **加固**：`clearWidget` 在 `deleteLater()` 旧 `DetailButton` 前 `disconnect` 其 `clicked` 信号，从根源阻断「链表已空、旧按钮延迟销毁仍派发点击」的时间窗。
3. **同步修复**：`showDeviceInfo` 的 `m_ListDetailSeperator[lstInfo.size()-1]` 同类越界（`if(!device) continue` 致链表短于 `lstInfo.size()`），改用 `m_ListDetailSeperator.last()` 并判空。

## 改动安全评估

低风险。三处改动均在 `PageDetail.cpp`，无函数签名变更、无公开 API 变更、无删除公开成员。`slotBtnClicked` 仅 `PageDetail.h` 声明 + `ut_pagedetail.cpp:147` 直接调用（无 sender、空链表场景）：保留 `if(!button) return` 守卫在前，行为不变、既有 UT 仍通过。`clearWidget`/`showDeviceInfo` 调用者（`PageMultiInfo`）无感知。正常路径行为不变，仅修正「过期点击越界」「null 设备越界」两条异常路径（由崩溃→安全忽略）。

## 关联

- PMS: https://pms.uniontech.com/bug-view-308175.html
- 基线：`develop/eagle @ ccd4ab90`，本 commit 直接基于该基线
- 根因分析产物：本 Issue 附件 `analysis-report.md`；根因复核通过

## Summary by Sourcery

Guard PageDetail "More" button handling against stale widgets to prevent crashes when refreshing device info in multi-display mode.

Bug Fixes:
- Prevent out-of-bounds access in PageDetail::slotBtnClicked by validating the clicked button index against the text browser list.
- Avoid separator list index overflow in showDeviceInfo when some device entries are skipped.
- Eliminate crashes caused by delayed deletion of DetailButton instances by disconnecting their clicked signals before clearing.