### PR TITLE
fix: 修复处理器缓存显示与 lscpu 不一致 (#373521)

### DIFF
--- a/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
+++ b/deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp
@@ -1306,43 +1306,31 @@ void DeviceGenerator::calAndSetCpuHeaderInfo(const QMap<QString, QString> &first
         singleCpuHeaderInfo.push_back(threadPerCore);
     }
     if (firstProcessorInfo.contains("L1d cache")) {
-        QString strL1dCache = firstProcessorInfo.value("L1d cache");
-        int sharedCount = Common::parseSharedCpuCount(firstProcessorInfo.value("L1d shared cpu list"));
-        int groupCount = (sharedCount > 0 && logicalNum > 0) ? logicalNum / sharedCount : coreNum;
-        QString strTotalL1dCache = Common::formatTotalCache(strL1dCache, groupCount);
-        if (!strTotalL1dCache.isEmpty()) {
-            QPair<QString, QString> totalL1dCache(tr("L1d cache"), strTotalL1dCache);
-            singleCpuHeaderInfo.push_back(totalL1dCache);
+        QString strL1dCache = Common::formatCacheSize(firstProcessorInfo.value("L1d cache"));
+        if (!strL1dCache.isEmpty()) {
+            QPair<QString, QString> l1dCache(tr("L1d cache"), strL1dCache);
+            singleCpuHeaderInfo.push_back(l1dCache);
         }
     }
     if (firstProcessorInfo.contains("L1i cache")) {
-        QString strL1iCache = firstProcessorInfo.value("L1i cache");
-        int sharedCount = Common::parseSharedCpuCount(firstProcessorInfo.value("L1i shared cpu list"));
-        int groupCount = (sharedCount > 0 && logicalNum > 0) ? logicalNum / sharedCount : coreNum;
-        QString strTotalL1iCache = Common::formatTotalCache(strL1iCache, groupCount);
-        if (!strTotalL1iCache.isEmpty()) {
-            QPair<QString, QString> totalL1iCache(tr("L1i cache"), strTotalL1iCache);
-            singleCpuHeaderInfo.push_back(totalL1iCache);
+        QString strL1iCache = Common::formatCacheSize(firstProcessorInfo.value("L1i cache"));
+        if (!strL1iCache.isEmpty()) {
+            QPair<QString, QString> l1iCache(tr("L1i cache"), strL1iCache);
+            singleCpuHeaderInfo.push_back(l1iCache);
         }
     }
     if (firstProcessorInfo.contains("L2 cache")) {
-        QString strL2Cache = firstProcessorInfo.value("L2 cache");
-        int sharedCount = Common::parseSharedCpuCount(firstProcessorInfo.value("L2 shared cpu list"));
-        int groupCount = (sharedCount > 0 && logicalNum > 0) ? logicalNum / sharedCount : coreNum;
-        QString strTotalL2Cache = Common::formatTotalCache(strL2Cache, groupCount);
-        if (!strTotalL2Cache.isEmpty()) {
-            QPair<QString, QString> totalL2Cache(tr("L2 cache"), strTotalL2Cache);
-            singleCpuHeaderInfo.push_back(totalL2Cache);
+        QString strL2Cache = Common::formatCacheSize(firstProcessorInfo.value("L2 cache"));
+        if (!strL2Cache.isEmpty()) {
+            QPair<QString, QString> l2Cache(tr("L2 cache"), strL2Cache);
+            singleCpuHeaderInfo.push_back(l2Cache);
         }
     }
     if (firstProcessorInfo.contains("L3 cache")) {
-        QString strL3Cache = firstProcessorInfo.value("L3 cache");
-        int sharedCount = Common::parseSharedCpuCount(firstProcessorInfo.value("L3 shared cpu list"));
-        int groupCount = (sharedCount > 0 && logicalNum > 0) ? logicalNum / sharedCount : 1;
-        QString strTotalL3Cache = Common::formatTotalCache(strL3Cache, groupCount);
-        if (!strTotalL3Cache.isEmpty()) {
-            QPair<QString, QString> totalL3Cache(tr("L3 cache"), strTotalL3Cache);
-            singleCpuHeaderInfo.push_back(totalL3Cache);
+        QString strL3Cache = Common::formatCacheSize(firstProcessorInfo.value("L3 cache"));
+        if (!strL3Cache.isEmpty()) {
+            QPair<QString, QString> l3Cache(tr("L3 cache"), strL3Cache);
+            singleCpuHeaderInfo.push_back(l3Cache);
         }
     }
 

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -259,10 +259,10 @@ bool Common::isShowScreenSize()
     return showScreenSize;
 }
 
-QString Common::formatTotalCache(const QString &perThreadCache, int coreCount)
+QString Common::formatCacheSize(const QString &cacheSize)
 {
     // 1. 清理并分离数字与单位
-    QString s = perThreadCache.trimmed();
+    QString s = cacheSize.trimmed();
     if (s.isEmpty())
         return QString();
 
@@ -278,37 +278,35 @@ QString Common::formatTotalCache(const QString &perThreadCache, int coreCount)
     if (!ok)
         return QString();
 
-    // 2. 将单核/单线程缓存转换为 KiB
-    double perCoreKiB = 0.0;
+    // 2. 将缓存大小转换为 KiB（单实例大小，不再按实例数累加）
+    double cacheKiB = 0.0;
     if (unitStr.startsWith("K") || unitStr == "KB" || unitStr == "KIB") {
-        perCoreKiB = num;
+        cacheKiB = num;
     } else if (unitStr.startsWith("M") || unitStr == "MB" || unitStr == "MIB") {
-        perCoreKiB = num * 1024.0;
+        cacheKiB = num * 1024.0;
     } else if (unitStr.startsWith("G") || unitStr == "GB" || unitStr == "GIB") {
-        perCoreKiB = num * 1024.0 * 1024.0;
+        cacheKiB = num * 1024.0 * 1024.0;
     } else if (unitStr.startsWith("T") || unitStr == "TB" || unitStr == "TIB") {
-        perCoreKiB = num * 1024.0 * 1024.0 * 1024.0;
+        cacheKiB = num * 1024.0 * 1024.0 * 1024.0;
     } else if (unitStr.isEmpty() || unitStr == "B") {
         // 无单位或纯字节，视为字节并转为 KiB
-        perCoreKiB = num / 1024.0;
+        cacheKiB = num / 1024.0;
     } else {
         // 未知单位，按原数值当作 KiB 处理
-        perCoreKiB = num;
+        cacheKiB = num;
     }
-
-    double totalKiB = perCoreKiB * coreCount;
 
     // 3. 选择最合适的单位并格式化数值
     double value;
     QString unit;
-    if (totalKiB >= 1024.0 * 1024.0) {
-        value = totalKiB / (1024.0 * 1024.0);
+    if (cacheKiB >= 1024.0 * 1024.0) {
+        value = cacheKiB / (1024.0 * 1024.0);
         unit = "GiB";
-    } else if (totalKiB >= 1024.0) {
-        value = totalKiB / 1024.0;
+    } else if (cacheKiB >= 1024.0) {
+        value = cacheKiB / 1024.0;
         unit = "MiB";
     } else {
-        value = totalKiB;
+        value = cacheKiB;
         unit = "KiB";
     }
 
@@ -319,36 +317,6 @@ QString Common::formatTotalCache(const QString &perThreadCache, int coreCount)
     } else {
         return QString::number(value, 'f', 1) + " " + unit;
     }
-}
-
-int Common::parseSharedCpuCount(const QString &sharedCpuList)
-{
-    QString s = sharedCpuList.trimmed();
-    if (s.isEmpty())
-        return 0;
-
-    int count = 0;
-    QStringList parts = s.split(',', QString::SkipEmptyParts);
-    for (const QString &part : parts) {
-        QString trimmed = part.trimmed();
-        if (trimmed.contains('-')) {
-            QStringList range = trimmed.split('-');
-            if (range.size() == 2) {
-                bool ok1 = false, ok2 = false;
-                int start = range[0].trimmed().toInt(&ok1);
-                int end = range[1].trimmed().toInt(&ok2);
-                if (ok1 && ok2 && end >= start) {
-                    count += end - start + 1;
-                }
-            }
-        } else {
-            bool ok = false;
-            if (trimmed.toInt(&ok) || ok) {
-                count += 1;
-            }
-        }
-    }
-    return count;
 }
 
 QString Common::formatNetworkSpeed(const QString& speed)

--- a/deepin-devicemanager/src/commonfunction.h
+++ b/deepin-devicemanager/src/commonfunction.h
@@ -66,9 +66,7 @@ public:
     static QByteArray executeClientCmd(const QString& cmd, const QStringList& args = QStringList(), const QString& workPath = QString(), int msecsWaiting = 30000);
 
     static bool isShowScreenSize();
-    static QString formatTotalCache(const QString& perThreadCache, int coreCount);
-
-    static int parseSharedCpuCount(const QString &sharedCpuList);
+    static QString formatCacheSize(const QString& cacheSize);
 
     /**
      * @brief formatNetworkSpeed: Convert network speed units to Mbps


### PR DESCRIPTION
## 修复：设备管理器-处理器缓存与 lscpu 显示不一致（PMS Bug 373521）

### 问题
设备管理器「处理器」页面**顶部头部**的 L1d/L1i/L2/L3 缓存显示与终端 `lscpu` 不一致：头部把**单实例缓存按实例数累加**成总量展示，而 `lscpu` 展示**单实例大小**。多核机型上每核私有缓存（L1d/L1i/L2）相差 N 倍（N=核数），L3 因被全部逻辑核共享（实例数=1）恰好一致。

实测（Loongson-3A6000，4 核/8 逻辑）：头部显示 `L1d=256 KiB / L1i=256 KiB / L2=1 MiB / L3=16 MiB`，lscpu 显示单实例 `64 KiB / 64 KiB / 256 KiB / 16 MiB`，L1d/L1i/L2 差 4 倍。

### 根因
- `DeviceGenerator::calAndSetCpuHeaderInfo`（`DeviceGenerator.cpp`）对 L1d/L1i/L2/L3 调用 `Common::formatTotalCache(单实例值, groupCount)`，`groupCount = logicalNum / sharedCount`，把单实例大小 ×实例数累加后展示。
- `Common::formatTotalCache`（`commonfunction.cpp`）关键乘法 `totalKiB = perCoreKiB * coreCount`。
- 而设备管理器自身的「逻辑处理器明细」本就展示单实例值（= lscpu），内部「头部累加 vs 明细单实例」割裂。

### 修复
- 头部 L1d/L1i/L2/L3 改为展示**单实例大小**（与 lscpu 口径对齐），不再 `× groupCount` 累加。
- 新增 `Common::formatCacheSize(cacheSize)`：单实例缓存大小单位归一化（KiB/MiB/GiB），复用原解析/归一化逻辑但去掉乘法。
- 移除不再使用的 `Common::formatTotalCache` 与 `Common::parseSharedCpuCount`（全仓仅此 4 处调用，已确认无其它引用/测试依赖）。

### 改动文件
- `deepin-devicemanager/src/GenerateDevice/DeviceGenerator.cpp` — 4 个缓存块改用 `formatCacheSize`，移除 sharedCount/groupCount 计算
- `deepin-devicemanager/src/commonfunction.cpp` — `formatTotalCache` → `formatCacheSize`（去乘法），移除 `parseSharedCpuCount`
- `deepin-devicemanager/src/commonfunction.h` — 声明同步

### 验证
- 两处改动文件用项目 CMake 生成的编译参数单独编译通过（`-Wall`，0 error / 0 warning）。
- `nm` 符号校验：`formatCacheSize` 已定义并被引用，无 `formatTotalCache`/`parseSharedCpuCount` 残留符号。
- 全量构建因环境缺 3rdparty Qt 私有头（`private/qzipreader_p.h`，与本次改动无关）未完成链接，但改动 TU 编译验证通过。

### 行为对比
| 缓存 | 修复前（头部，累加） | 修复后（头部，单实例） | lscpu |
|---|---|---|---|
| L1d | 256 KiB | 64 KiB | 64 KiB ✅ |
| L1i | 256 KiB | 64 KiB | 64 KiB ✅ |
| L2  | 1 MiB   | 256 KiB | 256 KiB ✅ |
| L3  | 16 MiB  | 16 MiB | 16 MiB ✅ |

Bug: https://pms.uniontech.com/bug-view-373521.html

## Summary by Sourcery

Align processor cache information in the device manager header with single-instance cache sizes reported by lscpu.

Bug Fixes:
- Correct CPU cache values in the device manager header to show per-instance sizes instead of multiplied totals, matching lscpu output.

Enhancements:
- Introduce a generic cache size formatting helper that normalizes cache units without relying on core or instance counts.
- Remove unused cache aggregation and shared-CPU parsing utilities from the common helpers interface.