### PR TITLE
fix(input): detect PS/2 wakeup by interface, not name only

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -437,12 +437,12 @@ EnableDeviceStatus DeviceInput::setEnable(bool e)
         }
         if(e){
             //鼠标启用时，唤醒能力打开
-            DBusWakeupInterface::getInstance()->setWakeupMachine(wakeupID(), sysPath(), true, name(), m_HardwareClass);
+            DBusWakeupInterface::getInstance()->setWakeupMachine(wakeupID(), sysPath(), true, name(), m_HardwareClass, m_Interface);
             m_wakeupChanged = true;
 
         } else if (m_wakeupChanged) { //鼠标禁用时，唤醒能力关闭
             m_wakeupChanged = false;
-            DBusWakeupInterface::getInstance()->setWakeupMachine(wakeupID(), sysPath(), false, name(), m_HardwareClass);
+            DBusWakeupInterface::getInstance()->setWakeupMachine(wakeupID(), sysPath(), false, name(), m_HardwareClass, m_Interface);
         }
         bool res  = DBusEnableInterface::getInstance()->enable(m_HardwareClass, m_Name, m_SysPath, m_UniqueID, e, m_Driver);
         if (res) {
@@ -505,7 +505,7 @@ QString DeviceInput::wakeupPath()
         return "";
     }
 
-    if (m_Name.contains("PS/2")) {
+    if (m_Name.contains("PS/2") || m_Interface.contains("PS/2")) {
         return "/proc/acpi/wakeup";
     } else {
         return QString("/sys") + m_SysPath.left(index) + QString("/power/wakeup");

--- a/deepin-devicemanager/src/Page/PageMultiInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageMultiInfo.cpp
@@ -325,7 +325,7 @@ void PageMultiInfo::getTableListInfo(const QList<DeviceBaseInfo *> &lst, QList<Q
         if (input) {
             menuControl.append(input->canWakeupMachine() ? "true" : "false");
             menuControl.append(input->wakeupPath());
-            if (info->name().contains("PS/2")) {
+            if (info->name().contains("PS/2") || input->getInterface().contains("PS/2")) {
                 menuControl.append(input->getBusInfo());
                 menuControl.append(input->name());
                 menuControl.append(input->hardwareClass());

--- a/deepin-devicemanager/src/Page/PageSingleInfo.cpp
+++ b/deepin-devicemanager/src/Page/PageSingleInfo.cpp
@@ -359,8 +359,9 @@ void PageSingleInfo::slotWakeupMachine()
         DBusWakeupInterface::getInstance()->setWakeupMachine(input->wakeupID(),
                                                              input->sysPath(),
                                                              mp_WakeupMachine->isChecked(),
-                                                             input->getInterface(),
-                                                             input->hardwareClass());
+                                                             input->name(),
+                                                             input->hardwareClass(),
+                                                             input->getInterface());
     }
 
     // 网卡的远程唤醒

--- a/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.cpp
+++ b/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.cpp
@@ -39,14 +39,15 @@ bool DBusWakeupInterface::setWakeupMachine(const QString &unique_id,
                                            const QString &path,
                                            bool wakeup,
                                            const QString &name,
-                                           const QString &hardwareclass)
+                                           const QString &hardwareclass,
+                                           const QString &interfaceType)
 {
     if (nullptr != mp_InputIface && mp_InputIface->isValid()) {
         QStringList pathList = path.split("/", QString::SkipEmptyParts);
         if (pathList.size() < 3)
             return false;
 
-        if (name.contains("PS/2")) {
+        if (name.contains("PS/2") || interfaceType.contains("PS/2")) {
             // ps2设备无法通过/sys/devices/platform/i8042/serio1/power/wakeup控制，只能通过acpi的接口进行控制
             QDBusInterface interface(INPUT_SERVICE_NAME, INPUT_WAKEUP_SERVICE_PATH, INPUT_WAKEUP_PROPERTIES_INTERFACE, QDBusConnection::systemBus());
             if (interface.isValid()) {

--- a/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.h
+++ b/deepin-devicemanager/src/WakeupControl/DBusWakeupInterface.h
@@ -38,13 +38,17 @@ public:
      * @param unique_id 设备的唯一标识
      * @param path 设备节点路径
      * @param wakeup 可唤醒 不可唤醒
+     * @param name 设备名称
+     * @param hardwareclass 硬件类型(mouse/keyboard)
+     * @param interfaceType 接口类型(PS/2/USB/Bluetooth等)
      * @return
      */
     bool setWakeupMachine(const QString &unique_id,
                           const QString &path,
                           bool wakeup,
                           const QString &name,
-                          const QString &hardwareclass);
+                          const QString &hardwareclass,
+                          const QString &interfaceType);
 
     /**
      * @brief canWakeupMachine 获取input是否支持唤醒

--- a/deepin-devicemanager/src/Widget/TextBrowser.cpp
+++ b/deepin-devicemanager/src/Widget/TextBrowser.cpp
@@ -111,7 +111,7 @@ void TextBrowser::setWakeupMachine(bool wakeup)
     // 键盘鼠标唤醒机器
     DeviceInput *input = qobject_cast<DeviceInput*>(mp_Info);
     if(input && !input->wakeupID().isEmpty() && !input->sysPath().isEmpty()){
-        DBusWakeupInterface::getInstance()->setWakeupMachine(input->wakeupID(),input->sysPath(),wakeup, input->name(), input->hardwareClass());
+        DBusWakeupInterface::getInstance()->setWakeupMachine(input->wakeupID(),input->sysPath(),wakeup, input->name(), input->hardwareClass(), input->getInterface());
     }
 
     // 网卡的远程唤醒


### PR DESCRIPTION
## 根因分析

`DeviceInput::wakeupPath()`（`src/DeviceManager/DeviceInput.cpp:508`）判断 PS/2 时仅 `m_Name.contains("PS/2")`，与同文件 `isWakeupMachine()`（第 484 行 `m_Name.contains("PS/2") || m_Interface.contains("PS/2")`）不一致。L420 等机型的内置 PS/2 键盘 hwinfo 名称为 `"AT Translated Set 2 keyboard"`（不含 "PS/2"），而 `m_Interface = "PS/2"`，导致 `wakeupPath()` 走错分支返回 sysfs `/sys<syspath>/power/wakeup`（PS/2 设备无此节点）→ `canWakeupMachine()` 打开失败返回 false → 右键菜单"允许唤起电脑"被置灰。

关键证据：
- `DeviceInput.cpp:508` name-only 判定 vs `:484` name||interface 判定（同文件不一致即缺陷）。
- `DeviceInput.cpp:469-471` `canWakeupMachine()` 经 `wakeupPath()` 打开失败返回 false（能力门禁）。
- git 历史：`98b67c8e`（Bug 336943）已把姊妹函数 `isInputWakeupMachine()` 的 PS/2 判定改为按 `interfaceType` 判定并加 `hardwareClass` 区分 PS2M/PS2K，但未同步修正 `wakeupPath()`、`setWakeupMachine()`、`PageMultiInfo` 三处同源 name-only 判定，启用 PS/2 键盘唤醒菜单的意图被抵消。

## 修复方案

对齐三处同源 PS/2 name-only 判定，统一为 `name.contains("PS/2") || interface.contains("PS/2")`：

1. **`DeviceInput.cpp:508`**（主根因）`wakeupPath()` 加 `|| m_Interface.contains("PS/2")`，与 `isWakeupMachine():484` 对齐 → `canWakeupMachine()` 返回 true，菜单显示。
2. **`PageMultiInfo.cpp:328`** 加 `|| input->getInterface().contains("PS/2")` → 表格页 menuControl 正确追加 PS/2 设备的 hardwareClass/interface，唤醒状态查询不再恒为未勾选。
3. **`DBusWakeupInterface::setWakeupMachine()`** 扩展签名增加 `interfaceType` 形参，`name.contains("PS/2")` → `name.contains("PS/2") || interfaceType.contains("PS/2")`；同步 4 个调用点（`DeviceInput.cpp:440/445`、`TextBrowser.cpp:114`、`PageSingleInfo.cpp:359`）。其中 `PageSingleInfo.cpp:359` 原误将 `getInterface()` 传入 `name` 形参（历史遗留），一并纠正为 `name()` + `getInterface()`。该签名扩展与 `98b67c8e` 对 `isInputWakeupMachine` 的改造同模式，`name` 形参仍用于判定故无新增 unused-param。

## 改动安全评估

风险等级：中（由 #3 的函数签名变更带来；#1/#2 为低风险单行加条件）。#3 经评估风险可控：有 `98b67c8e` 的成熟先例、4 处调用点全在仓内已同步、`name` 仅用于本次判定的 `contains` 检查、不变 DBus 协议（服务端 `ControlInterface::setWakeupMachine` 签名不变）、不撤销任何历史修复（相反补全了 `98b67c8e` 想做漏做的 `setWakeupMachine` 侧）。

PMS: https://pms.uniontech.com/bug-view-294489.html

## Summary by Sourcery

Detect PS/2 wakeup devices by interface as well as name so PS/2 input wakeup controls work consistently.

Bug Fixes:
- Fix PS/2 input wakeup detection for devices whose interface identifies them as PS/2 even when their names do not.
- Correct wakeup capability and state handling for PS/2 devices across single-device, multi-device, and enable/disable flows.

Enhancements:
- Extend wakeup control calls to use both device names and interface types when selecting PS/2 wakeup handling, while correcting the single-device call arguments.