### PR TITLE
fix: strip input suffix from m_SysPath on mismatch

### DIFF
--- a/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
+++ b/deepin-devicemanager/src/DeviceManager/DeviceInput.cpp
@@ -239,6 +239,13 @@ bool DeviceInput::getPS2Syspath(const QString &dfs)
         }
     }
 
+    // 匹配失败时 m_SysPath 仍保留 hwinfo 原始 SysFS ID（含 /input/inputN 或 /inputN 后缀），
+    // 需剥离后缀得到正确设备 syspath，否则 wakeupPath() 等会拼出错误路径
+    if (m_SysPath.contains("i2c_designware"))
+        m_SysPath.remove(QRegExp("/input/input[0-9]{1,2}$"));
+    else
+        m_SysPath.remove(QRegExp("/input[0-9]{1,2}$"));
+
     return true;
 }
 


### PR DESCRIPTION
## Root Cause Analysis

In `DeviceInput::getPS2Syspath()` (`DeviceInput.cpp:200-240`), `m_SysPath` is only reassigned when the event-number match against `/proc/bus/input/devices` succeeds. When the match fails, `m_SysPath` retains the raw hwinfo "SysFS ID" value, which carries an extra `/input/inputN` (i2c_designware) or `/inputN` suffix. Downstream `wakeupPath()` then builds `/sys/.../input/power/wakeup` (an extra `input` layer) which does not exist, so `canWakeupMachine()` returns false and the right-click menu item "允许唤出电脑" (Allow waking up computer) is greyed out. Connecting an external keyboard shifts input device enumeration, causing the event-number mismatch between `hwinfo --keyboard` and `/proc/bus/input/devices`. PS/2 and L2C keyboards share the same `setInfoFromHwinfo` → `getPS2Syspath` path, which is why both are affected.

## Fix Approach

Add an idempotent fallback at the end of `getPS2Syspath()` (before `return true`) that strips the trailing `/input/inputN` (for i2c_designware) or `/inputN` suffix from `m_SysPath`. Normalizing at the source fixes both the client-side `wakeupPath()` check and the server-side `DBusWakeupInterface::setWakeupMachine()` call that receives `sysPath()`, matching the analysis report's Method A recommendation.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The `m_SysPath = regfs.cap(1)` assignment (line 236) has been untouched since its introduction (commit `be1e8349`, 2022-03-08); this change does not revert any historical fix — related bugs (172035, 147047, 147393) target different code paths (USB mouse DBus, serial ID logic).
- Highest-risk affected callers: `wakeupPath()` (`DeviceInput.cpp:408`) and `setWakeupMachine()` (`PageSingleInfo.cpp:351`, `TextBrowser.cpp:114`) — both are positively fixed by the normalized path. The strip is idempotent (no-op when the suffix is already absent on a successful match).

### Business Impact Scope

Device Manager — keyboard/mouse "Allow waking up computer": the right-click context menu for PS/2 and L2C keyboards. After attaching an external keyboard the menu item must appear enabled and toggle correctly; the server-side wake-up DBus call must receive a valid sysfs path.

### Verification Suggestion

Test with and without an external keyboard: confirm the "允许唤出电脑" menu item is enabled for both PS/2 and L2C (i2c_designware) keyboards, and that wake-from-keyboard still functions as a regression check.

---

## 根因分析

`DeviceInput::getPS2Syspath()`（`DeviceInput.cpp:200-240`）仅在 event 号与 `/proc/bus/input/devices` 匹配成功时才重新赋值 `m_SysPath`；匹配失败时 `m_SysPath` 仍保留 hwinfo 原始 "SysFS ID" 值，带有多余的 `/input/inputN`（i2c_designware）或 `/inputN` 后缀。下游 `wakeupPath()` 据此拼出 `/sys/.../input/power/wakeup`（多一层 `input`），该文件不存在，`canWakeupMachine()` 返回 false，右键菜单项"允许唤出电脑"被置灰。外接键盘改变输入设备枚举，导致 `hwinfo --keyboard` 与 `/proc/bus/input/devices` 的 event 号不一致而匹配失败。PS/2 与 L2C 键盘走同一 `setInfoFromHwinfo` → `getPS2Syspath` 路径，故两者同时受影响。

## 修复方案

在 `getPS2Syspath()` 末尾（`return true` 之前）新增幂等的兜底逻辑，剥离 `m_SysPath` 尾部的 `/input/inputN`（i2c_designware）或 `/inputN` 后缀。在源头规范化 `m_SysPath`，一次性修复客户端 `wakeupPath()` 检查与服务端 `DBusWakeupInterface::setWakeupMachine()` 调用两条路径，与分析报告 Method A 建议一致。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- `m_SysPath = regfs.cap(1)`（第 236 行）自引入以来（commit `be1e8349`，2022-03-08）未被修改，本次修复不撤销任何历史修复——关联 bug（172035、147047、147393）走的是 USB 鼠标 DBus、序列号获取等不同路径。
- 受影响最高风险调用者：`wakeupPath()`（`DeviceInput.cpp:408`）与 `setWakeupMachine()`（`PageSingleInfo.cpp:351`、`TextBrowser.cpp:114`）均被正面修复；剥离幂等，匹配成功时后缀已不存在，remove 为空操作。

### 业务影响范围

设备管理器 — 键鼠"允许唤出电脑"功能：PS/2 与 L2C 键盘右键上下文菜单。外接键盘后菜单项应正常显示并可切换，服务端唤出 DBus 调用应收到正确 sysfs 路径。

### 验证建议

分别在不外接与外接键盘环境下测试：确认 PS/2 与 L2C（i2c_designware）键盘"允许唤出电脑"菜单项可用，并回归验证键盘唤出功能正常。

PMS: BUG-294489

## Summary by Sourcery

Bug Fixes:
- Normalize PS/2 and L2C keyboard sysfs paths when device matching fails, restoring valid wake-up detection and enabling the computer-wake menu action.