### PR TITLE
fix: honor DISABLE_DRIVER in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
    set(CMAKE_INSTALL_PREFIX /usr)
 endif()
 
-set(DISABLE_DRIVER false CACHE BOOL "disable driver")
-if (DISABLE_DRIVER)
+option(DISABLE_DRIVER "Disable driver support" OFF)
+if(DISABLE_DRIVER)
     add_definitions(-DDISABLE_DRIVER)
 endif()
 

--- a/deepin-devicemanager-server/deepin-devicecontrol/CMakeLists.txt
+++ b/deepin-devicemanager-server/deepin-devicecontrol/CMakeLists.txt
@@ -31,6 +31,10 @@ endforeach()
 
 file(GLOB_RECURSE SRC_CPP ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
 file(GLOB_RECURSE SRC_H ${CMAKE_CURRENT_LIST_DIR}/src/*.h)
+if(DISABLE_DRIVER)
+    list(FILTER SRC_CPP EXCLUDE REGEX "/drivercontrol/")
+    list(FILTER SRC_H EXCLUDE REGEX "/drivercontrol/")
+endif()
   
 # Find Qt package with detected version
 find_package(PkgConfig REQUIRED)
@@ -57,10 +61,9 @@ endif()
 # Find external dependencies
 find_package(${POLKITQT_NAME} REQUIRED)
 find_package(deepin-qdbus-service REQUIRED)
-find_package(${QAPT_NAME} REQUIRED)
-include_directories(${${QAPT_NAME}_INCLUDE_DIRS})
-
 if(NOT DISABLE_DRIVER)
+    find_package(${QAPT_NAME} REQUIRED)
+    include_directories(${${QAPT_NAME}_INCLUDE_DIRS})
     PKG_SEARCH_MODULE(kmod REQUIRED libkmod IMPORTED_TARGET)
 endif()
 
@@ -84,7 +87,6 @@ if(${QT_VERSION_MAJOR} EQUAL 6)
         Qt${QT_VERSION_MAJOR}::Sql
         Qt${QT_VERSION_MAJOR}::Gui
         ${deepin-qdbus-service_INCLUDE_DIR}
-        ${QAPT_NAME}
     )
 
     target_link_libraries(${BIN_NAME} PRIVATE
@@ -96,7 +98,6 @@ if(${QT_VERSION_MAJOR} EQUAL 6)
         Dtk${DTK_VERSION_MAJOR}::Core
         Dtk${DTK_VERSION_MAJOR}::Widget
         ${deepin-qdbus-service_LIBRARIES}
-        ${QAPT_NAME}
         cups
     )
 elseif(${QT_VERSION_MAJOR} EQUAL 5)
@@ -124,7 +125,7 @@ if(NOT DISABLE_DRIVER)
     target_link_libraries(${BIN_NAME} PRIVATE
         kmod
         ${QAPT_NAME}
-        )
+    )
 endif()
 
 install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/deepin-devicemanager-server/deepin-deviceinfo/CMakeLists.txt
+++ b/deepin-devicemanager-server/deepin-deviceinfo/CMakeLists.txt
@@ -57,8 +57,10 @@ endif()
 
 # Find external dependencies
 find_package(${POLKITQT_NAME} REQUIRED)
-find_package(${QAPT_NAME} REQUIRED)
-include_directories(${${QAPT_NAME}_INCLUDE_DIRS})
+if(NOT DISABLE_DRIVER)
+    find_package(${QAPT_NAME} REQUIRED)
+    include_directories(${${QAPT_NAME}_INCLUDE_DIRS})
+endif()
 
 add_library(${BIN_NAME} MODULE
     ${SRC_CPP}
@@ -70,7 +72,6 @@ if(${QT_VERSION_MAJOR} EQUAL 6)
     target_include_directories(${BIN_NAME} PUBLIC
         Qt${QT_VERSION_MAJOR}::Core
         Qt${QT_VERSION_MAJOR}::DBus
-        ${QAPT_NAME}
     )
 
     target_link_libraries(${BIN_NAME} PRIVATE
@@ -80,7 +81,6 @@ if(${QT_VERSION_MAJOR} EQUAL 6)
         Qt${QT_VERSION_MAJOR}::DBus
         ${POLKITQT_NAME}::Agent
         ${Dtk6Core_LIBRARIES}
-        ${QAPT_NAME}
     )
 elseif(${QT_VERSION_MAJOR} EQUAL 5)
     target_include_directories(${BIN_NAME} PUBLIC
@@ -96,6 +96,9 @@ elseif(${QT_VERSION_MAJOR} EQUAL 5)
     )
 else()
     message(FATAL_ERROR "Unsupported QT_VERSION_MAJOR: ${QT_VERSION_MAJOR}")
+endif()
+if(NOT DISABLE_DRIVER AND ${QT_VERSION_MAJOR} EQUAL 6)
+    target_link_libraries(${BIN_NAME} PRIVATE ${QAPT_NAME})
 endif()
 
 

--- a/deepin-devicemanager-server/tests/CMakeLists.txt
+++ b/deepin-devicemanager-server/tests/CMakeLists.txt
@@ -81,7 +81,6 @@ macro(SET_QT_VERSION)
     find_package(Qt5Network REQUIRED)
     find_package(DtkCore REQUIRED)
     find_package(PolkitQt5-1 REQUIRED)
-    find_package(QApt REQUIRED)
   else()
     message(FATAL_ERROR "Unsupported QT_VERSION: ${QT_VERSION}")
   endif()
@@ -90,19 +89,21 @@ endmacro()
 # 调用宏
 SET_QT_VERSION()
 
-if(${QT_VERSION_MAJOR} EQUAL 6)
-    find_package(QApt-qt6 REQUIRED)
-    include_directories(${QApt-qt6_INCLUDE_DIRS})
-    set(QAPT_LIB QApt-qt6)
-elseif(${QT_VERSION_MAJOR} EQUAL 5)
-    find_package(QApt REQUIRED)
-    include_directories(${QApt_INCLUDE_DIRS})
-    set(QAPT_LIB QApt)
-else()
-    message(FATAL_ERROR "Unsupported QT_VERSION: ${QT_VERSION_MAJOR}")
-endif()
+if(NOT DISABLE_DRIVER)
+    if(${QT_VERSION_MAJOR} EQUAL 6)
+        find_package(QApt-qt6 REQUIRED)
+        include_directories(${QApt-qt6_INCLUDE_DIRS})
+        set(QAPT_LIB QApt-qt6)
+    elseif(${QT_VERSION_MAJOR} EQUAL 5)
+        find_package(QApt REQUIRED)
+        include_directories(${QApt_INCLUDE_DIRS})
+        set(QAPT_LIB QApt)
+    else()
+        message(FATAL_ERROR "Unsupported QT_VERSION: ${QT_VERSION_MAJOR}")
+    endif()
 
-PKG_SEARCH_MODULE(kmod REQUIRED libkmod IMPORTED_TARGET)
+    PKG_SEARCH_MODULE(kmod REQUIRED libkmod IMPORTED_TARGET)
+endif()
 
 set(PROJECT_NAME_TEST
     ${PROJECT_NAME}-test)
@@ -119,6 +120,9 @@ file(GLOB_RECURSE CONTROL_SRCS
 # remove src main.cpp or will multi define
 list(REMOVE_ITEM INFO_SRCS ${CMAKE_CURRENT_LIST_DIR}/../deepin-deviceinfo/src/plugin.cpp)
 list(REMOVE_ITEM CONTROL_SRCS ${CMAKE_CURRENT_LIST_DIR}/../deepin-devicecontrol/src/main.cpp)
+if(DISABLE_DRIVER)
+    list(FILTER CONTROL_SRCS EXCLUDE REGEX "/drivercontrol/")
+endif()
 
 #test src
 file(GLOB_RECURSE TEST_SRC_CPP ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
@@ -150,8 +154,6 @@ if(${QT_VERSION_MAJOR} EQUAL 6)
     ${GTEST_MAIN_LIBRARIES}
     PolkitQt6-1::Agent
     pthread
-    kmod
-    ${QAPT_LIB}
     cups
     )
 elseif(${QT_VERSION_MAJOR} EQUAL 5)
@@ -170,12 +172,16 @@ elseif(${QT_VERSION_MAJOR} EQUAL 5)
     ${GTEST_MAIN_LIBRARIES}
     PolkitQt5-1::Agent
     pthread
-    kmod
-    ${QAPT_LIB}
     cups
     )
 else()
     message(FATAL_ERROR "Unsupported QT_VERSION: ${QT_VERSION_MAJOR}")
+endif()
+if(NOT DISABLE_DRIVER)
+    target_link_libraries(${PROJECT_NAME_TEST}
+        kmod
+        ${QAPT_LIB}
+    )
 endif()
 
 # 设置添加gocv相关信息的输出

--- a/deepin-devicemanager/CMakeLists.txt
+++ b/deepin-devicemanager/CMakeLists.txt
@@ -43,13 +43,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--as-needed -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2 -z noexecstack -pie -fPIC -z lazy")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 
-if(${QT_VERSION_MAJOR} EQUAL 6)
-    add_definitions(-DDISABLE_DRIVER)
-    message(STATUS "DISABLE_DRIVER macro added for Qt6 build")
-else()
-    message(STATUS "DISABLE_DRIVER macro NOT added for Qt5 build")
-endif()
-
 option (PERF_ON "Use provided math implementation" ON)
 
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
@@ -153,8 +146,10 @@ endif()
 
 # Find external dependencies
 find_package(${POLKITQT_NAME} REQUIRED)
-find_package(${QAPT_NAME} REQUIRED)
-include_directories(${${QAPT_NAME}_INCLUDE_DIRS})
+if(NOT DISABLE_DRIVER)
+    find_package(${QAPT_NAME} REQUIRED)
+    include_directories(${${QAPT_NAME}_INCLUDE_DIRS})
+endif()
 include_directories(${Qt${QT_VERSION_MAJOR}Gui_PRIVATE_INCLUDE_DIRS})
 
 # Tell CMake to create the executable
@@ -173,7 +168,6 @@ if(${QT_VERSION_MAJOR} EQUAL 6)
         Qt${QT_VERSION_MAJOR}::DBus
         Qt${QT_VERSION_MAJOR}::Xml
         Qt${QT_VERSION_MAJOR}::Network
-        ${QAPT_NAME}
         ${POLKITQT_NAME}::Agent
     )
 elseif(${QT_VERSION_MAJOR} EQUAL 5)
@@ -186,11 +180,13 @@ elseif(${QT_VERSION_MAJOR} EQUAL 5)
         Qt${QT_VERSION_MAJOR}::DBus
         Qt${QT_VERSION_MAJOR}::Xml
         Qt${QT_VERSION_MAJOR}::Network
-        ${QAPT_NAME}
         ${POLKITQT_NAME}::Agent
     )
 else()
     message(FATAL_ERROR "Unsupported QT_VERSION_MAJOR: ${QT_VERSION_MAJOR}")
+endif()
+if(NOT DISABLE_DRIVER)
+    target_link_libraries(${APP_BIN_NAME} ${QAPT_NAME})
 endif()
 
 # Install files

--- a/deepin-devicemanager/src/Page/MainWindow.cpp
+++ b/deepin-devicemanager/src/Page/MainWindow.cpp
@@ -526,6 +526,12 @@ void MainWindow::refreshDataBase()
 void MainWindow::slotSetPage(const QString &page)
 {
     qCDebug(appLog) << "MainWindow::slotSetPage page:" << page;
+#ifdef DISABLE_DRIVER
+    if ("driver" == page) {
+        qCInfo(appLog) << "Driver management is disabled";
+        return;
+    }
+#endif
     if ("driver" == page) {
         qCDebug(appLog) << "MainWindow::slotSetPage driver";
         if (m_IsFirstRefresh) {


### PR DESCRIPTION
The top-level option defines DISABLE_DRIVER for source code, but the build still required QApt and built driver-only sources. Make the option skip QApt/kmod discovery and driver-control sources, and ignore direct requests for the driver page when the feature is disabled.

## Summary by Sourcery

Make DISABLE_DRIVER fully control driver-related build dependencies, sources, and navigation behavior.

Bug Fixes:
- Honor the DISABLE_DRIVER option by ignoring direct requests to open the driver page when driver support is disabled.

Enhancements:
- Make driver support consistently optional across application, server, and test builds by excluding driver sources and conditionally handling QApt and kmod dependencies and linking.

Build:
- Expose DISABLE_DRIVER as a standard CMake option and prevent disabled-driver builds from requiring driver-specific dependencies.

Tests:
- Update test builds to omit driver sources and dependencies when driver support is disabled.