### PR TITLE
fix: link Qt CorePrivate for Qt 6.10+ QtXlsx builds

### DIFF
--- a/deepin-devicemanager/CMakeLists.txt
+++ b/deepin-devicemanager/CMakeLists.txt
@@ -121,6 +121,9 @@ set(QT_COMPONENTS
 # Add components only available in Qt6, remove SvgWidgets from Qt5
 if(${QT_VERSION_MAJOR} EQUAL 6)
     list(APPEND QT_COMPONENTS OpenGL OpenGLWidgets)
+    if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)
+        list(APPEND QT_COMPONENTS CorePrivate)
+    endif()
 else()
     # Remove SvgWidgets for Qt5 (not available)
     list(REMOVE_ITEM QT_COMPONENTS SvgWidgets)
@@ -165,6 +168,7 @@ if(${QT_VERSION_MAJOR} EQUAL 6)
         Dtk${DTK_VERSION_MAJOR}::Widget
         Qt${QT_VERSION_MAJOR}::Core
         Qt${QT_VERSION_MAJOR}::Gui
+        Qt${QT_VERSION_MAJOR}::CorePrivate
         Qt${QT_VERSION_MAJOR}::Widgets
         Qt${QT_VERSION_MAJOR}::DBus
         Qt${QT_VERSION_MAJOR}::Xml


### PR DESCRIPTION
The bundled QtXlsx sources include QtCore private zip headers, such as private/qzipreader_p.h and private/qzipwriter_p.h. Qt 6.10+ no longer exposes the CorePrivate target through the Core component, so request CorePrivate for those builds and link it to supply the versioned QtCore private include directory.

## Summary by Sourcery

Link Qt CorePrivate for Qt 6.10+ so bundled QtXlsx sources can access versioned private Core headers.

Bug Fixes:
- Enable bundled QtXlsx builds with Qt 6.10 and newer by linking the Qt Core private target needed for private ZIP headers.

Build:
- Add Qt 6 CorePrivate to the configured components for Qt 6.10+ and link it to the application.