### PR TITLE
fix: install systemd drop-in under libdir

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/CMakeLists.txt
+++ b/deepin-devicemanager-server/deepin-devicecontrol/CMakeLists.txt
@@ -133,4 +133,4 @@ install(FILES org.deepin.devicecontrol.conf DESTINATION share/dbus-1/system.d/)
 install(FILES org.deepin.DeviceControl.service DESTINATION share/dbus-1/system-services/)
 install(FILES deepin-devicecontrol.service DESTINATION lib/systemd/system/)
 # 添加安全加固策略
-install(DIRECTORY deepin-service-group@.service.d DESTINATION /etc/systemd/system/)
+install(DIRECTORY deepin-service-group@.service.d DESTINATION lib/systemd/system/)


### PR DESCRIPTION
The service drop-in is shipped by the project, so install it next to packaged systemd units instead of under /etc/systemd/system, which is reserved for local administrator overrides.

## Summary by Sourcery

Bug Fixes:
- Install the packaged systemd service drop-in under the system unit directory instead of the administrator override directory.