### PR TITLE
fix(network): persist wake-on-lan setting via TLP config

### DIFF
--- a/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/controlinterface.cpp
@@ -339,12 +339,11 @@ bool ControlInterface::setNetworkWake(const QString &logicalName, bool wakeup)
 {
     if (!getUserAuthorPasswd())
         return {};
-    bool res = WakeupUtils::setWakeOnLan(logicalName, wakeup);
-    if (res) {
-        // 将数据保存到数据库
-        EnableSqlManager::getInstance()->insertNetworkWakeup(logicalName, wakeup);
-    }
-    return res;
+    Q_UNUSED(logicalName)
+    // ioctl 立即生效，对所有支持 WoL 的网卡统一设置
+    WakeupUtils::setWakeOnLanAll(wakeup);
+    // 配置文件存在性即唤醒状态，用于持久化
+    return WakeupUtils::writeTlpWolConfig(wakeup);
 }
 
 void ControlInterface::updateWakeup(const QString &devInfo)
@@ -358,7 +357,14 @@ int ControlInterface::isNetworkWakeup(const QString &logicalName)
 {
     if (!getUserAuthorPasswd())
         return {};
-    return WakeupUtils::wakeOnLanIsOpen(logicalName);
+    // 不支持 WoL 的返回原状态码，前端置灰
+    WakeupUtils::EthStatus st = WakeupUtils::wakeOnLanIsOpen(logicalName);
+    if (WakeupUtils::ES_WAKE_ON_OPEN != st && WakeupUtils::ES_WAKE_ON_CLOSE != st)
+        return st;
+
+    // 不区分网卡，状态以配置文件存在性为准
+    return WakeupUtils::tlpWolConfigEnabled() ? WakeupUtils::ES_WAKE_ON_OPEN
+                                              : WakeupUtils::ES_WAKE_ON_CLOSE;
 }
 
 void ControlInterface::setMonitorWorkingDBFlag(bool flag)

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/wakecontrol/wakeuputils.cpp
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/wakecontrol/wakeuputils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,8 @@
 #include <QStringList>
 #include <QMap>
 #include <QFile>
+#include <QSaveFile>
+#include <QDir>
 #include <QLoggingCategory>
 #include <QCryptographicHash>
 #include <QRegularExpression>
@@ -182,6 +184,74 @@ bool WakeupUtils::setWakeOnLan(const QString &logicalName, bool open)
     if (0 == ioctl(fd, SIOCETHTOOL, &ifr))
         return true;
     return false;
+}
+
+const QString TLP_WOL_CONF_DIR = "/etc/tlp.d";
+const QString TLP_WOL_CONF_PATH = TLP_WOL_CONF_DIR + "/99-device-manager-wol.conf";
+// 写入与校验共用同一内容，避免两处不一致
+const QByteArray TLP_WOL_CONF_CONTENT = "WOL_DISABLE=N\nWOL_ENABLE=g\n";
+
+bool WakeupUtils::writeTlpWolConfig(bool wakeup)
+{
+    if (wakeup) {
+        QDir dir(TLP_WOL_CONF_DIR);
+        if (!dir.exists() && !dir.mkpath(".")) {
+            qCWarning(appLog) << "Failed to create tlp config dir:" << TLP_WOL_CONF_DIR;
+            return false;
+        }
+
+        // 原子写入，不跟随符号链接
+        QSaveFile file(TLP_WOL_CONF_PATH);
+        if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+            qCWarning(appLog) << "Failed to open tlp wol conf for writing:" << TLP_WOL_CONF_PATH;
+            return false;
+        }
+        // 权限固定 0644，不依赖进程 umask
+        file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner
+                            | QFileDevice::ReadGroup | QFileDevice::ReadOther);
+        qint64 size = file.write(TLP_WOL_CONF_CONTENT);
+        if (size < 1 || !file.commit()) {
+            qCWarning(appLog) << "Failed to write tlp wol conf:" << TLP_WOL_CONF_PATH;
+            return false;
+        }
+        qCInfo(appLog) << "TLP wol config written:" << TLP_WOL_CONF_PATH;
+        return true;
+    } else {
+        if (!QFile::exists(TLP_WOL_CONF_PATH))
+            return true;
+        if (!QFile::remove(TLP_WOL_CONF_PATH)) {
+            qCWarning(appLog) << "Failed to remove tlp wol conf:" << TLP_WOL_CONF_PATH;
+            return false;
+        }
+        qCInfo(appLog) << "TLP wol config removed:" << TLP_WOL_CONF_PATH;
+        return true;
+    }
+}
+
+bool WakeupUtils::tlpWolConfigEnabled()
+{
+    QFile file(TLP_WOL_CONF_PATH);
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+    const QByteArray content = file.readAll();
+    file.close();
+    return content == TLP_WOL_CONF_CONTENT;
+}
+
+void WakeupUtils::setWakeOnLanAll(bool open)
+{
+    qCDebug(appLog) << "Setting Wake-on-LAN for all supported interfaces, enable:" << open;
+    QDir netDir("/sys/class/net");
+    const QStringList lstIf = netDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+    foreach (const QString &name, lstIf) {
+        EthStatus st = wakeOnLanIsOpen(name);
+        // 不支持 WoL 的或已处于目标状态的跳过
+        if (ES_WAKE_ON_OPEN != st && ES_WAKE_ON_CLOSE != st)
+            continue;
+        if (open == (ES_WAKE_ON_OPEN == st))
+            continue;
+        setWakeOnLan(name, open);
+    }
 }
 
 bool WakeupUtils::getMapInfo(const QString &item, QMap<QString, QString> &mapInfo)

--- a/deepin-devicemanager-server/deepin-devicecontrol/src/wakecontrol/wakeuputils.h
+++ b/deepin-devicemanager-server/deepin-devicecontrol/src/wakecontrol/wakeuputils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,7 @@
 
 class WakeupUtils
 {
+public:
     /**
      * @brief The EthStatus enum
      * ioctl操作网络设备的返回值定义
@@ -29,7 +30,6 @@ class WakeupUtils
         ES_WAKE_ON_UNKNOW           // 位置错误
     };
 
-public:
     WakeupUtils();
 
     /**
@@ -68,6 +68,25 @@ public:
      * @return 返回设置状态
      */
     static bool setWakeOnLan(const QString &logicalName, bool open);
+
+    /**
+     * @brief writeTlpWolConfig 写入/删除 TLP 的 WoL 持久化配置文件
+     * @param wakeup true 生成配置，false 删除
+     * @return 操作是否成功
+     */
+    static bool writeTlpWolConfig(bool wakeup);
+
+    /**
+     * @brief tlpWolConfigEnabled 配置文件存在且内容与写入一致（即唤醒开启）
+     * @return 内容一致为 true
+     */
+    static bool tlpWolConfigEnabled();
+
+    /**
+     * @brief setWakeOnLanAll 对所有支持 WoL 的网卡统一设置
+     * @param open 开启或者关闭
+     */
+    static void setWakeOnLanAll(bool open);
 
 private:
     /**


### PR DESCRIPTION
Write /etc/tlp.d/99-device-manager-wol.conf atomically when wake-on-lan is enabled, and remove it when disabled; ioctl applies to all supported NICs immediately. Wake state is enabled only if the config content matches exactly what we wrote, shared by all NICs.

开启网卡唤醒时原子写入 TLP 配置文件，取消勾选时删除该文件；
ioctl 立即对全部支持 WoL 的网卡生效，与文件全局语义一致；
状态仅在文件内容与写入值完全一致时视为开启，多网卡显示一致。

Log: 网卡唤醒设置支持持久化并校验配置内容
PMS: BUG-372881
Influence: 网卡唤醒设置不再因重启或睡眠被重置；仅影响网络唤醒设置路径。

## Summary by Sourcery

Persist and validate the global Wake-on-LAN setting through TLP while applying changes immediately to all supported network interfaces.

New Features:
- Persist Wake-on-LAN enablement through a dedicated TLP configuration file.

Bug Fixes:
- Ensure Wake-on-LAN changes apply immediately to all supported network interfaces and remain consistent across reboots and sleep cycles.
- Validate the persisted Wake-on-LAN state against the exact expected configuration content before reporting it as enabled.

Enhancements:
- Use a unified global Wake-on-LAN state for supported network interfaces while preserving unsupported-interface status reporting.