### PR TITLE
fix: use Qt version-compatible APIs to fix build failure

### DIFF
--- a/deepin-devicemanager/src/Tool/LoadCpuInfoThread.cpp
+++ b/deepin-devicemanager/src/Tool/LoadCpuInfoThread.cpp
@@ -30,7 +30,7 @@ void LoadCpuInfoThread::runCmd(QString &info, const QString &cmd)
     qCDebug(appLog) << "Executing command:" << cmd;
 
     QProcess process;
-    process.startCommand(cmd);
+    process.start(cmd);
     process.waitForFinished(-1);
     info = process.readAllStandardOutput();
 }

--- a/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
+++ b/deepin-devicemanager/src/Tool/ThreadExecXrandr.cpp
@@ -82,7 +82,7 @@ void ThreadExecXrandr::runCmd(QString &info, const QString &cmd)
     qCDebug(appLog) << "Executing command:" << cmd;
 
     QProcess process;
-    process.startCommand(cmd);
+    process.start(cmd);
     process.waitForFinished(-1);
     info = process.readAllStandardOutput();
 }

--- a/deepin-devicemanager/src/commonfunction.cpp
+++ b/deepin-devicemanager/src/commonfunction.cpp
@@ -385,7 +385,11 @@ int Common::parseSharedCpuCount(const QString &sharedCpuList)
         return 0;
 
     int count = 0;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QStringList parts = s.split(',', QString::SkipEmptyParts);
+#else
     QStringList parts = s.split(',', Qt::SkipEmptyParts);
+#endif
     for (const QString &part : parts) {
         QString trimmed = part.trimmed();
         if (trimmed.contains('-')) {


### PR DESCRIPTION
- Replace QProcess::startCommand() with QProcess::start() in LoadCpuInfoThread and ThreadExecXrandr (startCommand requires Qt 5.15+)
- Add QT_VERSION guard to select QString::SkipEmptyParts (Qt 5) or Qt::SkipEmptyParts (Qt 6) in Common::parseSharedCpuCount

- 将 LoadCpuInfoThread 和 ThreadExecXrandr 中的 QProcess::startCommand() 替换为 QProcess::start() （startCommand 需要 Qt 5.15+）
- 在 Common::parseSharedCpuCount 中增加 QT_VERSION 条件编译， Qt 5 使用 QString::SkipEmptyParts，Qt 6 使用 Qt::SkipEmptyParts

Log: 修复 Qt 版本不兼容 API 导致的编译错误
Influence: 仅影响编译兼容性，无功能变化

## Summary by Sourcery

Restore cross-version Qt build compatibility without changing runtime behavior.

Bug Fixes:
- Fix build compatibility with older Qt 5 versions by replacing unsupported process APIs.
- Support both Qt 5 and Qt 6 string-splitting APIs when parsing shared CPU counts.